### PR TITLE
[extension] add Extension API

### DIFF
--- a/src/main/java/io/javalin/Extension.java
+++ b/src/main/java/io/javalin/Extension.java
@@ -1,0 +1,17 @@
+package io.javalin;
+
+/**
+ * An extension is a feature module adding a group of functionality to the Javalin application.
+ *
+ * It's similar to Handler groups but allows to read and modify the Javalin app instance.
+ * Helpful where you like to group a cross-cutting concern in a class or lambda expression.
+ *
+ * Inspired by Sinatra extensions and the `Sinatra.register` DSL.
+ *
+ * @link http://sinatrarb.com/extensions.html#extending-the-dsl-class-context-with-sinatraregister
+ */
+@FunctionalInterface
+public interface Extension {
+
+    void register(Javalin app);
+}

--- a/src/main/java/io/javalin/Extension.java
+++ b/src/main/java/io/javalin/Extension.java
@@ -6,7 +6,7 @@ package io.javalin;
  * It's similar to Handler groups but allows to read and modify the Javalin app instance.
  * Helpful where you like to group a cross-cutting concern in a class or lambda expression.
  *
- * Inspired by Sinatra extensions and the `Sinatra.register` DSL.
+ * Inspired by Sinatra extensions and the `Sinatra.extension` DSL.
  *
  * @link http://sinatrarb.com/extensions.html#extending-the-dsl-class-context-with-sinatraregister
  */

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -732,4 +732,17 @@ public class Javalin {
         exceptionMapper.getExceptionMap().clear();
     }
 
+    // Extension
+
+    /**
+     * Registers a {@link Extension} to the Javalin application.
+     *
+     * @param extension You're free to implement the extension as a class or a lambda expression.
+     * @return Self instance for fluent, method-chaining API
+     */
+    public Javalin register(Extension extension) {
+        extension.register(this);
+
+        return this;
+    }
 }

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -737,30 +737,43 @@ public class Javalin {
     // Extension
 
     /**
-     * Registers an {@link Extension} with the Javalin application.
+     * Registers an anonymous {@link Extension} with the Javalin application.
      *
-     * @param extension You're free to implement the extension as a class or a lambda expression.
+     * @param extension You're free to implement the extension as a class or a lambda expression
      * @return Self instance for fluent, method-chaining API
      */
     public Javalin extension(Extension extension) {
         extension.register(this);
 
-        String clazzName = extension.getClass().getCanonicalName();
-        if (clazzName != null) {
-            extensions.put(clazzName, extension);
+        return this;
+    }
+
+    /**
+     * Registers an {@link Extension} with the Javalin application.
+     *
+     * @param extClazz The extension key
+     * @param extension You're free to implement the extension as a class or a lambda expression
+     * @return Self instance for fluent, method-chaining API
+     */
+    public Javalin extension(Class<?> extClazz, Extension extension) {
+        extension.register(this);
+
+        String extKey = extClazz.getCanonicalName();
+        if (extKey != null) {
+            extensions.put(extKey, extension);
         }
 
         return this;
     }
 
     /**
-     * Returns a class-based {@link Extension} that was registered with the Javalin application.
+     * Returns an {@link Extension} that was registered with the Javalin application.
      *
      * @param extClazz The class implementing the `Extension` interface
-     * @return An instance of `T` or null.
+     * @return An instance of `T` or null
      */
     @SuppressWarnings("unchecked")
-    public <T extends Extension> T extension(Class<T> extClazz) {
+    public <T> T extension(Class<T> extClazz) {
 
         return (T) extensions.get(extClazz.getCanonicalName());
     }

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -66,6 +66,8 @@ public class Javalin {
         throw new IllegalStateException("No access manager configured. Add an access manager using 'accessManager()'");
     };
 
+    private final Map<String, Extension> extensions = new HashMap<>();
+
     private Javalin() {
     }
 
@@ -735,14 +737,31 @@ public class Javalin {
     // Extension
 
     /**
-     * Registers a {@link Extension} to the Javalin application.
+     * Registers an {@link Extension} with the Javalin application.
      *
      * @param extension You're free to implement the extension as a class or a lambda expression.
      * @return Self instance for fluent, method-chaining API
      */
-    public Javalin register(Extension extension) {
+    public Javalin extension(Extension extension) {
         extension.register(this);
 
+        String clazzName = extension.getClass().getCanonicalName();
+        if (clazzName != null) {
+            extensions.put(clazzName, extension);
+        }
+
         return this;
+    }
+
+    /**
+     * Returns a class-based {@link Extension} that was registered with the Javalin application.
+     *
+     * @param extClazz The class implementing the `Extension` interface
+     * @return An instance of `T` or null.
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends Extension> T extension(Class<T> extClazz) {
+
+        return (T) extensions.get(extClazz.getCanonicalName());
     }
 }

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -66,7 +66,7 @@ public class Javalin {
         throw new IllegalStateException("No access manager configured. Add an access manager using 'accessManager()'");
     };
 
-    private final Map<String, Extension> extensions = new HashMap<>();
+    private final Map<Class<?>, Extension> extensions = new HashMap<>();
 
     private Javalin() {
     }
@@ -756,12 +756,11 @@ public class Javalin {
      * @return Self instance for fluent, method-chaining API
      */
     public Javalin extension(Class<?> extClazz, Extension extension) {
-        extension.register(this);
-
-        String extKey = extClazz.getCanonicalName();
-        if (extKey != null) {
-            extensions.put(extKey, extension);
+        if (extClazz == null) {
+            throw new IllegalArgumentException("Extension key extClazz must not be null");
         }
+        extension.register(this);
+        extensions.put(extClazz, extension);
 
         return this;
     }
@@ -775,6 +774,6 @@ public class Javalin {
     @SuppressWarnings("unchecked")
     public <T> T extension(Class<T> extClazz) {
 
-        return (T) extensions.get(extClazz.getCanonicalName());
+        return (T) extensions.get(extClazz);
     }
 }

--- a/src/test/java/io/javalin/TestExtension.java
+++ b/src/test/java/io/javalin/TestExtension.java
@@ -85,7 +85,7 @@ public class TestExtension {
 
     @Test
     public void test_javaClassExtensions() {
-        app.extension(new JavaClassExtension("Foobar!"))
+        app.extension(JavaClassExtension.class, new JavaClassExtension("Foobar!"))
             .extension((app) -> {
                 assertThat(app.extension(JavaClassExtension.class).getMagicValue(), is("Foobar!"));
             });

--- a/src/test/java/io/javalin/TestExtension.java
+++ b/src/test/java/io/javalin/TestExtension.java
@@ -1,3 +1,9 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
 package io.javalin;
 
 import com.mashape.unirest.http.HttpResponse;

--- a/src/test/java/io/javalin/TestExtension.java
+++ b/src/test/java/io/javalin/TestExtension.java
@@ -1,0 +1,78 @@
+package io.javalin;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import java.io.IOException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class TestExtension {
+
+    private static Javalin app;
+    private static String origin = null;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        app = Javalin.create()
+                .port(0)
+                .start();
+        origin = "http://localhost:" + app.port();
+    }
+
+    @After
+    public void clear() {
+        app.clearMatcherAndMappers();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        app.stop();
+    }
+
+    @Test
+    public void test_helloWorldExtension() throws Exception {
+        app.register((app) -> {
+            app.before("/protected", ctx -> {
+                throw new HaltException(401, "Protected");
+            });
+            app.get("/", ctx -> ctx.result("Hello world"));
+        });
+
+        HttpResponse<String> response = Unirest.get(origin + "/").asString();
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getBody(), is("Hello world"));
+
+        HttpResponse<String> response2 = Unirest.get(origin + "/protected").asString();
+        assertThat(response2.getStatus(), is(401));
+        assertThat(response2.getBody(), is("Protected"));
+    }
+
+    @Test
+    public void test_javaClassExtension() throws Exception {
+        app.register(new JavaClassExtension("Foobar!"));
+
+        HttpResponse<String> response = Unirest.get(origin + "/").asString();
+        assertThat(response.getStatus(), is(400));
+        assertThat(response.getBody(), is("Foobar!"));
+    }
+
+    static class JavaClassExtension implements Extension {
+        private final String magicValue;
+
+        public JavaClassExtension(String magicValue) {
+            this.magicValue = magicValue;
+        }
+
+        @Override
+        public void register(Javalin app) {
+            app.before(ctx -> {
+                throw new HaltException(400, magicValue);
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
Hi,

this change adds a `register()` method similar to [sinatras register DSL](http://sinatrarb.com/extensions.html#extending-the-dsl-class-context-with-sinatraregister).

The motivation is to write a feature module and reflect the cohesiveness of the feature in the cohesiveness of the source code. Code that belongs to the same feature should be grouped closely together and written in source files next to each other.

Something similar is already possible with the endpoint groups (handler groups) but extensions give access to the `Javalin` app instance. Extensions should be especially helpful for cross-cutting concerns, e.g. adding a persistence data layer to an application, or adding a complex authentication feature (one that adds an access manager and a login/logout route and possibly adds other before/after handlers or exception mappers).

#### Example

Here's  a scribble of the case I have in mind:

```java
public class App {
  public static void main(String[] args) {
    Javalin.create()
      .get("/", ctx -> ctx.result("Hello world"))
      .post("/", ctx -> { /* do things on the database */ })
      .register(new PersistenceLayer("jdbc://connection-url")
      .start();
  }
}
```

```java
public class PersistenceExtension implements Extension {

  public PersistenceExtension(String dependenciesForPersistence) {
    /* set up jdbc, session factory, or entity manager (general start-up code) */
  }

  public void register(Javalin app) {
    app.before(ctx -> { /* per-request initialising code, e.g. create a session, start transaction */ });

    app.after(ctx -> { /* per-request finalising code, e.g. transaction commit/rollback */ });
  }
}
```

#### Other thoughts: `extends Javalin`

I initially had in mind whether `Extension` should return a `Javalin` instance (or sub-class of it), that would allow a DSL like

```java
public class ExtensionA extends Javalin {
  public ExtensionA doThingsOnA();
}
```

```java
app.register(new ExtensionA()).doThingsOnA().start();
```

But that won't work with Java's static typing for adding multiple extension:

```java
app.register(new ExtA())
  .register(new ExtB()) // <-- would need to return like a "union type"
                        // type ExtAB = ExtA : Javalin & ExtB: Javalin
  .doThingsOnA()
  .doThingsOnB()
```

And also, it would need to forward method calls to a wrapped inner `Javalin` instance (with reflection or something dynamic at runtime).

#### Other thoughts: `AugmentedContext extends Context`

I thought about whether extension could add functionality to the `Context` object. This would become something like:

```java
class AugmentedContext extends Context {
  JdbcTransactionThingDoer getTransaction();
}
```

to be used like:

```java
app.post(ctx -> {
  ctx.getTransaction().doJdbcThingsOrWhatsoever(); // <-- AugmentedContext
  ctx.result(/* ..*); // <-- Context
});
```

But again, that won't work with Java's static typing.