### PR TITLE
[core] Return 405 instead of 404 when applicable

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -29,6 +29,7 @@ import io.javalin.event.EventManager;
 import io.javalin.event.EventType;
 import io.javalin.security.AccessManager;
 import io.javalin.security.Role;
+
 import java.net.BindException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -61,6 +62,7 @@ public class Javalin {
     private String defaultCharacterEncoding = StandardCharsets.UTF_8.name();
     private long maxRequestCacheBodySize = Long.MAX_VALUE;
     private boolean hideBanner = false;
+    private boolean prefer405over404 = false;
     private EventManager eventManager = new EventManager();
 
     private AccessManager accessManager = (Handler handler, Context ctx, List<Role> permittedRoles) -> {
@@ -127,7 +129,8 @@ public class Javalin {
                     dynamicGzipEnabled,
                     defaultContentType,
                     defaultCharacterEncoding,
-                    maxRequestCacheBodySize
+                    maxRequestCacheBodySize,
+                    prefer405over404
                 ), staticFileConfig);
                 log.info("Starting Javalin ...");
                 port = embeddedServer.start(port);
@@ -164,6 +167,16 @@ public class Javalin {
         }
         log.info("Javalin has stopped");
         eventManager.fireEvent(EventType.SERVER_STOPPED, this);
+        return this;
+    }
+
+    /**
+     * Configure the instance to return 405 (Method Not Allowed) instead of 404 (Not Found) whenever a request method doesn't exists but there are handlers for other methods on the same requested path.
+     * The method must be called before {@link Javalin#start()}.
+     */
+    public Javalin prefer405over404() {
+        ensureActionIsPerformedBeforeServerStart("Telling Javalin to return 405 instead of 404 when applicable");
+        prefer405over404 = true;
         return this;
     }
 

--- a/src/main/java/io/javalin/core/HandlerType.kt
+++ b/src/main/java/io/javalin/core/HandlerType.kt
@@ -11,11 +11,9 @@ import javax.servlet.http.HttpServletRequest
 enum class HandlerType {
     GET, POST, PUT, PATCH, DELETE, HEAD, TRACE, CONNECT, OPTIONS, BEFORE, AFTER, INVALID, WEBSOCKET;
 
-    fun isHttpMethod(): Boolean {
-        return when (this) {
-            GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH -> true
-            else -> false
-        }
+    fun isHttpMethod() = when (this) {
+        GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH -> true
+        else -> false
     }
 
     companion object {

--- a/src/main/java/io/javalin/core/HandlerType.kt
+++ b/src/main/java/io/javalin/core/HandlerType.kt
@@ -11,6 +11,13 @@ import javax.servlet.http.HttpServletRequest
 enum class HandlerType {
     GET, POST, PUT, PATCH, DELETE, HEAD, TRACE, CONNECT, OPTIONS, BEFORE, AFTER, INVALID, WEBSOCKET;
 
+    fun isHttpMethod(): Boolean {
+        return when (this) {
+            GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH -> true
+            else -> false
+        }
+    }
+
     companion object {
         private val methodMap = HandlerType.values().map { it.toString() to it }.toMap()
         fun fromServletRequest(httpRequest: HttpServletRequest): HandlerType {

--- a/src/main/java/io/javalin/core/JavalinServlet.kt
+++ b/src/main/java/io/javalin/core/JavalinServlet.kt
@@ -79,20 +79,7 @@ class JavalinServlet(
             if (endpointEntries.isEmpty() && type != HandlerType.HEAD && type != HandlerType.GET) {
 
                 if (prefer405over404) {
-                    val availableHandlerTypes = MethodNotAllowedUtil.findAvailableHandlerTypes(matcher, requestUri)
-
-                    if (availableHandlerTypes.isEmpty()) {
-                        throw HaltException(404, "Not found")
-                    }
-
-                    val acceptableReturnTypes = ctx.header("Accept")
-
-                    val body = if (acceptableReturnTypes != null && acceptableReturnTypes.contains("application/json")) {
-                        MethodNotAllowedUtil.createJsonMethodNotAllowed(availableHandlerTypes)
-                    } else {
-                        MethodNotAllowedUtil.createHtmlMethodNotAllowed(availableHandlerTypes)
-                    }
-                    throw HaltException(405, body)
+                    handleMethodNotAllowed(ctx, requestUri)
                 } else {
                     throw HaltException(404, "Not found")
                 }
@@ -138,6 +125,23 @@ class JavalinServlet(
                 }
             }
         }
+    }
+
+    private fun handleMethodNotAllowed(ctx: Context, requestUri: String) {
+        val availableHandlerTypes = MethodNotAllowedUtil.findAvailableHandlerTypes(matcher, requestUri)
+
+        if (availableHandlerTypes.isEmpty()) {
+            throw HaltException(404, "Not found")
+        }
+
+        val acceptableReturnTypes = ctx.header("Accept")
+
+        val body = if (acceptableReturnTypes != null && acceptableReturnTypes.contains("application/json")) {
+            MethodNotAllowedUtil.createJsonMethodNotAllowed(availableHandlerTypes)
+        } else {
+            MethodNotAllowedUtil.createHtmlMethodNotAllowed(availableHandlerTypes)
+        }
+        throw HaltException(405, body)
     }
 
     private fun writeResult(ctx: Context, res: HttpServletResponse) {

--- a/src/main/java/io/javalin/core/JavalinServlet.kt
+++ b/src/main/java/io/javalin/core/JavalinServlet.kt
@@ -17,6 +17,7 @@ import io.javalin.embeddedserver.CachedRequestWrapper
 import io.javalin.embeddedserver.CachedResponseWrapper
 import io.javalin.embeddedserver.StaticResourceHandler
 import io.javalin.embeddedserver.jetty.websocket.WebSocketHandler
+import io.javalin.translator.json.JavalinJsonPlugin
 import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.util.zip.GZIPOutputStream
@@ -83,7 +84,15 @@ class JavalinServlet(
                     if (availableHandlerTypes.isEmpty()) {
                         throw HaltException(404, "Not found")
                     }
-                    throw HaltException(405, MethodNotAllowedUtil.createHtmlMethodNotAllowed(availableHandlerTypes))
+
+                    val acceptableReturnTypes = ctx.header("Accept")
+
+                    val body = if (acceptableReturnTypes != null && acceptableReturnTypes.contains("application/json")) {
+                        MethodNotAllowedUtil.createJsonMethodNotAllowed(availableHandlerTypes)
+                    } else {
+                        MethodNotAllowedUtil.createHtmlMethodNotAllowed(availableHandlerTypes)
+                    }
+                    throw HaltException(405, body)
                 } else {
                     throw HaltException(404, "Not found")
                 }

--- a/src/main/java/io/javalin/core/JavalinServlet.kt
+++ b/src/main/java/io/javalin/core/JavalinServlet.kt
@@ -17,7 +17,6 @@ import io.javalin.embeddedserver.CachedRequestWrapper
 import io.javalin.embeddedserver.CachedResponseWrapper
 import io.javalin.embeddedserver.StaticResourceHandler
 import io.javalin.embeddedserver.jetty.websocket.WebSocketHandler
-import io.javalin.translator.json.JavalinJsonPlugin
 import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.util.zip.GZIPOutputStream
@@ -128,7 +127,7 @@ class JavalinServlet(
     }
 
     private fun handleMethodNotAllowed(ctx: Context, requestUri: String) {
-        val availableHandlerTypes = MethodNotAllowedUtil.findAvailableHandlerTypes(matcher, requestUri)
+        val availableHandlerTypes = MethodNotAllowedUtil.findAvailableHttpHandlerTypes(matcher, requestUri)
 
         if (availableHandlerTypes.isEmpty()) {
             throw HaltException(404, "Not found")

--- a/src/main/java/io/javalin/core/JavalinServlet.kt
+++ b/src/main/java/io/javalin/core/JavalinServlet.kt
@@ -76,9 +76,10 @@ class JavalinServlet(
                 }
             }
             if (endpointEntries.isEmpty() && type != HandlerType.HEAD && type != HandlerType.GET) {
+                val availableHandlerTypes = MethodNotAllowedUtil.findAvailableHttpHandlerTypes(matcher, requestUri)
 
-                if (prefer405over404) {
-                    handleMethodNotAllowed(ctx, requestUri)
+                if (prefer405over404 && !availableHandlerTypes.isEmpty()) {
+                    throwMethodNotAllowed(ctx, availableHandlerTypes)
                 } else {
                     throw HaltException(404, "Not found")
                 }
@@ -126,13 +127,7 @@ class JavalinServlet(
         }
     }
 
-    private fun handleMethodNotAllowed(ctx: Context, requestUri: String) {
-        val availableHandlerTypes = MethodNotAllowedUtil.findAvailableHttpHandlerTypes(matcher, requestUri)
-
-        if (availableHandlerTypes.isEmpty()) {
-            throw HaltException(404, "Not found")
-        }
-
+    private fun throwMethodNotAllowed(ctx: Context, availableHandlerTypes: List<HandlerType>) {
         val acceptableReturnTypes = ctx.header("Accept")
 
         val body = if (acceptableReturnTypes != null && acceptableReturnTypes.contains("application/json")) {

--- a/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
+++ b/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
@@ -2,7 +2,6 @@ package io.javalin.core.util
 
 import io.javalin.core.HandlerType
 import io.javalin.core.PathMatcher
-import io.javalin.translator.json.JavalinJsonPlugin.objectToJsonMapper
 
 private data class JsonMethodNotAllowed(val availableMethods: List<HandlerType>)
 

--- a/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
+++ b/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
@@ -8,10 +8,14 @@ private data class JsonMethodNotAllowed(val availableMethods: List<HandlerType>)
 object MethodNotAllowedUtil {
 
     @JvmStatic
-    fun findAvailableHandlerTypes(matcher: PathMatcher, requestUri: String): List<HandlerType> {
+    fun findAvailableHttpHandlerTypes(matcher: PathMatcher, requestUri: String): List<HandlerType> {
         val availableHandlerTypes = ArrayList<HandlerType>()
 
         enumValues<HandlerType>().forEach {
+
+            if (!it.isHttpMethod())
+                return@forEach
+
             val entries = matcher.findEntries(it, requestUri)
 
             if (!entries.isEmpty()) {

--- a/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
+++ b/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
@@ -1,0 +1,40 @@
+package io.javalin.core.util
+
+import io.javalin.core.HandlerType
+import io.javalin.core.PathMatcher
+
+object MethodNotAllowedUtil {
+
+    @JvmStatic
+    fun findAvailableHandlerTypes(matcher: PathMatcher, requestUri: String): List<HandlerType> {
+        val availableHandlerTypes = ArrayList<HandlerType>()
+
+        enumValues<HandlerType>().forEach {
+            val entries = matcher.findEntries(it, requestUri)
+
+            if (!entries.isEmpty()) {
+                availableHandlerTypes.add(it)
+            }
+        }
+        return availableHandlerTypes
+    }
+
+    @JvmStatic
+    fun createHtmlMethodNotAllowed(availableHandlerTypes: List<HandlerType>): String {
+        return """
+                    <!DOCTYPE html>
+                    <html lang="en">
+                        <head>
+                            <meta charset="UTF-8">
+                            <title>Method Not Allowed</title>
+                        </head>
+                        <body>
+                            <h1>405 - Method Not Allowed</h1>
+                            <p>
+                                Available Methods: <strong>${availableHandlerTypes.joinToString(", ")}</strong>
+                            </p>
+                        </body>
+                    </html>
+                """
+    }
+}

--- a/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
+++ b/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
@@ -2,6 +2,9 @@ package io.javalin.core.util
 
 import io.javalin.core.HandlerType
 import io.javalin.core.PathMatcher
+import io.javalin.translator.json.JavalinJsonPlugin.objectToJsonMapper
+
+private data class JsonMethodNotAllowed(val availableMethods: List<HandlerType>)
 
 object MethodNotAllowedUtil {
 
@@ -17,6 +20,10 @@ object MethodNotAllowedUtil {
             }
         }
         return availableHandlerTypes
+    }
+
+    fun createJsonMethodNotAllowed(availableHandlerTypes: List<HandlerType>): String {
+        return objectToJsonMapper.map(JsonMethodNotAllowed(availableHandlerTypes))
     }
 
     @JvmStatic

--- a/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
+++ b/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
@@ -23,7 +23,8 @@ object MethodNotAllowedUtil {
     }
 
     fun createJsonMethodNotAllowed(availableHandlerTypes: List<HandlerType>): String {
-        return objectToJsonMapper.map(JsonMethodNotAllowed(availableHandlerTypes))
+
+        return """{"availableMethods":${availableHandlerTypes.joinToString(separator = "\", \"", prefix = "[\"", postfix = "\"]")}}"""
     }
 
     @JvmStatic

--- a/src/test/java/io/javalin/TestMethodNotAllowed.java
+++ b/src/test/java/io/javalin/TestMethodNotAllowed.java
@@ -24,12 +24,12 @@ public class TestMethodNotAllowed {
             + "                        <body>\n"
             + "                            <h1>405 - Method Not Allowed</h1>\n"
             + "                            <p>\n"
-            + "                                Available Methods: <strong>GET</strong>\n"
+            + "                                Available Methods: <strong>GET, PUT, DELETE</strong>\n"
             + "                            </p>\n"
             + "                        </body>\n"
             + "                    </html>\n"
             + "                ";
-    private static final String EXPECTED_JSON_BODY = "{\"availableMethods\":[\"GET\"]}";
+    private static final String EXPECTED_JSON_BODY = "{\"availableMethods\":[\"GET\", \"PUT\", \"DELETE\"]}";
     private static Javalin app;
     private static String baseUrl;
 
@@ -42,6 +42,8 @@ public class TestMethodNotAllowed {
         baseUrl = "http://localhost:" + app.port();
 
         app.get("/test", ctx -> ctx.result("Hello world"));
+        app.put("/test", ctx -> ctx.result("Hello world"));
+        app.delete("/test", ctx -> ctx.result("Hello world"));
     }
 
     @Test

--- a/src/test/java/io/javalin/TestMethodNotAllowed.java
+++ b/src/test/java/io/javalin/TestMethodNotAllowed.java
@@ -15,20 +15,20 @@ import static org.hamcrest.Matchers.is;
 public class TestMethodNotAllowed {
 
     private static final String EXPECTED_BODY = "\n"
-            + "                            <!DOCTYPE html>\n"
-            + "                            <html lang=\"en\">\n"
-            + "                                <head>\n"
-            + "                                    <meta charset=\"UTF-8\">\n"
-            + "                                    <title>Method Not Allowed</title>\n"
-            + "                                </head>\n"
-            + "                                <body>\n"
-            + "                                    <h1>405 - Method Not Allowed</h1>\n"
-            + "                                    <p>\n"
-            + "                                        Available Methods: <strong>GET</strong>\n"
-            + "                                    </p>\n"
-            + "                                </body>\n"
-            + "                            </html>\n"
-            + "                        ";
+            + "                    <!DOCTYPE html>\n"
+            + "                    <html lang=\"en\">\n"
+            + "                        <head>\n"
+            + "                            <meta charset=\"UTF-8\">\n"
+            + "                            <title>Method Not Allowed</title>\n"
+            + "                        </head>\n"
+            + "                        <body>\n"
+            + "                            <h1>405 - Method Not Allowed</h1>\n"
+            + "                            <p>\n"
+            + "                                Available Methods: <strong>GET</strong>\n"
+            + "                            </p>\n"
+            + "                        </body>\n"
+            + "                    </html>\n"
+            + "                ";
     private static Javalin app;
     private static String baseUrl;
 

--- a/src/test/java/io/javalin/TestMethodNotAllowed.java
+++ b/src/test/java/io/javalin/TestMethodNotAllowed.java
@@ -1,0 +1,58 @@
+package io.javalin;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class TestMethodNotAllowed {
+
+    private static final String EXPECTED_BODY = "\n"
+            + "                            <!DOCTYPE html>\n"
+            + "                            <html lang=\"en\">\n"
+            + "                                <head>\n"
+            + "                                    <meta charset=\"UTF-8\">\n"
+            + "                                    <title>Method Not Allowed</title>\n"
+            + "                                </head>\n"
+            + "                                <body>\n"
+            + "                                    <h1>405 - Method Not Allowed</h1>\n"
+            + "                                    <p>\n"
+            + "                                        Available Methods: <strong>GET</strong>\n"
+            + "                                    </p>\n"
+            + "                                </body>\n"
+            + "                            </html>\n"
+            + "                        ";
+    private static Javalin app;
+    private static String baseUrl;
+
+    @BeforeClass
+    public static void setup() {
+        app = Javalin.create()
+                     .port(0)
+                     .prefer405over404()
+                     .start();
+        baseUrl = "http://localhost:" + app.port();
+
+        app.get("/test", ctx -> ctx.result("Hello world"));
+    }
+
+    @Test
+    public void test_methodNotAllowed() throws UnirestException {
+        HttpResponse<String> response = Unirest.post(baseUrl + "/test").asString();
+
+        assertThat(response.getStatus(), is(HttpServletResponse.SC_METHOD_NOT_ALLOWED));
+        assertThat(response.getBody(), is(EXPECTED_BODY));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        app.stop();
+    }
+}

--- a/src/test/java/io/javalin/TestMethodNotAllowed.java
+++ b/src/test/java/io/javalin/TestMethodNotAllowed.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 
 public class TestMethodNotAllowed {
 
-    private static final String EXPECTED_BODY = "\n"
+    private static final String EXPECTED_HTML_BODY = "\n"
             + "                    <!DOCTYPE html>\n"
             + "                    <html lang=\"en\">\n"
             + "                        <head>\n"
@@ -29,6 +29,7 @@ public class TestMethodNotAllowed {
             + "                        </body>\n"
             + "                    </html>\n"
             + "                ";
+    private static final String EXPECTED_JSON_BODY = "{\"availableMethods\":[\"GET\"]}";
     private static Javalin app;
     private static String baseUrl;
 
@@ -44,11 +45,19 @@ public class TestMethodNotAllowed {
     }
 
     @Test
-    public void test_methodNotAllowed() throws UnirestException {
+    public void test_htmlMethodNotAllowed() throws UnirestException {
         HttpResponse<String> response = Unirest.post(baseUrl + "/test").asString();
 
         assertThat(response.getStatus(), is(HttpServletResponse.SC_METHOD_NOT_ALLOWED));
-        assertThat(response.getBody(), is(EXPECTED_BODY));
+        assertThat(response.getBody(), is(EXPECTED_HTML_BODY));
+    }
+
+    @Test
+    public void test_jsonMethodNotAllowed() throws UnirestException {
+        HttpResponse<String> response = Unirest.post(baseUrl + "/test").header("Accept", "application/json").asString();
+
+        assertThat(response.getStatus(), is(HttpServletResponse.SC_METHOD_NOT_ALLOWED));
+        assertThat(response.getBody(), is(EXPECTED_JSON_BODY));
     }
 
     @AfterClass


### PR DESCRIPTION
This pull request implements the feature requested in the issue #228 and adds a new test case. I've made the feature toggable and disabled by default to preserve backwards compatibility. I'm open to any suggestions on how this can be improved.