### PR TITLE
[core] Remove default body from HaltException

### DIFF
--- a/src/main/java/io/javalin/HaltException.kt
+++ b/src/main/java/io/javalin/HaltException.kt
@@ -10,7 +10,7 @@ package io.javalin
  * Exception which is handled before all other exceptions. Can be used to short-circuit the request cycle.
  * @see <a href="https://javalin.io/documentation#exception-mapping">HaltException in docs</a>
  */
-class HaltException(var statusCode: Int = 200, var body: String = "Execution halted") : RuntimeException() {
+class HaltException(var statusCode: Int = 200, var body: String = "") : RuntimeException() {
     constructor(statusCode: Int) : this() {
         this.statusCode = statusCode
     }

--- a/src/main/java/io/javalin/HaltException.kt
+++ b/src/main/java/io/javalin/HaltException.kt
@@ -10,12 +10,9 @@ package io.javalin
  * Exception which is handled before all other exceptions. Can be used to short-circuit the request cycle.
  * @see <a href="https://javalin.io/documentation#exception-mapping">HaltException in docs</a>
  */
-class HaltException(var statusCode: Int = 200, var body: String = "") : RuntimeException() {
-    constructor(statusCode: Int) : this() {
-        this.statusCode = statusCode
-    }
+class HaltException(var statusCode: Int, var body: String) : RuntimeException() {
 
-    constructor(body: String) : this() {
-        this.body = body
+    constructor(statusCode: Int) : this(statusCode, "") {
+        this.statusCode = statusCode
     }
 }


### PR DESCRIPTION
The purpose of this PR is to remove the default body message (`Execution halted`) from the `HaltException`.

The message itself doesn't relay any sort of useful information outside of a debug environment. When short-circuiting logic i was often finding myself writing code to remove the default message, for example:

```java
if (message == null) {
    throw new HaltException(HttpServletResponse.SC_NOT_FOUND, "");
}
```

If anyone has any objections, please post it.