### PR TITLE
Add anyParam helper to Context object.

### DIFF
--- a/src/main/java/io/javalin/Context.kt
+++ b/src/main/java/io/javalin/Context.kt
@@ -175,6 +175,14 @@ class Context(private val servletResponse: HttpServletResponse,
      */
     fun paramMap(): Map<String, String> = Collections.unmodifiableMap(paramMap)
 
+    /**
+     * Get all param values from any of path, form, query and headers.
+     *
+     * Ex: If there is a form which submits comments to /comments as a form parameter or a query param
+     * like /comments?comment=comments, or both, this handler will return both comments.
+     */
+    fun anyParam(param: String): Collection<String> = listOfNotNull(param(param), formParam(param), queryParam(param), header(param))
+
     //
     // Gets a splat by its index.
     // Ex: If the handler path is /users/*

--- a/src/test/java/io/javalin/TestRequest.java
+++ b/src/test/java/io/javalin/TestRequest.java
@@ -218,4 +218,13 @@ public class TestRequest extends _UnirestBaseTest {
         assertThat(GET_body("/matched/p1"), is("/matched/:param"));
         assertThat(GET_body("/matched/p1/p2"), is("/matched/:param/:param2"));
     }
+
+    /*
+     * Any params.
+     */
+    @Test
+    public void test_anyParam_works() throws Exception {
+        app.get("/:param/", ctx -> ctx.result(String.join(",", ctx.anyParam("param"))));
+        assertThat(GET_body("/path?param=query"), is("path,query"));
+    }
 }


### PR DESCRIPTION
Simple `Context` method to search for parameters in multiple places. I often mix up path/query/form so something like this would help me when I know there's a `comment` parameter somewhere but can't seem to find it.