### PR TITLE
[core] Log correct host/IP that Jetty is listening on. (#289)

### DIFF
--- a/src/main/java/io/javalin/core/util/JettyServerUtil.kt
+++ b/src/main/java/io/javalin/core/util/JettyServerUtil.kt
@@ -89,7 +89,7 @@ object JettyServerUtil {
             })
         }.start()
 
-        log.info("Jetty is listening on: " + server.connectors.map { (if (it.protocols.contains("ssl")) "https" else "http") + "://localhost:" + (it as ServerConnector).localPort })
+        log.info("Jetty is listening on: " + server.connectors.map { it as ServerConnector; (if (it.protocols.contains("ssl")) "https" else "http") + "://${it.host}:${it.localPort}" })
 
         return (server.connectors[0] as ServerConnector).localPort
     }


### PR DESCRIPTION
Previously log always said Jetty was listening on localhost.