### PR TITLE
Generating runtime null-checks for method parameters marked by @NotNull

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,14 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Compile-only -->
+        <dependency>
+            <groupId>tech.harmonysoft</groupId>
+            <artifactId>traute-javac</artifactId>
+            <version>1.0.10</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- BEGIN Optional dependencies -->
         <dependency>
             <groupId>commons-fileupload</groupId>
@@ -237,6 +245,9 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <optimize>true</optimize>
+                    <compilerArgs>
+                        <arg>-Xplugin:Traute</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -135,7 +135,6 @@ public class Javalin {
 
     public Javalin enableStaticFiles(@NotNull String path, @NotNull Location location) {
         ensureActionIsPerformedBeforeServerStart("Enabling static files");
-        Util.INSTANCE.notNull("Location cannot be null", path);
         staticFileConfig = new StaticFileConfig(path, location);
         return this;
     }

--- a/src/main/java/io/javalin/core/util/Util.kt
+++ b/src/main/java/io/javalin/core/util/Util.kt
@@ -19,12 +19,6 @@ object Util {
     fun normalizeContextPath(contextPath: String) = ("/" + contextPath).replace("/{2,}".toRegex(), "/").removeSuffix("/")
     fun prefixContextPath(path: String, contextPath: String) = if (path == "*") path else (contextPath + "/" + path).replace("/{2,}".toRegex(), "/")
 
-    fun notNull(obj: Any?, message: String) {
-        if (obj == null) {
-            throw IllegalArgumentException(message)
-        }
-    }
-
     fun classExists(className: String): Boolean {
         return try {
             Class.forName(className)


### PR DESCRIPTION
Applied [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin to the project in order to enhance resulting bytecode by *null*-checks for method parameters marked by *NotNull*.  

Example: consider [ApiBuilder.setStaticJavalin()](https://github.com/tipsy/javalin/blob/master/src/main/java/io/javalin/ApiBuilder.java#L24). Its bytecode looks like if it's compiled from the source below:  

```java
static void setStaticJavalin(@NotNull Javalin javalin) {
    if (javalin == null) {
        throw new NullPointerException("String Argument 'javalin' of type Javalin (#0 out of 1, zero-based) is marked by @org.jetbrains.annotations.NotNull but got null for it");
    }
    staticJavalin = javalin;
}
```

Details:  

```
javap -c ./target/classes/io/javalin/ApiBuilder.class
...
  static void setStaticJavalin(io.javalin.Javalin);
    Code:
       0: aload_0
       1: ifnonnull     14
       4: new           #2                  // class java/lang/NullPointerException
       7: dup
       8: ldc           #3                  // String Argument 'javalin' of type Javalin (#0 out of 1, zero-based) is marked by @org.jetbrains.annotations.NotNull but got null for it
      10: invokespecial #4                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      13: athrow
      14: aload_0
      15: putstatic     #5                  // Field staticJavalin:Lio/javalin/Javalin;
      18: return
```
TESTED: mvn clean package & ensured that
        the checks are present in the
        resulting bytecode