### PR TITLE
Allow configuration of request body cache

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -7,7 +7,12 @@
 
 package io.javalin;
 
-import io.javalin.core.*;
+import io.javalin.core.ErrorMapper;
+import io.javalin.core.ExceptionMapper;
+import io.javalin.core.HandlerEntry;
+import io.javalin.core.HandlerType;
+import io.javalin.core.JavalinServlet;
+import io.javalin.core.PathMatcher;
 import io.javalin.core.util.CorsUtil;
 import io.javalin.core.util.Util;
 import io.javalin.embeddedserver.EmbeddedServer;
@@ -22,15 +27,15 @@ import io.javalin.event.EventManager;
 import io.javalin.event.EventType;
 import io.javalin.security.AccessManager;
 import io.javalin.security.Role;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Javalin {
 
@@ -50,7 +55,7 @@ public class Javalin {
     private LogLevel logLevel = LogLevel.OFF;
     private String defaultContentType = "text/plain";
     private String defaultCharacterEncoding = StandardCharsets.UTF_8.name();
-    private long maxRequestCacheBodySize = 8 * 1024;
+    private long maxRequestCacheBodySize = Long.MAX_VALUE;
 
     private EventManager eventManager = new EventManager();
 
@@ -200,29 +205,16 @@ public class Javalin {
         return this;
     }
 
-    /**
-     * Sets maximum body size allowed to cache in request. Requests with [Transfer-Encoding: chunked] are not cached.
-     *
-     * The method must be called before {@link Javalin#start()}.
-     */
     public Javalin maxBodySizeForRequestCache(long value) {
         ensureActionIsPerformedBeforeServerStart("Changing request cache body size");
         this.maxRequestCacheBodySize = value;
         return this;
     }
 
-    /**
-     * Disables request body caching.
-     *
-     * The method must be called before {@link Javalin#start()}.
-     */
     public Javalin disableRequestBodyCache() {
         return maxBodySizeForRequestCache(0);
     }
 
-    /**
-     * @return maximum body size allowed to cache in request. Requests with [Transfer-Encoding: chunked] are not cached.
-     */
     public long maxBodySizeForRequestCache() {
         return maxRequestCacheBodySize;
     }

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -7,12 +7,7 @@
 
 package io.javalin;
 
-import io.javalin.core.ErrorMapper;
-import io.javalin.core.ExceptionMapper;
-import io.javalin.core.HandlerEntry;
-import io.javalin.core.HandlerType;
-import io.javalin.core.JavalinServlet;
-import io.javalin.core.PathMatcher;
+import io.javalin.core.*;
 import io.javalin.core.util.CorsUtil;
 import io.javalin.core.util.Util;
 import io.javalin.embeddedserver.EmbeddedServer;
@@ -27,14 +22,15 @@ import io.javalin.event.EventManager;
 import io.javalin.event.EventType;
 import io.javalin.security.AccessManager;
 import io.javalin.security.Role;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Javalin {
 
@@ -54,6 +50,7 @@ public class Javalin {
     private LogLevel logLevel = LogLevel.OFF;
     private String defaultContentType = "text/plain";
     private String defaultCharacterEncoding = StandardCharsets.UTF_8.name();
+    private long maxRequestCacheBodySize = 8 * 1024;
 
     private EventManager eventManager = new EventManager();
 
@@ -95,7 +92,8 @@ public class Javalin {
                     logLevel,
                     dynamicGzipEnabled,
                     defaultContentType,
-                    defaultCharacterEncoding
+                    defaultCharacterEncoding,
+                    maxRequestCacheBodySize
                 ), staticFileConfig);
                 log.info("Starting Javalin ...");
                 port = embeddedServer.start(port);
@@ -200,6 +198,33 @@ public class Javalin {
         ensureActionIsPerformedBeforeServerStart("Changing default character encoding");
         this.defaultCharacterEncoding = characterEncoding;
         return this;
+    }
+
+    /**
+     * Sets maximum body size allowed to cache in request. Requests with [Transfer-Encoding: chunked] are not cached.
+     *
+     * The method must be called before {@link Javalin#start()}.
+     */
+    public Javalin maxBodySizeForRequestCache(long value) {
+        ensureActionIsPerformedBeforeServerStart("Changing request cache body size");
+        this.maxRequestCacheBodySize = value;
+        return this;
+    }
+
+    /**
+     * Disables request body caching.
+     *
+     * The method must be called before {@link Javalin#start()}.
+     */
+    public Javalin disableRequestBodyCache() {
+        return maxBodySizeForRequestCache(0);
+    }
+
+    /**
+     * @return maximum body size allowed to cache in request. Requests with [Transfer-Encoding: chunked] are not cached.
+     */
+    public long maxBodySizeForRequestCache() {
+        return maxRequestCacheBodySize;
     }
 
     private void ensureActionIsPerformedBeforeServerStart(@NotNull String action) {

--- a/src/main/java/io/javalin/core/JavalinServlet.kt
+++ b/src/main/java/io/javalin/core/JavalinServlet.kt
@@ -31,7 +31,8 @@ class JavalinServlet(
         val logLevel: LogLevel,
         val dynamicGzipEnabled: Boolean,
         val defaultContentType: String,
-        val defaultCharacterEncoding: String) {
+        val defaultCharacterEncoding: String,
+        val maxRequestCacheBodySize: Long) {
 
     private val log = LoggerFactory.getLogger(JavalinServlet::class.java)
 
@@ -39,7 +40,7 @@ class JavalinServlet(
 
     fun service(servletRequest: ServletRequest, servletResponse: ServletResponse) {
 
-        val req = CachedRequestWrapper(servletRequest as HttpServletRequest) // cached for reading multiple times
+        val req = CachedRequestWrapper(servletRequest as HttpServletRequest, maxRequestCacheBodySize) // cached for reading multiple times
         val res =
                 if (logLevel == LogLevel.EXTENSIVE) CachedResponseWrapper(servletResponse as HttpServletResponse) // body needs to be copied for logging
                 else servletResponse as HttpServletResponse

--- a/src/main/java/io/javalin/embeddedserver/CachedRequestWrapper.kt
+++ b/src/main/java/io/javalin/embeddedserver/CachedRequestWrapper.kt
@@ -6,19 +6,27 @@
 
 package io.javalin.embeddedserver
 
+import io.javalin.core.util.Header
 import java.io.ByteArrayInputStream
 import javax.servlet.ReadListener
 import javax.servlet.ServletInputStream
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletRequestWrapper
 
-class CachedRequestWrapper(request: HttpServletRequest) : HttpServletRequestWrapper(request) {
+class CachedRequestWrapper(request: HttpServletRequest, private val maxCacheSize: Long) : HttpServletRequestWrapper(request) {
 
-    private val cachedBytes: ByteArray = super.getInputStream().readBytes()
+    private val size = request.contentLengthLong
+    private val chunkedTransferEncoding by lazy { request.getHeader(Header.TRANSFER_ENCODING)?.contains("chunked") ?: false }
 
-    override fun getInputStream(): ServletInputStream = if (chunkedTransferEncoding()) super.getInputStream() else CachedServletInputStream()
+    // Do not read unless we have to
+    private val cachedBytes: ByteArray by lazy { super.getInputStream().readBytes() }
 
-    private fun chunkedTransferEncoding(): Boolean = "chunked" == (super.getRequest() as HttpServletRequest).getHeader("Transfer-Encoding")
+    override fun getInputStream(): ServletInputStream =
+        if (chunkedTransferEncoding || maxCacheSize < size) {
+            super.getInputStream()
+        } else  {
+            CachedServletInputStream()
+        }
 
     private inner class CachedServletInputStream : ServletInputStream() {
         private val byteArrayInputStream: ByteArrayInputStream = ByteArrayInputStream(cachedBytes)

--- a/src/main/java/io/javalin/embeddedserver/CachedRequestWrapper.kt
+++ b/src/main/java/io/javalin/embeddedserver/CachedRequestWrapper.kt
@@ -16,7 +16,9 @@ import javax.servlet.http.HttpServletRequestWrapper
 class CachedRequestWrapper(request: HttpServletRequest, private val maxCacheSize: Long) : HttpServletRequestWrapper(request) {
 
     private val size = request.contentLengthLong
-    private val chunkedTransferEncoding by lazy { request.getHeader(Header.TRANSFER_ENCODING)?.contains("chunked") ?: false }
+    private val chunkedTransferEncoding by lazy {
+        request.getHeader(Header.TRANSFER_ENCODING)?.contains("chunked") ?: false
+    }
 
     // Do not read unless we have to
     private val cachedBytes: ByteArray by lazy { super.getInputStream().readBytes() }
@@ -24,7 +26,7 @@ class CachedRequestWrapper(request: HttpServletRequest, private val maxCacheSize
     override fun getInputStream(): ServletInputStream =
         if (chunkedTransferEncoding || maxCacheSize < size) {
             super.getInputStream()
-        } else  {
+        } else {
             CachedServletInputStream()
         }
 

--- a/src/test/java/io/javalin/TestRequestCache.java
+++ b/src/test/java/io/javalin/TestRequestCache.java
@@ -1,0 +1,83 @@
+package io.javalin;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestRequestCache {
+
+    private static Javalin app;
+    private static Javalin appCacheDisabled;
+    private static String origin;
+    private static String originCacheDisabled;
+
+    @BeforeClass
+    public static void setUp() {
+        app = Javalin.create()
+                .start();
+        origin = "http://localhost:" + app.port();
+
+        appCacheDisabled = Javalin.create()
+            .port(5000)
+            .disableRequestBodyCache()
+            .start();
+        originCacheDisabled = "http://localhost:" + appCacheDisabled.port();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        app.stop();
+        appCacheDisabled.stop();
+    }
+
+    @Test
+    public void test_cache_not_draining_InputStream() throws Exception {
+        app.post("/cache-chunked-encoding", ctx -> ctx.result(ctx.request().getInputStream()));
+
+        byte[] body = new byte[10000];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) (i % 256);
+        }
+
+        CloseableHttpClient client = HttpClients.createDefault();
+        HttpPost post = new HttpPost(origin + "/cache-chunked-encoding");
+        ByteArrayEntity entity = new ByteArrayEntity(body);
+        entity.setChunked(true);
+        post.setEntity(entity);
+        CloseableHttpResponse response = client.execute(post);
+        byte[] result = EntityUtils.toByteArray(response.getEntity());
+
+        assertThat("Body should match", Arrays.equals(result, body));
+
+        response.close();
+    }
+
+    @Test
+    public void test_allows_disabling_cache() throws Exception {
+        appCacheDisabled.post("/disabled-cache", ctx -> {
+            if (ctx.request().getInputStream().getClass().getSimpleName().equals("CachedServletInputStream")) {
+                throw new IllegalStateException("Cache should be disabled");
+            } else {
+                ctx.result("");
+            }
+        });
+        HttpResponse<InputStream> response = Unirest.post(originCacheDisabled + "/disabled-cache")
+                .body("test")
+                .asBinary();
+
+        assertThat("Request cache should be disabled", response.getStatus() == 200);
+    }
+}

--- a/src/test/java/io/javalin/TestRequestCache.java
+++ b/src/test/java/io/javalin/TestRequestCache.java
@@ -19,19 +19,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestRequestCache {
 
-    private static Javalin app;
+    private static Javalin appCacheEnabled;
     private static Javalin appCacheDisabled;
-    private static String origin;
+    private static String originCacheEnabled;
     private static String originCacheDisabled;
 
     @BeforeClass
     public static void setUp() {
-        app = Javalin.create()
-                .start();
-        origin = "http://localhost:" + app.port();
+        appCacheEnabled = Javalin.start(0);
+        originCacheEnabled = "http://localhost:" + appCacheEnabled.port();
 
         appCacheDisabled = Javalin.create()
-            .port(5000)
+            .port(0)
             .disableRequestBodyCache()
             .start();
         originCacheDisabled = "http://localhost:" + appCacheDisabled.port();
@@ -39,13 +38,13 @@ public class TestRequestCache {
 
     @AfterClass
     public static void tearDown() {
-        app.stop();
+        appCacheEnabled.stop();
         appCacheDisabled.stop();
     }
 
     @Test
     public void test_cache_not_draining_InputStream() throws Exception {
-        app.post("/cache-chunked-encoding", ctx -> ctx.result(ctx.request().getInputStream()));
+        appCacheEnabled.post("/cache-chunked-encoding", ctx -> ctx.result(ctx.request().getInputStream()));
 
         byte[] body = new byte[10000];
         for (int i = 0; i < body.length; i++) {
@@ -53,7 +52,7 @@ public class TestRequestCache {
         }
 
         CloseableHttpClient client = HttpClients.createDefault();
-        HttpPost post = new HttpPost(origin + "/cache-chunked-encoding");
+        HttpPost post = new HttpPost(originCacheEnabled + "/cache-chunked-encoding");
         ByteArrayEntity entity = new ByteArrayEntity(body);
         entity.setChunked(true);
         post.setEntity(entity);


### PR DESCRIPTION
Initialize cache in request lazily, so the original stream will not be drained.
#131 and #116 