### PR TITLE
Add Graceful Jetty Shutdown Feature (RE: #286)

### DIFF
--- a/src/main/java/io/javalin/core/util/JettyServerUtil.kt
+++ b/src/main/java/io/javalin/core/util/JettyServerUtil.kt
@@ -11,6 +11,7 @@ import io.javalin.websocket.WsPathMatcher
 import org.eclipse.jetty.server.*
 import org.eclipse.jetty.server.handler.HandlerList
 import org.eclipse.jetty.server.handler.HandlerWrapper
+import org.eclipse.jetty.server.handler.StatisticsHandler
 import org.eclipse.jetty.server.session.SessionHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
@@ -29,6 +30,7 @@ object JettyServerUtil {
     @JvmStatic
     fun defaultServer() = Server(QueuedThreadPool(250, 8, 60_000)).apply {
         server.addBean(LowResourceMonitor(this))
+        server.insertHandler(StatisticsHandler())
     }
 
     @JvmStatic

--- a/src/test/java/io/javalin/TestGracefulShutdown.java
+++ b/src/test/java/io/javalin/TestGracefulShutdown.java
@@ -8,8 +8,11 @@ package io.javalin;
 
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.junit.Test;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -20,8 +23,8 @@ public class TestGracefulShutdown {
     private static final int CONNECT_WAIT_TIME_IN_MSEC = 30;
 
     @Test
-    public void long_running_query_does_not_abort_during_graceful_shutdown() throws Exception {
-        Javalin app = launchedJavalinApplication();
+    public void long_running_query_completes_during_shutdown_when_jetty_is_auto_configured() throws Exception {
+        Javalin app = sharedJavalinConfiguration().start();
         waitForJavalinServletToLoad(app);
 
         Future<HttpResponse<String>> runningRequest = performLongRunningRequest(app);
@@ -30,11 +33,36 @@ public class TestGracefulShutdown {
         assertThat(runningRequest.get().getStatus(), equalTo(200));
     }
 
-    private Javalin launchedJavalinApplication() {
+    @Test
+    public void long_running_query_completes_during_shutdown_when_jetty_is_manually_configured_with_statistics_handler() throws Exception {
+        Javalin app = sharedJavalinConfiguration().server(() -> {
+            Server server = new Server();
+            server.insertHandler(new StatisticsHandler());
+            return server;
+        }).start();
+        waitForJavalinServletToLoad(app);
+
+        Future<HttpResponse<String>> runningRequest = performLongRunningRequest(app);
+        app.stop(); // request has not completed yet
+
+        assertThat(runningRequest.get().getStatus(), equalTo(200));
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void long_running_query_aborts_during_shutdown_when_jetty_is_manually_configured_without_statistics_handler() throws Exception {
+        Javalin app = sharedJavalinConfiguration().server(Server::new).start();
+        waitForJavalinServletToLoad(app);
+
+        Future<HttpResponse<String>> runningRequest = performLongRunningRequest(app);
+        app.stop(); // request has not completed yet
+
+        runningRequest.get();
+    }
+
+    private Javalin sharedJavalinConfiguration() {
         return Javalin.create().disableStartupBanner().port(0)
                 .get("/immediate-response", context -> context.status(200))
-                .get("/delayed-response", context -> Thread.sleep(LONG_WAIT_TIME_IN_MSECS))
-                .start();
+                .get("/delayed-response", context -> Thread.sleep(LONG_WAIT_TIME_IN_MSECS));
     }
 
     private void waitForJavalinServletToLoad(Javalin app) throws Exception {

--- a/src/test/java/io/javalin/TestGracefulShutdown.java
+++ b/src/test/java/io/javalin/TestGracefulShutdown.java
@@ -8,66 +8,45 @@ package io.javalin;
 
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.async.Callback;
-import com.mashape.unirest.http.exceptions.UnirestException;
-import org.junit.Before;
 import org.junit.Test;
+
+import java.util.concurrent.Future;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 public class TestGracefulShutdown {
     private static final int LONG_WAIT_TIME_IN_MSECS = 500;
     private static final int CONNECT_WAIT_TIME_IN_MSEC = 30;
 
-    private Javalin app;
-
-    @Before
-    public void configureJavalinBeforeEachTest() {
-        app = Javalin.create().disableStartupBanner().port(0);
-        app.get("/immediate-response", context -> context.status(200));
-        app.get("/delayed-response", context -> Thread.sleep(LONG_WAIT_TIME_IN_MSECS));
-        app.start();
-    }
-
     @Test
     public void long_running_query_does_not_abort_during_graceful_shutdown() throws Exception {
-        waitForServletToLoad();
-        validateLongRunningRequestCompletes();
-        waitForSocketToConnect();
-        performShutdown();
+        Javalin app = launchedJavalinApplication();
+        waitForJavalinServletToLoad(app);
+
+        Future<HttpResponse<String>> runningRequest = performLongRunningRequest(app);
+        app.stop(); // request has not completed yet
+
+        assertThat(runningRequest.get().getStatus(), equalTo(200));
     }
 
-    private void waitForServletToLoad() throws Exception {
-        String baseUri = String.format("http://localhost:%d", app.port());
-        Unirest.get(baseUri + "/immediate-response").asString();
+    private Javalin launchedJavalinApplication() {
+        return Javalin.create().disableStartupBanner().port(0)
+                .get("/immediate-response", context -> context.status(200))
+                .get("/delayed-response", context -> Thread.sleep(LONG_WAIT_TIME_IN_MSECS))
+                .start();
     }
 
-    private void validateLongRunningRequestCompletes() {
-        String baseUri = String.format("http://localhost:%d", app.port());
-        Unirest.get(baseUri + "/delayed-response").asStringAsync(new AsyncResponseHandler());
+    private void waitForJavalinServletToLoad(Javalin app) throws Exception {
+        String requestUri = String.format("http://localhost:%d/%s", app.port(), "immediate-response");
+        Unirest.get(requestUri).asString();
     }
 
-    private void waitForSocketToConnect() throws Exception {
+    private Future<HttpResponse<String>> performLongRunningRequest(Javalin app) throws Exception {
+        String requestUri = String.format("http://localhost:%d/%s", app.port(), "delayed-response");
+        Future<HttpResponse<String>> responseFuture = Unirest.get(requestUri).asStringAsync();
         Thread.sleep(CONNECT_WAIT_TIME_IN_MSEC);
-    }
 
-    private void performShutdown() {
-        app.stop();
-    }
-
-    static class AsyncResponseHandler implements Callback<String> {
-        public void completed(HttpResponse<String> response) {
-            assertThat(response.getStatus(), equalTo(200));
-        }
-
-        public void failed(UnirestException exception) {
-            fail("request failed: " + exception.getMessage());
-        }
-
-        public void cancelled() {
-            fail("request was cancelled");
-        }
+        return responseFuture;
     }
 }

--- a/src/test/java/io/javalin/TestGracefulShutdown.java
+++ b/src/test/java/io/javalin/TestGracefulShutdown.java
@@ -1,0 +1,73 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.async.Callback;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class TestGracefulShutdown {
+    private static final int LONG_WAIT_TIME_IN_MSECS = 500;
+    private static final int CONNECT_WAIT_TIME_IN_MSEC = 30;
+
+    private Javalin app;
+
+    @Before
+    public void configureJavalinBeforeEachTest() {
+        app = Javalin.create().disableStartupBanner().port(0);
+        app.get("/immediate-response", context -> context.status(200));
+        app.get("/delayed-response", context -> Thread.sleep(LONG_WAIT_TIME_IN_MSECS));
+        app.start();
+    }
+
+    @Test
+    public void long_running_query_does_not_abort_during_graceful_shutdown() throws Exception {
+        waitForServletToLoad();
+        validateLongRunningRequestCompletes();
+        waitForSocketToConnect();
+        performShutdown();
+    }
+
+    private void waitForServletToLoad() throws Exception {
+        String baseUri = String.format("http://localhost:%d", app.port());
+        Unirest.get(baseUri + "/immediate-response").asString();
+    }
+
+    private void validateLongRunningRequestCompletes() {
+        String baseUri = String.format("http://localhost:%d", app.port());
+        Unirest.get(baseUri + "/delayed-response").asStringAsync(new AsyncResponseHandler());
+    }
+
+    private void waitForSocketToConnect() throws Exception {
+        Thread.sleep(CONNECT_WAIT_TIME_IN_MSEC);
+    }
+
+    private void performShutdown() {
+        app.stop();
+    }
+
+    static class AsyncResponseHandler implements Callback<String> {
+        public void completed(HttpResponse<String> response) {
+            assertThat(response.getStatus(), equalTo(200));
+        }
+
+        public void failed(UnirestException exception) {
+            fail("request failed: " + exception.getMessage());
+        }
+
+        public void cancelled() {
+            fail("request was cancelled");
+        }
+    }
+}

--- a/src/test/java/io/javalin/TestGracefulShutdown.java
+++ b/src/test/java/io/javalin/TestGracefulShutdown.java
@@ -20,10 +20,10 @@ import static org.junit.Assert.assertThat;
 
 public class TestGracefulShutdown {
     private static final int LONG_WAIT_TIME_IN_MSECS = 500;
-    private static final int CONNECT_WAIT_TIME_IN_MSEC = 30;
+    private static final int CONNECT_WAIT_TIME_IN_MSECS = 30;
 
     @Test
-    public void long_running_query_completes_during_shutdown_when_jetty_is_auto_configured() throws Exception {
+    public void long_running_request_completes_during_shutdown_when_jetty_is_auto_configured() throws Exception {
         Javalin app = sharedJavalinConfiguration().start();
         waitForJavalinServletToLoad(app);
 
@@ -34,7 +34,7 @@ public class TestGracefulShutdown {
     }
 
     @Test
-    public void long_running_query_completes_during_shutdown_when_jetty_is_manually_configured_with_statistics_handler() throws Exception {
+    public void long_running_request_completes_during_shutdown_when_jetty_is_manually_configured_with_statistics_handler() throws Exception {
         Javalin app = sharedJavalinConfiguration().server(() -> {
             Server server = new Server();
             server.insertHandler(new StatisticsHandler());
@@ -49,7 +49,7 @@ public class TestGracefulShutdown {
     }
 
     @Test(expected = ExecutionException.class)
-    public void long_running_query_aborts_during_shutdown_when_jetty_is_manually_configured_without_statistics_handler() throws Exception {
+    public void long_running_request_aborts_during_shutdown_when_jetty_is_manually_configured_without_statistics_handler() throws Exception {
         Javalin app = sharedJavalinConfiguration().server(Server::new).start();
         waitForJavalinServletToLoad(app);
 
@@ -73,7 +73,7 @@ public class TestGracefulShutdown {
     private Future<HttpResponse<String>> performLongRunningRequest(Javalin app) throws Exception {
         String requestUri = String.format("http://localhost:%d/%s", app.port(), "delayed-response");
         Future<HttpResponse<String>> responseFuture = Unirest.get(requestUri).asStringAsync();
-        Thread.sleep(CONNECT_WAIT_TIME_IN_MSEC);
+        Thread.sleep(CONNECT_WAIT_TIME_IN_MSECS);
 
         return responseFuture;
     }


### PR DESCRIPTION
This pull request is concerned with adding support for configuring Jetty with a graceful shutdown handler by default as identified in issue #286. This PR will include a functional test to validate whether the functionality has been added, and will also include an implementation of the configuration changes required.