### PR TITLE
Use EnumMap in handler matcher

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -405,7 +405,7 @@ public class Javalin {
     private Javalin addHandler(@NotNull HandlerType httpMethod, @NotNull String path, @NotNull Handler handler, List<Role> roles) {
         String prefixedPath = Util.INSTANCE.prefixContextPath(path, contextPath);
         Handler handlerWrap = roles == null ? handler : ctx -> accessManager.manage(handler, ctx, roles);
-        pathMatcher.getHandlerEntries().add(new HandlerEntry(httpMethod, prefixedPath, handlerWrap));
+        pathMatcher.getHandlerEntries().get(httpMethod).add(new HandlerEntry(httpMethod, prefixedPath, handlerWrap));
         routeOverviewEntries.add(new RouteOverviewEntry(httpMethod, prefixedPath, handler, roles));
         return this;
     }
@@ -727,7 +727,7 @@ public class Javalin {
 
     // package private method used for testing
     void clearMatcherAndMappers() {
-        pathMatcher.getHandlerEntries().clear();
+        pathMatcher.getHandlerEntries().forEach((__, values) -> values.clear());
         errorMapper.getErrorHandlerMap().clear();
         exceptionMapper.getExceptionMap().clear();
     }

--- a/src/main/java/io/javalin/core/PathMatcher.kt
+++ b/src/main/java/io/javalin/core/PathMatcher.kt
@@ -84,13 +84,10 @@ class PathMatcher {
 
     private val log = LoggerFactory.getLogger(PathMatcher::class.java)
 
-    val handlerEntries = EnumMap<HandlerType, ArrayList<HandlerEntry>>(HandlerType::class.java)
-
-    init {
-        HandlerType.values().forEach {
-            handlerEntries[it] = ArrayList()
+    val handlerEntries = HandlerType.values()
+        .associateTo(EnumMap<HandlerType, ArrayList<HandlerEntry>>(HandlerType::class.java)) {
+            it to arrayListOf()
         }
-    }
 
     fun findEntries(requestType: HandlerType, requestUri: String): List<HandlerEntry> {
         return handlerEntries[requestType]?.filter { he -> match(he, requestType, requestUri) } ?: emptyList()


### PR DESCRIPTION
- win in performance in usual path matching (less paths to check)
- lose in performance in reverse routing (need to transform routes from map)