### PR TITLE
Update kotlin-stdlib-jre8 to kotlin-stdlib-jdk8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jre8</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
 


### PR DESCRIPTION
jre8 package is deprecated in favor of jdk8 now.