### PR TITLE
Add default branch for LogLevel.OFF

### DIFF
--- a/src/main/java/io/javalin/core/util/LogUtil.kt
+++ b/src/main/java/io/javalin/core/util/LogUtil.kt
@@ -46,6 +46,7 @@ object LogUtil {
                         |${if (resBody.isNotEmpty()) (if (gzipped) "dynamically gzipped response ..." else resBody) else "No body was set"}
                         |----------------------------------------------------------------------------------""".trimMargin())
                 }
+                LogLevel.OFF -> {}
             }
         }
     }


### PR DESCRIPTION
Not having this inside the `when` gives a warning, and I like covering all cases.