### PR TITLE
Return 404 if the websocket request cannot be mapped.

### DIFF
--- a/src/main/java/io/javalin/embeddedserver/jetty/EmbeddedJettyServer.kt
+++ b/src/main/java/io/javalin/embeddedserver/jetty/EmbeddedJettyServer.kt
@@ -9,6 +9,7 @@ package io.javalin.embeddedserver.jetty
 import io.javalin.core.JavalinServlet
 import io.javalin.embeddedserver.EmbeddedServer
 import io.javalin.embeddedserver.jetty.websocket.CustomWebSocketCreator
+import io.javalin.embeddedserver.jetty.websocket.RootWebSocketCreator
 import io.javalin.embeddedserver.jetty.websocket.WebSocketHandlerRoot
 import org.eclipse.jetty.server.Handler
 import org.eclipse.jetty.server.Request
@@ -60,10 +61,12 @@ class EmbeddedJettyServer(private val server: Server, private val javalinServlet
                 }), path)
             }
 
+            val rootHandler = WebSocketHandlerRoot(javalinServlet.javalinWsHandlers)
+
             // add custom javalin websocket handler (root websocket handler which does routing)
             addServlet(ServletHolder(object : WebSocketServlet() {
                 override fun configure(factory: WebSocketServletFactory) {
-                    factory.creator = CustomWebSocketCreator(WebSocketHandlerRoot(javalinServlet.javalinWsHandlers))
+                    factory.creator = RootWebSocketCreator(rootHandler, javalinServlet.javalinWsHandlers)
                 }
             }), "/*")
 

--- a/src/main/java/io/javalin/embeddedserver/jetty/EmbeddedJettyServer.kt
+++ b/src/main/java/io/javalin/embeddedserver/jetty/EmbeddedJettyServer.kt
@@ -61,12 +61,10 @@ class EmbeddedJettyServer(private val server: Server, private val javalinServlet
                 }), path)
             }
 
-            val rootHandler = WebSocketHandlerRoot(javalinServlet.javalinWsHandlers)
-
             // add custom javalin websocket handler (root websocket handler which does routing)
             addServlet(ServletHolder(object : WebSocketServlet() {
                 override fun configure(factory: WebSocketServletFactory) {
-                    factory.creator = RootWebSocketCreator(rootHandler, javalinServlet.javalinWsHandlers)
+                    factory.creator = RootWebSocketCreator(WebSocketHandlerRoot(javalinServlet.javalinWsHandlers), javalinServlet.javalinWsHandlers)
                 }
             }), "/*")
 

--- a/src/main/java/io/javalin/embeddedserver/jetty/websocket/RootWebSocketCreator.kt
+++ b/src/main/java/io/javalin/embeddedserver/jetty/websocket/RootWebSocketCreator.kt
@@ -1,0 +1,22 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin.embeddedserver.jetty.websocket
+
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator
+
+class RootWebSocketCreator(private val handlerRoot: WebSocketHandlerRoot, private val javalinWsHandlers: List<WebSocketHandler>) : WebSocketCreator {
+
+    override fun createWebSocket(req: ServletUpgradeRequest, resp: ServletUpgradeResponse): Any {
+        if (javalinWsHandlers.find { it.matches(req.requestPath) } == null) {
+            resp.sendError(404, "Not found")
+        }
+        return handlerRoot
+    }
+
+}

--- a/src/main/java/io/javalin/embeddedserver/jetty/websocket/RootWebSocketCreator.kt
+++ b/src/main/java/io/javalin/embeddedserver/jetty/websocket/RootWebSocketCreator.kt
@@ -13,7 +13,7 @@ import org.eclipse.jetty.websocket.servlet.WebSocketCreator
 class RootWebSocketCreator(private val handlerRoot: WebSocketHandlerRoot, private val javalinWsHandlers: List<WebSocketHandler>) : WebSocketCreator {
 
     override fun createWebSocket(req: ServletUpgradeRequest, resp: ServletUpgradeResponse): Any {
-        if (javalinWsHandlers.find { it.matches(req.requestPath) } == null) {
+        if (javalinWsHandlers.find { it.matches(req.requestURI.path) } == null) {
             resp.sendError(404, "Not found")
         }
         return handlerRoot


### PR DESCRIPTION
See #174 

Now javalin sends a 404 to all upgrade-requests that can't be mapped.

#### curl Request:
```
curl --include \
     --no-buffer \
     --header "Connection: Upgrade" \
     --header "Upgrade: websocket" \
     --header "Host: localhost:7000" \
     --header "Sec-WebSocket-Key: SGVsbG8sIHdvcmxkIQ==" \
     --header "Sec-WebSocket-Version: 13" \
     http://localhost:7000/context-path/not/a/valid/path
```

#### curl Output:
```
HTTP/1.1 404 Not found
Date: Mon, 19 Mar 2018 15:34:03 GMT
Cache-Control: must-revalidate,no-cache,no-store
Content-Type: text/html;charset=iso-8859-1
Content-Length: 345
Server: Jetty(9.4.8.v20171121)

<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 404 Not found</title>
</head>
<body><h2>HTTP ERROR 404</h2>
<p>Problem accessing /context-path/not/a/valid/path. Reason:
<pre>    Not found</pre></p><hr><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.4.8.v20171121</a><hr/>

</body>
</html>

```

One minor thing: I couldn't write a test for this because I didn't find any method in `WebSocketClient` to get the status-code.