### PR TITLE
 Split Javalin class by function

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -1,400 +1,145 @@
-/*
- * Javalin - https://javalin.io
- * Copyright 2017 David Åse
- * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
- *
- */
-
 package io.javalin;
 
-import io.javalin.core.ErrorMapper;
-import io.javalin.core.ExceptionMapper;
-import io.javalin.core.HandlerEntry;
 import io.javalin.core.HandlerType;
-import io.javalin.core.JavalinServlet;
-import io.javalin.core.PathMatcher;
-import io.javalin.core.util.CorsUtil;
 import io.javalin.core.util.Util;
-import io.javalin.embeddedserver.EmbeddedServer;
 import io.javalin.embeddedserver.EmbeddedServerFactory;
 import io.javalin.embeddedserver.Location;
-import io.javalin.embeddedserver.StaticFileConfig;
-import io.javalin.embeddedserver.jetty.EmbeddedJettyFactory;
 import io.javalin.embeddedserver.jetty.websocket.WebSocketConfig;
-import io.javalin.embeddedserver.jetty.websocket.WebSocketHandler;
 import io.javalin.event.EventListener;
-import io.javalin.event.EventManager;
 import io.javalin.event.EventType;
 import io.javalin.security.AccessManager;
 import io.javalin.security.Role;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class Javalin {
+import java.util.List;
 
-    private static Logger log = LoggerFactory.getLogger(Javalin.class);
+@SuppressWarnings({"unused", "UnusedReturnValue"})
+public interface Javalin {
 
-    private int port = 7000;
-    private String contextPath = "/";
-    private boolean dynamicGzipEnabled = false;
-
-    private EmbeddedServer embeddedServer;
-    private EmbeddedServerFactory embeddedServerFactory = new EmbeddedJettyFactory();
-
-    private List<StaticFileConfig> staticFileConfig = new ArrayList<>();
-    private PathMatcher pathMatcher = new PathMatcher();
-    private ExceptionMapper exceptionMapper = new ExceptionMapper();
-    private ErrorMapper errorMapper = new ErrorMapper();
-    private LogLevel logLevel = LogLevel.OFF;
-    private String defaultContentType = "text/plain";
-    private String defaultCharacterEncoding = StandardCharsets.UTF_8.name();
-    private long maxRequestCacheBodySize = Long.MAX_VALUE;
-
-    private EventManager eventManager = new EventManager();
-
-    private AccessManager accessManager = (Handler handler, Context ctx, List<Role> permittedRoles) -> {
-        throw new IllegalStateException("No access manager configured. Add an access manager using 'accessManager()'");
-    };
-
-    private Javalin() {
-    }
-
-    public static Javalin create() {
+    static Javalin create() {
         Util.INSTANCE.printHelpfulMessageIfNoServerHasBeenStartedAfterOneSecond();
-        return new Javalin();
+        return new JavalinInstance();
     }
 
-    public static Javalin start(int port) {
-        return new Javalin()
+    static Javalin start(int port) {
+        return create()
             .port(port)
             .start();
     }
 
-    // Begin embedded server methods
+    Javalin start();
 
-    private boolean started = false;
+    Javalin stop();
 
-    public Javalin start() {
-        if (!started) {
-            log.info(Util.INSTANCE.javalinBanner());
-            Util.INSTANCE.printHelpfulMessageIfLoggerIsMissing();
-            Util.INSTANCE.setNoServerHasBeenStarted(false);
-            eventManager.fireEvent(EventType.SERVER_STARTING, this);
-            try {
-                embeddedServer = embeddedServerFactory.create(new JavalinServlet(
-                    contextPath,
-                    pathMatcher,
-                    exceptionMapper,
-                    errorMapper,
-                    pathWsHandlers,
-                    logLevel,
-                    dynamicGzipEnabled,
-                    defaultContentType,
-                    defaultCharacterEncoding,
-                    maxRequestCacheBodySize
-                ), staticFileConfig);
-                log.info("Starting Javalin ...");
-                port = embeddedServer.start(port);
-                log.info("Javalin has started \\o/");
-                started = true;
-                eventManager.fireEvent(EventType.SERVER_STARTED, this);
-            } catch (Exception e) {
-                log.error("Failed to start Javalin", e);
-                eventManager.fireEvent(EventType.SERVER_START_FAILED, this);
-            }
+    Javalin embeddedServer(@NotNull EmbeddedServerFactory embeddedServerFactory);
+
+    String contextPath();
+
+    Javalin contextPath(@NotNull String contextPath);
+
+    int port();
+
+    Javalin port(int port);
+
+    Javalin enableStaticFiles(@NotNull String classpathPath);
+
+    Javalin enableStaticFiles(@NotNull String path, @NotNull Location location);
+
+    Javalin enableStandardRequestLogging();
+
+    Javalin requestLogLevel(@NotNull LogLevel logLevel);
+
+    Javalin enableCorsForOrigin(@NotNull String... origin);
+
+    Javalin enableCorsForAllOrigins();
+
+    Javalin enableDynamicGzip();
+
+    Javalin defaultContentType(String contentType);
+
+    Javalin defaultCharacterEncoding(String characterEncoding);
+
+    Javalin maxBodySizeForRequestCache(long value);
+
+    Javalin disableRequestCache();
+
+    Javalin dontIgnoreTrailingSlashes();
+
+    default Javalin routes(@NotNull ApiBuilder.EndpointGroup endpointGroup) {
+        synchronized(ApiBuilder.class) {
+            ApiBuilder.setStaticJavalin(this);
+            endpointGroup.addEndpoints();
+            ApiBuilder.clearStaticJavalin();
         }
         return this;
-    }
-
-    public Javalin stop() {
-        eventManager.fireEvent(EventType.SERVER_STOPPING, this);
-        log.info("Stopping Javalin ...");
-        try {
-            embeddedServer.stop();
-        } catch (Exception e) {
-            log.error("Javalin failed to stop gracefully", e);
-        }
-        log.info("Javalin has stopped");
-        eventManager.fireEvent(EventType.SERVER_STOPPED, this);
-        return this;
-    }
-
-    public Javalin dontIgnoreTrailingSlashes() {
-        ensureActionIsPerformedBeforeServerStart("Telling Javalin to not ignore slashes");
-        pathMatcher.setIgnoreTrailingSlashes(false);
-        return this;
-    }
-
-    public Javalin embeddedServer(@NotNull EmbeddedServerFactory embeddedServerFactory) {
-        ensureActionIsPerformedBeforeServerStart("Setting a custom server");
-        this.embeddedServerFactory = embeddedServerFactory;
-        return this;
-    }
-
-    public Javalin enableStaticFiles(@NotNull String classpathPath) {
-        return enableStaticFiles(classpathPath, Location.CLASSPATH);
-    }
-
-    public Javalin enableStaticFiles(@NotNull String path, @NotNull Location location) {
-        ensureActionIsPerformedBeforeServerStart("Enabling static files");
-        staticFileConfig.add(new StaticFileConfig(path, location));
-        return this;
-    }
-
-    public String contextPath() {
-        return this.contextPath;
-    }
-
-    public Javalin contextPath(@NotNull String contextPath) {
-        ensureActionIsPerformedBeforeServerStart("Setting the context path");
-        this.contextPath = Util.INSTANCE.normalizeContextPath(contextPath);
-        return this;
-    }
-
-    public int port() {
-        return port;
-    }
-
-    public Javalin port(int port) {
-        ensureActionIsPerformedBeforeServerStart("Setting the port");
-        this.port = port;
-        return this;
-    }
-
-    public Javalin enableStandardRequestLogging() {
-        return requestLogLevel(LogLevel.STANDARD);
-    }
-
-    public Javalin requestLogLevel(@NotNull LogLevel logLevel) {
-        ensureActionIsPerformedBeforeServerStart("Enabling request-logging");
-        this.logLevel = logLevel;
-        return this;
-    }
-
-    public Javalin enableCorsForOrigin(@NotNull String... origin) {
-        ensureActionIsPerformedBeforeServerStart("Enabling CORS");
-        return CorsUtil.INSTANCE.enableCors(this, origin);
-    }
-
-    public Javalin enableCorsForAllOrigins() {
-        return enableCorsForOrigin("*");
-    }
-
-    public Javalin enableDynamicGzip() {
-        ensureActionIsPerformedBeforeServerStart("Enabling dynamic GZIP");
-        this.dynamicGzipEnabled = true;
-        return this;
-    }
-
-    public Javalin defaultContentType(String contentType) {
-        ensureActionIsPerformedBeforeServerStart("Changing default content type");
-        this.defaultContentType = contentType;
-        return this;
-    }
-
-    public Javalin defaultCharacterEncoding(String characterEncoding) {
-        ensureActionIsPerformedBeforeServerStart("Changing default character encoding");
-        this.defaultCharacterEncoding = characterEncoding;
-        return this;
-    }
-
-    public Javalin maxBodySizeForRequestCache(long value) {
-        ensureActionIsPerformedBeforeServerStart("Changing request cache body size");
-        this.maxRequestCacheBodySize = value;
-        return this;
-    }
-
-    public Javalin disableRequestCache() {
-        return maxBodySizeForRequestCache(0);
-    }
-
-    private void ensureActionIsPerformedBeforeServerStart(@NotNull String action) {
-        if (started) {
-            throw new IllegalStateException(action + " must be done before starting the server");
-        }
-    }
-
-    // End embedded server methods
-
-    public Javalin accessManager(@NotNull AccessManager accessManager) {
-        this.accessManager = accessManager;
-        return this;
-    }
-
-    public <T extends Exception> Javalin exception(@NotNull Class<T> exceptionClass, @NotNull ExceptionHandler<? super T> exceptionHandler) {
-        exceptionMapper.getExceptionMap().put(exceptionClass, (ExceptionHandler<Exception>) exceptionHandler);
-        return this;
-    }
-
-    public Javalin event(@NotNull EventType eventType, @NotNull EventListener eventListener) {
-        ensureActionIsPerformedBeforeServerStart("Event-mapping");
-        eventManager.getListenerMap().get(eventType).add(eventListener);
-        return this;
-    }
-
-    public Javalin error(int statusCode, @NotNull ErrorHandler errorHandler) {
-        errorMapper.getErrorHandlerMap().put(statusCode, errorHandler);
-        return this;
-    }
-
-    public Javalin routes(@NotNull ApiBuilder.EndpointGroup endpointGroup) {
-        ApiBuilder.setStaticJavalin(this);
-        endpointGroup.addEndpoints();
-        ApiBuilder.clearStaticJavalin();
-        return this;
-    }
-
-    private Javalin addHandler(@NotNull HandlerType httpMethod, @NotNull String path, @NotNull Handler handler) {
-        String prefixedPath = Util.INSTANCE.prefixContextPath(path, contextPath);
-        pathMatcher.getHandlerEntries().add(new HandlerEntry(httpMethod, prefixedPath, handler));
-        return this;
-    }
-
-    private Javalin addSecuredHandler(@NotNull HandlerType httpMethod, @NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addHandler(httpMethod, path, ctx -> accessManager.manage(handler, ctx, permittedRoles));
     }
 
     // HTTP verbs
-    public Javalin get(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.GET, path, handler);
-    }
+    Javalin get(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin post(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.POST, path, handler);
-    }
+    Javalin post(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin put(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.PUT, path, handler);
-    }
+    Javalin put(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin patch(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.PATCH, path, handler);
-    }
+    Javalin patch(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin delete(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.DELETE, path, handler);
-    }
+    Javalin delete(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin head(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.HEAD, path, handler);
-    }
+    Javalin head(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin trace(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.TRACE, path, handler);
-    }
+    Javalin trace(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin connect(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.CONNECT, path, handler);
-    }
+    Javalin connect(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin options(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.OPTIONS, path, handler);
-    }
+    Javalin options(@NotNull String path, @NotNull Handler handler);
 
     // Secured HTTP verbs
-    public Javalin get(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.GET, path, handler, permittedRoles);
-    }
+    Javalin accessManager(@NotNull AccessManager accessManager);
 
-    public Javalin post(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.POST, path, handler, permittedRoles);
-    }
+    Javalin get(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
 
-    public Javalin put(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.PUT, path, handler, permittedRoles);
-    }
+    Javalin post(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
 
-    public Javalin patch(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.PATCH, path, handler, permittedRoles);
-    }
+    Javalin put(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
 
-    public Javalin delete(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.DELETE, path, handler, permittedRoles);
-    }
+    Javalin patch(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
 
-    public Javalin head(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.HEAD, path, handler, permittedRoles);
-    }
+    Javalin delete(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
 
-    public Javalin trace(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.TRACE, path, handler, permittedRoles);
-    }
+    Javalin head(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
 
-    public Javalin connect(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.CONNECT, path, handler, permittedRoles);
-    }
+    Javalin trace(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
 
-    public Javalin options(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles) {
-        return addSecuredHandler(HandlerType.OPTIONS, path, handler, permittedRoles);
-    }
+    Javalin connect(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
+
+    Javalin options(@NotNull String path, @NotNull Handler handler, @NotNull List<Role> permittedRoles);
 
     // Filters
-    public Javalin before(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.BEFORE, path, handler);
-    }
+    Javalin before(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin before(@NotNull Handler handler) {
-        return before("*", handler);
-    }
+    Javalin before(@NotNull Handler handler);
 
-    public Javalin after(@NotNull String path, @NotNull Handler handler) {
-        return addHandler(HandlerType.AFTER, path, handler);
-    }
+    Javalin after(@NotNull String path, @NotNull Handler handler);
 
-    public Javalin after(@NotNull Handler handler) {
-        return after("*", handler);
-    }
+    Javalin after(@NotNull Handler handler);
 
     // Reverse routing
-    public String pathFinder(@NotNull Handler handler) {
-        return pathMatcher.findHandlerPath(he -> he.getHandler().equals(handler));
-    }
+    String pathFinder(@NotNull Handler handler);
 
-    public String pathFinder(@NotNull Handler handler, @NotNull HandlerType handlerType) {
-        return pathMatcher.findHandlerPath(he -> he.getHandler().equals(handler) && he.getType() == handlerType);
-    }
+    String pathFinder(@NotNull Handler handler, @NotNull HandlerType handlerType);
+
+    <T extends Exception> Javalin exception(Class<T> exceptionClass, ExceptionHandler<? super T> exceptionHandler);
+
+    Javalin error(int statusCode, ErrorHandler errorHandler);
+
+    Javalin event(EventType eventType, EventListener eventListener);
 
     // WebSockets
     // Only available via Jetty, as there is no WebSocket interface in Java to build on top of
 
-    private Map<String, Object> pathWsHandlers = new HashMap<>();
+    Javalin ws(@NotNull String path, @NotNull WebSocketConfig ws);
 
-    public Javalin ws(@NotNull String path, @NotNull WebSocketConfig ws) {
-        WebSocketHandler configuredHandler = new WebSocketHandler();
-        ws.configure(configuredHandler);
-        return addWebSocketHandler(path, configuredHandler);
-    }
+    Javalin ws(@NotNull String path, @NotNull Class webSocketClass);
 
-    public Javalin ws(@NotNull String path, @NotNull Class webSocketClass) {
-        return addWebSocketHandler(path, webSocketClass);
-    }
-
-    public Javalin ws(@NotNull String path, @NotNull Object webSocketObject) {
-        return addWebSocketHandler(path, webSocketObject);
-    }
-
-    private Javalin addWebSocketHandler(@NotNull String path, @NotNull Object webSocketObject) {
-        ensureActionIsPerformedBeforeServerStart("Configuring WebSockets");
-        pathWsHandlers.put(path, webSocketObject);
-        return this;
-    }
-
-    // package private method used for testing
-    EmbeddedServer embeddedServer() {
-        return embeddedServer;
-    }
-
-    // package private method used for testing
-    void clearMatcherAndMappers() {
-        pathMatcher.getHandlerEntries().clear();
-        errorMapper.getErrorHandlerMap().clear();
-        exceptionMapper.getExceptionMap().clear();
-    }
-
+    Javalin ws(@NotNull String path, @NotNull Object webSocketObject);
 }

--- a/src/main/java/io/javalin/JavalinInstance.kt
+++ b/src/main/java/io/javalin/JavalinInstance.kt
@@ -1,0 +1,103 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ *
+ */
+
+package io.javalin
+
+import io.javalin.base.JavalinConfig
+import io.javalin.core.JavalinServlet
+import io.javalin.core.util.Util
+import io.javalin.embeddedserver.EmbeddedServer
+import io.javalin.embeddedserver.EmbeddedServerFactory
+import io.javalin.embeddedserver.jetty.EmbeddedJettyFactory
+import io.javalin.event.EventListener
+import io.javalin.event.EventManager
+import io.javalin.event.EventType
+import org.slf4j.LoggerFactory
+
+internal class JavalinInstance : JavalinConfig() {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(Javalin::class.java)
+    }
+
+    private lateinit var embeddedServer: EmbeddedServer
+    private var embeddedServerFactory: EmbeddedServerFactory = EmbeddedJettyFactory()
+
+
+    private val eventManager = EventManager()
+
+    override fun event(type: EventType, listener: EventListener): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Event-mapping")
+        eventManager.listenerMap[type]?.add(listener)
+        return this
+    }
+
+    override fun embeddedServer(embeddedServerFactory: EmbeddedServerFactory): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Setting a custom server")
+        this.embeddedServerFactory = embeddedServerFactory
+        return this
+    }
+
+    override fun start(): Javalin {
+        if (!started) {
+            log.info(Util.javalinBanner())
+            Util.printHelpfulMessageIfLoggerIsMissing()
+            Util.noServerHasBeenStarted = false
+            eventManager.fireEvent(EventType.SERVER_STARTING, this)
+            try {
+                embeddedServer = embeddedServerFactory.create(JavalinServlet(
+                    contextPath,
+                    pathMatcher,
+                    exceptionMapper,
+                    errorMapper,
+                    pathWsHandlers,
+                    logLevel,
+                    dynamicGzipEnabled,
+                    defaultContentType,
+                    defaultCharacterEncoding,
+                    maxRequestCacheBodySize
+                ), staticFileConfigs)
+                log.info("Starting JavalinInstance ...")
+                port = embeddedServer.start(port)
+                log.info("JavalinInstance has started \\o/")
+                started = true
+                eventManager.fireEvent(EventType.SERVER_STARTED, this)
+            } catch (e: Exception) {
+                log.error("Failed to start JavalinInstance", e)
+                eventManager.fireEvent(EventType.SERVER_START_FAILED, this)
+            }
+
+        }
+        return this
+    }
+
+    override fun stop(): Javalin {
+        eventManager.fireEvent(EventType.SERVER_STOPPING, this)
+        log.info("Stopping JavalinInstance ...")
+        try {
+            embeddedServer.stop()
+        } catch (e: Exception) {
+            log.error("JavalinInstance failed to stop gracefully", e)
+        }
+
+        log.info("JavalinInstance has stopped")
+        eventManager.fireEvent(EventType.SERVER_STOPPED, this)
+        return this
+    }
+
+    // package private method used for testing
+    public fun embeddedServer(): EmbeddedServer? {
+        return embeddedServer
+    }
+
+    // package private method used for testing
+    public fun clearMatcherAndMappers() {
+        pathMatcher.handlerEntries.clear()
+        errorMapper.errorHandlerMap.clear()
+        exceptionMapper.exceptionMap.clear()
+    }
+}

--- a/src/main/java/io/javalin/base/JavalinBase.kt
+++ b/src/main/java/io/javalin/base/JavalinBase.kt
@@ -1,0 +1,34 @@
+package io.javalin.base
+
+import io.javalin.Javalin
+import io.javalin.core.util.Util
+
+internal abstract class JavalinBase : Javalin {
+
+    protected var started = false
+
+    protected var contextPath = "/"
+    protected var port = 7000
+
+    protected fun ensureActionIsPerformedBeforeServerStart(action: String) {
+        if (started) {
+            throw IllegalStateException(action + " must be done before starting the server")
+        }
+    }
+
+    override fun contextPath() = contextPath
+
+    override fun contextPath(contextPath: String): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Setting the context path")
+        this.contextPath = Util.normalizeContextPath(contextPath)
+        return this
+    }
+
+    override fun port() = port
+
+    override fun port(port: Int): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Setting the port")
+        this.port = port
+        return this
+    }
+}

--- a/src/main/java/io/javalin/base/JavalinConfig.kt
+++ b/src/main/java/io/javalin/base/JavalinConfig.kt
@@ -1,0 +1,76 @@
+package io.javalin.base
+
+import io.javalin.Javalin
+import io.javalin.LogLevel
+import io.javalin.core.util.CorsUtil
+import io.javalin.embeddedserver.Location
+import io.javalin.embeddedserver.StaticFileConfig
+import java.nio.charset.StandardCharsets
+import java.util.ArrayList
+
+internal abstract class JavalinConfig : JavalinWS() {
+
+    protected val staticFileConfigs = ArrayList<StaticFileConfig>()
+    protected var logLevel = LogLevel.OFF
+    protected var dynamicGzipEnabled = false
+    protected var defaultContentType = "text/plain"
+    protected var defaultCharacterEncoding = StandardCharsets.UTF_8.name()
+    protected var maxRequestCacheBodySize = java.lang.Long.MAX_VALUE
+
+    override fun enableCorsForOrigin(vararg origin: String): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Enabling CORS")
+        return CorsUtil.enableCors(this, origin)
+    }
+
+    override fun enableCorsForAllOrigins() = enableCorsForOrigin("*")
+
+    override fun enableStaticFiles(classpathPath: String): Javalin {
+        return enableStaticFiles(classpathPath, Location.CLASSPATH)
+    }
+
+    override fun enableStaticFiles(path: String, location: Location): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Enabling static files")
+        staticFileConfigs.add(StaticFileConfig(path, location))
+        return this
+    }
+
+    override fun requestLogLevel(logLevel: LogLevel): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Enabling request-logging")
+        this.logLevel = logLevel
+        return this
+    }
+
+    override fun enableStandardRequestLogging() = requestLogLevel(LogLevel.STANDARD)
+
+    override fun enableDynamicGzip(): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Enabling dynamic GZIP")
+        this.dynamicGzipEnabled = true
+        return this
+    }
+
+    override fun defaultContentType(contentType: String): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Changing default content type")
+        this.defaultContentType = contentType
+        return this
+    }
+
+    override fun defaultCharacterEncoding(characterEncoding: String): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Changing default character encoding")
+        this.defaultCharacterEncoding = characterEncoding
+        return this
+    }
+
+    override fun maxBodySizeForRequestCache(value: Long): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Changing request cache body size")
+        this.maxRequestCacheBodySize = value
+        return this
+    }
+
+    override fun disableRequestCache() = maxBodySizeForRequestCache(0)
+
+    override fun dontIgnoreTrailingSlashes(): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Telling Javalin to not ignore slashes")
+        pathMatcher.ignoreTrailingSlashes = false
+        return this
+    }
+}

--- a/src/main/java/io/javalin/base/JavalinMappers.kt
+++ b/src/main/java/io/javalin/base/JavalinMappers.kt
@@ -1,0 +1,24 @@
+package io.javalin.base
+
+import io.javalin.ErrorHandler
+import io.javalin.ExceptionHandler
+import io.javalin.Javalin
+import io.javalin.core.ErrorMapper
+import io.javalin.core.ExceptionMapper
+
+internal abstract class JavalinMappers : JavalinBase() {
+
+    protected val exceptionMapper = ExceptionMapper()
+    protected val errorMapper = ErrorMapper()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Exception> exception(clazz: Class<T>, handler: ExceptionHandler<in T>): Javalin {
+        exceptionMapper.exceptionMap[clazz] = handler as ExceptionHandler<Exception>
+        return this
+    }
+
+    override fun error(statusCode: Int, handler: ErrorHandler): Javalin {
+        errorMapper.errorHandlerMap[statusCode] = handler
+        return this
+    }
+}

--- a/src/main/java/io/javalin/base/JavalinRoutes.kt
+++ b/src/main/java/io/javalin/base/JavalinRoutes.kt
@@ -1,0 +1,52 @@
+package io.javalin.base
+
+import io.javalin.Handler
+import io.javalin.Javalin
+import io.javalin.core.HandlerEntry
+import io.javalin.core.HandlerType
+import io.javalin.core.PathMatcher
+import io.javalin.core.util.Util
+
+internal abstract class JavalinRoutes : JavalinMappers() {
+
+    protected val pathMatcher = PathMatcher()
+
+    protected fun addHandler(httpMethod: HandlerType, path: String, handler: Handler): Javalin {
+        val prefixedPath = Util.prefixContextPath(path, contextPath)
+        pathMatcher.handlerEntries.add(HandlerEntry(httpMethod, prefixedPath, handler))
+        return this
+    }
+
+    // HTTP verbs
+    override fun get(path: String, handler: Handler) = addHandler(HandlerType.GET, path, handler)
+
+    override fun post(path: String, handler: Handler) = addHandler(HandlerType.POST, path, handler)
+
+    override fun put(path: String, handler: Handler) = addHandler(HandlerType.PUT, path, handler)
+
+    override fun patch(path: String, handler: Handler) = addHandler(HandlerType.PATCH, path, handler)
+
+    override fun delete(path: String, handler: Handler) = addHandler(HandlerType.DELETE, path, handler)
+
+    override fun head(path: String, handler: Handler) = addHandler(HandlerType.HEAD, path, handler)
+
+    override fun trace(path: String, handler: Handler) = addHandler(HandlerType.TRACE, path, handler)
+
+    override fun connect(path: String, handler: Handler) = addHandler(HandlerType.CONNECT, path, handler)
+
+    override fun options(path: String, handler: Handler) = addHandler(HandlerType.OPTIONS, path, handler)
+
+    // Filters
+    override fun before(path: String, handler: Handler) = addHandler(HandlerType.BEFORE, path, handler)
+
+    override fun before(handler: Handler) = before("*", handler)
+
+    override fun after(path: String, handler: Handler) = addHandler(HandlerType.AFTER, path, handler)
+
+    override fun after(handler: Handler) = after("*", handler)
+
+    // Reverse routing
+    override fun pathFinder(handler: Handler) = pathMatcher.findHandlerPath { he -> he.handler == handler }
+
+    override fun pathFinder(handler: Handler, type: HandlerType) = pathMatcher.findHandlerPath { he -> he.handler == handler && he.type === type }
+}

--- a/src/main/java/io/javalin/base/JavalinSecuredRoutes.kt
+++ b/src/main/java/io/javalin/base/JavalinSecuredRoutes.kt
@@ -1,0 +1,51 @@
+package io.javalin.base
+
+import io.javalin.Context
+import io.javalin.Handler
+import io.javalin.Javalin
+import io.javalin.core.HandlerType
+import io.javalin.security.AccessManager
+import io.javalin.security.Role
+
+internal abstract class JavalinSecuredRoutes : JavalinRoutes() {
+
+    protected var accessManager = AccessManager { _: Handler, _: Context, _: List<Role> ->
+        throw IllegalStateException("No access manager configured. Add an access manager using 'accessManager()'")
+    }
+
+    protected fun addSecuredHandler(httpMethod: HandlerType, path: String, handler: Handler, permittedRoles: List<Role>) =
+            addHandler(httpMethod, path, Handler { ctx -> accessManager.manage(handler, ctx, permittedRoles) })
+
+    override fun accessManager(accessManager: AccessManager): Javalin {
+        this.accessManager = accessManager
+        return this
+    }
+
+    // Secured HTTP verbs
+    override fun get(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.GET, path, handler, permittedRoles)
+
+    override fun post(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.POST, path, handler, permittedRoles)
+
+    override fun put(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.PUT, path, handler, permittedRoles)
+
+    override fun patch(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.PATCH, path, handler, permittedRoles)
+
+    override fun delete(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.DELETE, path, handler, permittedRoles)
+
+    override fun head(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.HEAD, path, handler, permittedRoles)
+
+    override fun trace(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.TRACE, path, handler, permittedRoles)
+
+    override fun connect(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.CONNECT, path, handler, permittedRoles)
+
+    override fun options(path: String, handler: Handler, permittedRoles: List<Role>) =
+            addSecuredHandler(HandlerType.OPTIONS, path, handler, permittedRoles)
+}

--- a/src/main/java/io/javalin/base/JavalinWS.kt
+++ b/src/main/java/io/javalin/base/JavalinWS.kt
@@ -1,0 +1,34 @@
+package io.javalin.base
+
+import io.javalin.Javalin
+import io.javalin.embeddedserver.jetty.websocket.WebSocketConfig
+import io.javalin.embeddedserver.jetty.websocket.WebSocketHandler
+import java.util.HashMap
+
+internal abstract class JavalinWS : JavalinSecuredRoutes() {
+
+    // WebSockets
+    // Only available via Jetty, as there is no WebSocket interface in Java to build on top of
+
+    protected val pathWsHandlers = HashMap<String, Any>()
+
+    private fun addWebSocketHandler(path: String, webSocketObject: Any): Javalin {
+        ensureActionIsPerformedBeforeServerStart("Configuring WebSockets")
+        pathWsHandlers[path] = webSocketObject
+        return this
+    }
+
+    override fun ws(path: String, ws: WebSocketConfig): Javalin {
+        val configuredHandler = WebSocketHandler()
+        ws.configure(configuredHandler)
+        return addWebSocketHandler(path, configuredHandler)
+    }
+
+    override fun ws(path: String, webSocketClass: Class<*>): Javalin {
+        return addWebSocketHandler(path, webSocketClass)
+    }
+
+    override fun ws(path: String, webSocketObject: Any): Javalin {
+        return addWebSocketHandler(path, webSocketObject)
+    }
+}

--- a/src/main/java/io/javalin/core/util/CorsUtil.kt
+++ b/src/main/java/io/javalin/core/util/CorsUtil.kt
@@ -10,7 +10,7 @@ import io.javalin.Javalin
 
 object CorsUtil {
 
-    fun enableCors(app: Javalin, origins: Array<String>): Javalin {
+    fun enableCors(app: Javalin, origins: Array<out String>): Javalin {
         if (origins.isEmpty()) throw IllegalArgumentException("Origins cannot be empty")
         app.options("*") { ctx ->
             ctx.header(Header.ACCESS_CONTROL_REQUEST_HEADERS)?.let {

--- a/src/test/java/io/javalin/TestCustomJetty.java
+++ b/src/test/java/io/javalin/TestCustomJetty.java
@@ -30,7 +30,7 @@ public class TestCustomJetty {
                 return server;
             }))
             .start();
-        assertThat(app.embeddedServer().attribute("is-custom-server"), is(true));
+        assertThat(((JavalinInstance) app).embeddedServer().attribute("is-custom-server"), is(true));
         app.stop();
     }
 

--- a/src/test/java/io/javalin/TestStaticFiles.java
+++ b/src/test/java/io/javalin/TestStaticFiles.java
@@ -36,7 +36,7 @@ public class TestStaticFiles {
 
     @After
     public void clear() {
-        app.clearMatcherAndMappers();
+        ((JavalinInstance) app).clearMatcherAndMappers();
     }
 
     @AfterClass

--- a/src/test/java/io/javalin/_SimpleClientBaseTest.java
+++ b/src/test/java/io/javalin/_SimpleClientBaseTest.java
@@ -31,7 +31,7 @@ public class _SimpleClientBaseTest {
 
     @After
     public void clear() {
-        app.clearMatcherAndMappers();
+        ((JavalinInstance) app).clearMatcherAndMappers();
     }
 
     @AfterClass

--- a/src/test/java/io/javalin/_UnirestBaseTest.java
+++ b/src/test/java/io/javalin/_UnirestBaseTest.java
@@ -45,7 +45,7 @@ public class _UnirestBaseTest {
 
     @After
     public void clear() {
-        app.clearMatcherAndMappers();
+        ((JavalinInstance) app).clearMatcherAndMappers();
     }
 
     @AfterClass


### PR DESCRIPTION
The `Javalin` class is now is a Java interface.
The implementation is in Kotlin, split into several files to avoid bloated "super file".
Backward compatibility seems to be saved, though internal tests should now rely on cast to `JavalinInstance`.