### PR TITLE
`async` expects a `CompletionStage` instead of a `CompletableFuture`

### DIFF
--- a/src/main/java/io/javalin/Context.kt
+++ b/src/main/java/io/javalin/Context.kt
@@ -19,7 +19,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.net.URLDecoder
 import java.nio.charset.Charset
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -64,7 +64,7 @@ class Context(private val servletResponse: HttpServletResponse,
 
     fun request(): HttpServletRequest = servletRequest
 
-    fun async(asyncHandler: () -> CompletableFuture<Void>) {
+    fun async(asyncHandler: () -> CompletionStage<Void>) {
         val asyncContext = servletRequest.startAsync()
         asyncHandler().thenAccept { _ -> asyncContext.complete() }
                 .exceptionally { e ->


### PR DESCRIPTION
In the Java's _"Programming into the Future"_ world, the `CompletionStage` is the global interface to use as return type (would be `Future` in _Scala_). The `CompletableFuture` is the concrete object to use to create __and control__ the `CompletionStage` (would be `Promise` in _Scala_). A method providing "a value in the future" has no reason to return a `CompletableFuture`, since the caller of that method could decide to completable that Future himself.

In the context of the Javalin's `Context`, the `async` method expects the user of the library to provide "something in the future" and is only interested in when it finishes. In this context, a `CompletionStage<Void>` (could be `<Unit>` to be more Kotlin-ish) is enough.

I propose this modification on a use-case basis. When using _Javalin_ async, I want to do something like this:

```kotlin
ctx.async {
    thirdPartyLibrary
        .returningSomethingInTheFuture("foo", "bar")
        .thenCompose { a ->
                otherLibrary.giveMeSomethingInTheFuture(a)
        }
        .thenAccept { finalResult ->
                ctx.status(200).result(finalResult)
        }
}
```

Right now, I have to wrap my `CompletionStage` into a `CompletableFuture` at the end, for no reason (and allowing the caller to complete _my_ future, which it does not need to do, and I do not want it to do!):

```kotlin
ctx.async {
    thirdPartyLibrary
        .returningSomethingInTheFuture("foo", "bar")
        .thenCompose { a ->
                otherLibrary.giveMeSomethingInTheFuture(a)
        }
        .thenAccept { finalResult ->
                ctx.status(200).result(finalResult)
        }
        .toCompletableFuture()
}
```
