### PR TITLE
[core] log "localhost" instead of null when host not set (#289)

### DIFF
--- a/src/main/java/io/javalin/core/util/JettyServerUtil.kt
+++ b/src/main/java/io/javalin/core/util/JettyServerUtil.kt
@@ -89,7 +89,7 @@ object JettyServerUtil {
             })
         }.start()
 
-        log.info("Jetty is listening on: " + server.connectors.map { it as ServerConnector; (if (it.protocols.contains("ssl")) "https" else "http") + "://${it.host}:${it.localPort}" })
+        log.info("Jetty is listening on: " + server.connectors.map { it as ServerConnector; (if (it.protocols.contains("ssl")) "https" else "http") + "://${it.host?:"localhost"}:${it.localPort}" })
 
         return (server.connectors[0] as ServerConnector).localPort
     }


### PR DESCRIPTION
I forgot to test bd13123388ab0f5c9ec3f9f8d09f64d636d3cb5b with the default (no host) config. Fixed.