### PR TITLE
[core] Add the '.twig' extension as a default recognized jTwig template

### DIFF
--- a/src/main/java/io/javalin/rendering/JavalinRenderer.kt
+++ b/src/main/java/io/javalin/rendering/JavalinRenderer.kt
@@ -20,7 +20,7 @@ object JavalinRenderer {
         register(JavalinVelocity, ".vm", ".vtl")
         register(JavalinFreemarker, ".ftl")
         register(JavalinMustache, ".mustache")
-        register(JavalinJtwig, ".jtwig")
+        register(JavalinJtwig, ".jtwig", ".twig")
         register(JavalinPebble, ".peb", ".pebble")
         register(JavalinThymeleaf, ".html", ".tl", ".thyme", ".thymeleaf")
         register(JavalinCommonmark, ".md", ".markdown")


### PR DESCRIPTION
Adds the `.twig` extension as a default