### PR TITLE
re #4: implement Response.body(InputStream)

### DIFF
--- a/src/main/java/io/javalin/Response.java
+++ b/src/main/java/io/javalin/Response.java
@@ -23,6 +23,7 @@ import io.javalin.translator.template.Freemarker;
 import io.javalin.translator.template.Mustache;
 import io.javalin.translator.template.Thymeleaf;
 import io.javalin.translator.template.Velocity;
+import java.io.InputStream;
 
 public class Response {
 
@@ -30,6 +31,8 @@ public class Response {
 
     private HttpServletResponse servletResponse;
     private String body;
+    private InputStream bodyStream;
+    
     private String encoding;
 
     public Response(HttpServletResponse servletResponse) {
@@ -55,9 +58,20 @@ public class Response {
 
     public Response body(String body) {
         this.body = body;
+        this.bodyStream = null; // can only have one or the other
         return this;
     }
 
+    public InputStream bodyStream() {
+        return bodyStream;
+    }
+    
+    public Response body(InputStream bodyStream) {
+        this.body = null; // can only have one or the other
+        this.bodyStream = bodyStream;
+        return this;
+    }
+    
     public String encoding() {
         return encoding;
     }

--- a/src/main/java/io/javalin/core/JavalinServlet.java
+++ b/src/main/java/io/javalin/core/JavalinServlet.java
@@ -24,6 +24,7 @@ import io.javalin.Handler;
 import io.javalin.Request;
 import io.javalin.Response;
 import io.javalin.core.util.RequestUtil;
+import io.javalin.core.util.Util;
 import io.javalin.embeddedserver.StaticResourceHandler;
 
 public class JavalinServlet implements Servlet {
@@ -108,6 +109,8 @@ public class JavalinServlet implements Servlet {
             httpResponse.getWriter().write(response.body());
             httpResponse.getWriter().flush();
             httpResponse.getWriter().close();
+        } else if (response.bodyStream() != null) {
+            Util.copyStream(response.bodyStream(), httpResponse.getOutputStream());
         }
 
     }

--- a/src/main/java/io/javalin/core/util/Util.java
+++ b/src/main/java/io/javalin/core/util/Util.java
@@ -17,6 +17,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.javalin.HaltException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class Util {
 
@@ -86,4 +89,16 @@ public class Util {
             + "|_________________________________________|\n";
     }
 
+    public static long copyStream(InputStream in, OutputStream out) throws IOException {
+        byte[] buf = new byte[8192];
+        long totalBytesCopied = 0;
+        int bytesReadThisPass = 0;
+        
+        while((bytesReadThisPass = in.read(buf)) > 0) {
+            out.write(buf, 0, bytesReadThisPass);
+            totalBytesCopied += bytesReadThisPass;
+        }
+        
+        return totalBytesCopied;
+    }
 }

--- a/src/test/java/io/javalin/TestResponse.java
+++ b/src/test/java/io/javalin/TestResponse.java
@@ -21,8 +21,6 @@ import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
 
 public class TestResponse extends _UnirestBaseTest {
 
@@ -53,8 +51,8 @@ public class TestResponse extends _UnirestBaseTest {
         HttpResponse<String> response = call(HttpMethod.GET, "/stream");
         
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        assertEquals(Util.copyStream(response.getRawBody(), bout), (long) buf.length);
-        assertArrayEquals(buf, bout.toByteArray());
+        assertThat(Util.copyStream(response.getRawBody(), bout), is((long) buf.length));
+        assertThat(buf, equalTo(bout.toByteArray()));
     }
     
     @Test


### PR DESCRIPTION
This adds Response.body(InputStream).  There can be only one body, so calling body(String) clears any previously set InputStream, and vice-versa.  Added a unit test as well.