### PR TITLE
[core] Add single page mode

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -18,6 +18,7 @@ import io.javalin.core.util.CorsUtil;
 import io.javalin.core.util.HttpResponseExceptionMapper;
 import io.javalin.core.util.JettyServerUtil;
 import io.javalin.core.util.RouteOverviewUtil;
+import io.javalin.core.util.SinglePageHandler;
 import io.javalin.core.util.Util;
 import io.javalin.security.AccessManager;
 import io.javalin.security.Role;
@@ -61,6 +62,7 @@ public class Javalin {
     private AccessManager accessManager = SecurityUtil::noopAccessManager;
     private RequestLogger requestLogger = null;
 
+    private SinglePageHandler singlePageHandler = new SinglePageHandler();
     private PathMatcher pathMatcher = new PathMatcher();
     private WsPathMatcher wsPathMatcher = new WsPathMatcher();
     private ExceptionMapper exceptionMapper = new ExceptionMapper();
@@ -125,6 +127,7 @@ public class Javalin {
                     defaultContentType,
                     maxRequestCacheBodySize,
                     prefer405over404,
+                    singlePageHandler,
                     new JettyResourceHandler(staticFileConfig, jettyServer, ignoreTrailingSlashes)
                 );
                 port = JettyServerUtil.initialize(jettyServer, port, contextPath, javalinServlet, wsPathMatcher, log);
@@ -228,6 +231,16 @@ public class Javalin {
     public Javalin enableStaticFiles(@NotNull String path, @NotNull Location location) {
         ensureActionIsPerformedBeforeServerStart("Enabling static files");
         staticFileConfig.add(new StaticFileConfig(path, location));
+        return this;
+    }
+
+    /**
+     * Any request that would normally result in a 404 for the path and its subpaths
+     * instead results in a 200 with the file-content as response body
+     */
+    public Javalin enableSinglePageMode(@NotNull String path, @NotNull String filePath) {
+        ensureActionIsPerformedBeforeServerStart("Enabling single page subpath");
+        singlePageHandler.add(path, filePath);
         return this;
     }
 

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -239,7 +239,7 @@ public class Javalin {
      * instead results in a 200 with the file-content as response body
      */
     public Javalin enableSinglePageMode(@NotNull String path, @NotNull String filePath) {
-        ensureActionIsPerformedBeforeServerStart("Enabling single page subpath");
+        ensureActionIsPerformedBeforeServerStart("Enabling single page mode");
         singlePageHandler.add(path, filePath);
         return this;
     }

--- a/src/main/java/io/javalin/core/JavalinServlet.kt
+++ b/src/main/java/io/javalin/core/JavalinServlet.kt
@@ -28,6 +28,7 @@ class JavalinServlet(
         val defaultContentType: String,
         val maxRequestCacheBodySize: Long,
         val prefer405over404: Boolean,
+        val singlePageHandler: SinglePageHandler,
         val jettyResourceHandler: JettyResourceHandler) {
 
     fun service(servletRequest: HttpServletRequest, res: HttpServletResponse) {
@@ -52,6 +53,7 @@ class JavalinServlet(
             }
             if (type == HandlerType.HEAD || type == HandlerType.GET) { // let Jetty check for static resources
                 if (jettyResourceHandler.handle(req, res)) return@tryWithExceptionMapper
+                if (singlePageHandler.handle(ctx)) return@tryWithExceptionMapper
             }
             val availableHandlerTypes = MethodNotAllowedUtil.findAvailableHttpHandlerTypes(matcher, requestUri)
             if (prefer405over404 && availableHandlerTypes.isNotEmpty()) {

--- a/src/main/java/io/javalin/core/util/ContextUtil.kt
+++ b/src/main/java/io/javalin/core/util/ContextUtil.kt
@@ -46,4 +46,6 @@ object ContextUtil {
         null
     }
 
+    fun acceptsHtml(ctx: Context) = ctx.header(Header.ACCEPT)?.contains("text/html") == true
+
 }

--- a/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
+++ b/src/main/java/io/javalin/core/util/MethodNotAllowedUtil.kt
@@ -9,10 +9,7 @@ object MethodNotAllowedUtil {
     fun findAvailableHttpHandlerTypes(matcher: PathMatcher, requestUri: String) =
             enumValues<HandlerType>().filter { it.isHttpMethod() && matcher.findEntries(it, requestUri).isNotEmpty() }
 
-    fun getAvailableHandlerTypes(ctx: Context, availableHandlerTypes: List<HandlerType>): Map<String, String> {
-        if (ctx.header(Header.ACCEPT)?.contains("text/html") == true) {
-            return mapOf("Available methods" to availableHandlerTypes.joinToString(", "))
-        }
-        return mapOf("availableMethods" to availableHandlerTypes.joinToString(", "))
-    }
+    fun getAvailableHandlerTypes(ctx: Context, availableHandlerTypes: List<HandlerType>): Map<String, String> = mapOf(
+            (if (ContextUtil.acceptsHtml(ctx)) "Available methods" else "availableMethods") to availableHandlerTypes.joinToString(", ")
+    )
 }

--- a/src/main/java/io/javalin/core/util/SinglePageHandler.kt
+++ b/src/main/java/io/javalin/core/util/SinglePageHandler.kt
@@ -1,0 +1,31 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin.core.util
+
+import io.javalin.Context
+
+class SinglePageHandler {
+
+    private val pathPageMap = mutableMapOf<String, String>()
+
+    fun add(path: String, filePath: String) {
+        pathPageMap[path] = Util.getResource(filePath.removePrefix("/"))?.readText()
+                ?: throw IllegalArgumentException("File at '$filePath' not found. Path should be relative to resource folder.")
+    }
+
+    fun handle(ctx: Context): Boolean { // this could be more idiomatic
+        if (!ContextUtil.acceptsHtml(ctx)) return false
+        for (entry in pathPageMap) {
+            if (ctx.path().startsWith(entry.key)) {
+                ctx.html(entry.value)
+                return true
+            }
+        }
+        return false
+    }
+
+}

--- a/src/main/java/io/javalin/core/util/SwaggerRenderer.kt
+++ b/src/main/java/io/javalin/core/util/SwaggerRenderer.kt
@@ -14,16 +14,15 @@ import org.slf4j.LoggerFactory
 class SwaggerRenderer(val filePath: String) : Handler {
 
     private val log = LoggerFactory.getLogger(SwaggerRenderer::class.java)
-    private val classLoader = this.javaClass.classLoader
     private val swaggerVersion = OptionalDependency.SWAGGERUI.version
 
     override fun handle(ctx: Context) {
-        if (classLoader.getResource("META-INF/resources/webjars/swagger-ui/3.17.1/swagger-ui.css") == null) {
+        if (Util.getResource("META-INF/resources/webjars/swagger-ui/3.17.1/swagger-ui.css") == null) {
             log.warn(Util.missingDependencyMessage(OptionalDependency.SWAGGERUI))
             throw InternalServerErrorResponse(Util.missingDependencyMessage(OptionalDependency.SWAGGERUI))
         }
         if (ctx.queryParam("spec") != null)
-            ctx.result(classLoader.getResource(ctx.queryParam("spec")).readText())
+            ctx.result(Util.getResource(ctx.queryParam("spec")!!)!!.readText())
         else ctx.html("""
             <head>
                 <meta charset="UTF-8">

--- a/src/main/java/io/javalin/core/util/Util.kt
+++ b/src/main/java/io/javalin/core/util/Util.kt
@@ -13,6 +13,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
+import java.net.URL
 import java.util.*
 import java.util.zip.Adler32
 import java.util.zip.CheckedInputStream
@@ -108,10 +109,12 @@ object Util {
     }
 
     fun enableWebJarsIfAnyWebJarsIncluded(app: Javalin, log: Logger) {
-        if (this.javaClass.classLoader.getResource("META-INF/resources/webjars") != null) {
+        if (getResource("META-INF/resources/webjars") != null) {
             log.info("WebJars detected, enabling static file handling for WebJars.")
             app.enableStaticFiles("/webjars", Location.CLASSPATH)
         }
     }
+
+    fun getResource(path: String): URL? = this.javaClass.classLoader.getResource(path)
 
 }

--- a/src/test/java/io/javalin/TestMethodNotAllowed.kt
+++ b/src/test/java/io/javalin/TestMethodNotAllowed.kt
@@ -1,6 +1,5 @@
 package io.javalin
 
-import io.javalin.core.util.Header
 import io.javalin.util.TestUtil
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
@@ -11,7 +10,7 @@ class TestMethodNotAllowed {
 
     private val preferring405Javalin = Javalin.create()
             .prefer405over404()
-            .get("/test") { ctx -> ctx.result("Hello world") }
+            .post("/test") { ctx -> ctx.result("Hello world") }
             .put("/test") { ctx -> ctx.result("Hello world") }
             .delete("/test") { ctx -> ctx.result("Hello world") }
 
@@ -19,28 +18,26 @@ class TestMethodNotAllowed {
             |Method not allowed
             |
             |Available methods:
-            |GET, PUT, DELETE
+            |POST, PUT, DELETE
             |""".trimMargin()
 
     private val expectedJson = """{
     |    "title": "Method not allowed",
     |    "status": 405,
     |    "type": "https://javalin.io/documentation#MethodNotAllowedResponse",
-    |    "details": [{"availableMethods": "GET, PUT, DELETE"}]
+    |    "details": [{"availableMethods": "POST, PUT, DELETE"}]
     |}""".trimMargin()
 
     @Test
     fun `405 response for HTML works`() = TestUtil.test(preferring405Javalin) { app, http ->
-        val response = http.post("/test").header(Header.ACCEPT, "text/html").asString()
-        assertThat(response.status, `is`(HttpServletResponse.SC_METHOD_NOT_ALLOWED))
-        assertThat(response.body, `is`(expectedHtml))
+        assertThat(http.htmlGet("/test").status, `is`(HttpServletResponse.SC_METHOD_NOT_ALLOWED))
+        assertThat(http.htmlGet("/test").body, `is`(expectedHtml))
     }
 
     @Test
     fun `405 response for JSON works`() = TestUtil.test(preferring405Javalin) { app, http ->
-        val response = http.post("/test").header(Header.ACCEPT, "application/json").asString()
-        assertThat(response.status, `is`(HttpServletResponse.SC_METHOD_NOT_ALLOWED))
-        assertThat(response.body, `is`(expectedJson))
+        assertThat(http.jsonGet("/test").status, `is`(HttpServletResponse.SC_METHOD_NOT_ALLOWED))
+        assertThat(http.jsonGet("/test").body, `is`(expectedJson))
     }
 
 }

--- a/src/test/java/io/javalin/TestSinglePageMode.kt
+++ b/src/test/java/io/javalin/TestSinglePageMode.kt
@@ -15,39 +15,41 @@ import org.junit.Test
 
 class TestSinglePageMode {
 
-    private val singlePageApp = Javalin.create().enableStaticFiles("/public").enableSinglePageMode("/", "/public/html.html")
+    private val rootSinglePageApp = Javalin.create().enableStaticFiles("/public").enableSinglePageMode("/", "/public/html.html")
     private val dualSinglePageApp = Javalin.create().enableStaticFiles("/public")
             .enableSinglePageMode("/admin", "/public/protected/secret.html")
             .enableSinglePageMode("/public", "/public/html.html")
 
     @Test
-    fun `SinglePageHandler works for HTML requests`() = TestUtil.test(singlePageApp) { app, http ->
+    fun `SinglePageHandler works for HTML requests`() = TestUtil.test(rootSinglePageApp) { app, http ->
         assertThat(http.htmlGet("/not-a-path").body, containsString("HTML works"))
         assertThat(http.htmlGet("/not-a-file.html").body, containsString("HTML works"))
         assertThat(http.htmlGet("/not-a-file.html").status, `is`(200))
     }
 
     @Test
-    fun `SinglePageHandler works for just subpaths`() = TestUtil.test(dualSinglePageApp) { app, http ->
-        assertThat(http.htmlGet("/admin").body, containsString("Secret file"))
-        assertThat(http.htmlGet("/admin/not-a-path").body, containsString("Secret file"))
-        assertThat(http.htmlGet("/public").body, containsString("HTML works"))
-        assertThat(http.htmlGet("/public/not-a-file.html").body, containsString("HTML works"))
-        assertThat(http.htmlGet("/public/not-a-file.html").status, `is`(200))
-    }
-
-    @Test
-    fun `SinglePageHandler doesn't affect static files`() = TestUtil.test(singlePageApp) { app, http ->
+    fun `SinglePageHandler doesn't affect static files`() = TestUtil.test(rootSinglePageApp) { app, http ->
         assertThat(http.htmlGet("/script.js").headers.getFirst(Header.CONTENT_TYPE), containsString("application/javascript"))
         assertThat(http.htmlGet("/webjars/swagger-ui/3.17.1/swagger-ui.css").headers.getFirst(Header.CONTENT_TYPE), containsString("text/css"))
         assertThat(http.htmlGet("/webjars/swagger-ui/3.17.1/swagger-ui.css").status, `is`(200))
     }
 
     @Test
-    fun `SinglePageHandler doesn't affect JSON requests`() = TestUtil.test(singlePageApp) { app, http ->
+    fun `SinglePageHandler doesn't affect JSON requests`() = TestUtil.test(rootSinglePageApp) { app, http ->
         assertThat(http.jsonGet("/").body, containsString("Not found"))
         assertThat(http.jsonGet("/not-a-file.html").body, containsString("Not found"))
         assertThat(http.jsonGet("/not-a-file.html").status, `is`(404))
+    }
+
+    @Test
+    fun `SinglePageHandler works for just subpaths`() = TestUtil.test(dualSinglePageApp) { app, http ->
+        assertThat(http.htmlGet("/").body, containsString("Not found"))
+        assertThat(http.htmlGet("/").status, `is`(404))
+        assertThat(http.htmlGet("/admin").body, containsString("Secret file"))
+        assertThat(http.htmlGet("/admin/not-a-path").body, containsString("Secret file"))
+        assertThat(http.htmlGet("/public").body, containsString("HTML works"))
+        assertThat(http.htmlGet("/public/not-a-file.html").body, containsString("HTML works"))
+        assertThat(http.htmlGet("/public/not-a-file.html").status, `is`(200))
     }
 
 }

--- a/src/test/java/io/javalin/TestSinglePageMode.kt
+++ b/src/test/java/io/javalin/TestSinglePageMode.kt
@@ -1,0 +1,54 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin
+
+import io.javalin.core.util.Header
+import io.javalin.util.TestUtil
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class TestSinglePageMode {
+
+    private val singlePageApp = Javalin.create().enableStaticFiles("/public").enableSinglePageMode("/", "/public/html.html")
+    private val dualSinglePageApp = Javalin.create().enableStaticFiles("/public")
+            .enableSinglePageMode("/admin", "/public/protected/secret.html")
+            .enableSinglePageMode("/public", "/public/html.html")
+
+    @Test
+    fun `SinglePageHandler works for HTML requests`() = TestUtil.test(singlePageApp) { app, http ->
+        assertThat(http.htmlGet("/not-a-path").body, containsString("HTML works"))
+        assertThat(http.htmlGet("/not-a-file.html").body, containsString("HTML works"))
+        assertThat(http.htmlGet("/not-a-file.html").status, `is`(200))
+    }
+
+    @Test
+    fun `SinglePageHandler works for just subpaths`() = TestUtil.test(dualSinglePageApp) { app, http ->
+        assertThat(http.htmlGet("/admin").body, containsString("Secret file"))
+        assertThat(http.htmlGet("/admin/not-a-path").body, containsString("Secret file"))
+        assertThat(http.htmlGet("/public").body, containsString("HTML works"))
+        assertThat(http.htmlGet("/public/not-a-file.html").body, containsString("HTML works"))
+        assertThat(http.htmlGet("/public/not-a-file.html").status, `is`(200))
+    }
+
+    @Test
+    fun `SinglePageHandler doesn't affect static files`() = TestUtil.test(singlePageApp) { app, http ->
+        assertThat(http.htmlGet("/script.js").headers.getFirst(Header.CONTENT_TYPE), containsString("application/javascript"))
+        assertThat(http.htmlGet("/webjars/swagger-ui/3.17.1/swagger-ui.css").headers.getFirst(Header.CONTENT_TYPE), containsString("text/css"))
+        assertThat(http.htmlGet("/webjars/swagger-ui/3.17.1/swagger-ui.css").status, `is`(200))
+    }
+
+    @Test
+    fun `SinglePageHandler doesn't affect JSON requests`() = TestUtil.test(singlePageApp) { app, http ->
+        assertThat(http.jsonGet("/").body, containsString("Not found"))
+        assertThat(http.jsonGet("/not-a-file.html").body, containsString("Not found"))
+        assertThat(http.jsonGet("/not-a-file.html").status, `is`(404))
+    }
+
+}
+

--- a/src/test/java/io/javalin/TestStaticFiles.kt
+++ b/src/test/java/io/javalin/TestStaticFiles.kt
@@ -25,7 +25,6 @@ class TestStaticFiles {
             .enableStaticFiles("/public/protected")
             .enableStaticFiles("/public/subdir")
     private val debugLoggingApp = Javalin.create().enableStaticFiles("/public").enableDebugLogging()
-    private val singlePageApp = Javalin.create().enableStaticFiles("/public").enableSinglePageMode("/", "/public/html.html")
 
     @Test
     fun `serving HTML from classpath works`() = TestUtil.test(defaultStaticResourceApp) { app, http ->
@@ -107,16 +106,6 @@ class TestStaticFiles {
     fun `WebJars available if enabled`() = TestUtil.test { app, http ->
         assertThat(http.get("/webjars/swagger-ui/3.17.1/swagger-ui.css").status, `is`(200))
         assertThat(http.get("/webjars/swagger-ui/3.17.1/swagger-ui.css").headers.getFirst(Header.CONTENT_TYPE), containsString("text/css"))
-    }
-
-    @Test // SPLIT
-    fun `SinglePageHandler does what it should`() = TestUtil.test(singlePageApp) { app, http ->
-        assertThat(http.htmlGet("/script.js").headers.getFirst(Header.CONTENT_TYPE), containsString("application/javascript"))
-        assertThat(http.htmlGet("/webjars/swagger-ui/3.17.1/swagger-ui.css").headers.getFirst(Header.CONTENT_TYPE), containsString("text/css"))
-        assertThat(http.htmlGet("/not-a-path").body, containsString("HTML works"))
-        assertThat(http.htmlGet("/not-a-file.html").body, containsString("HTML works"))
-        assertThat(http.jsonGet("/not-a-path").body, containsString("Not found"))
-        assertThat(http.jsonGet("/not-a-file.html").body, containsString("Not found"))
     }
 
 }

--- a/src/test/java/io/javalin/TestStaticFiles.kt
+++ b/src/test/java/io/javalin/TestStaticFiles.kt
@@ -25,6 +25,7 @@ class TestStaticFiles {
             .enableStaticFiles("/public/protected")
             .enableStaticFiles("/public/subdir")
     private val debugLoggingApp = Javalin.create().enableStaticFiles("/public").enableDebugLogging()
+    private val singlePageApp = Javalin.create().enableStaticFiles("/public").enableSinglePageMode("/", "/public/html.html")
 
     @Test
     fun `serving HTML from classpath works`() = TestUtil.test(defaultStaticResourceApp) { app, http ->
@@ -106,6 +107,16 @@ class TestStaticFiles {
     fun `WebJars available if enabled`() = TestUtil.test { app, http ->
         assertThat(http.get("/webjars/swagger-ui/3.17.1/swagger-ui.css").status, `is`(200))
         assertThat(http.get("/webjars/swagger-ui/3.17.1/swagger-ui.css").headers.getFirst(Header.CONTENT_TYPE), containsString("text/css"))
+    }
+
+    @Test // SPLIT
+    fun `SinglePageHandler does what it should`() = TestUtil.test(singlePageApp) { app, http ->
+        assertThat(http.htmlGet("/script.js").headers.getFirst(Header.CONTENT_TYPE), containsString("application/javascript"))
+        assertThat(http.htmlGet("/webjars/swagger-ui/3.17.1/swagger-ui.css").headers.getFirst(Header.CONTENT_TYPE), containsString("text/css"))
+        assertThat(http.htmlGet("/not-a-path").body, containsString("HTML works"))
+        assertThat(http.htmlGet("/not-a-file.html").body, containsString("HTML works"))
+        assertThat(http.jsonGet("/not-a-path").body, containsString("Not found"))
+        assertThat(http.jsonGet("/not-a-file.html").body, containsString("Not found"))
     }
 
 }

--- a/src/test/java/io/javalin/util/HttpUtil.kt
+++ b/src/test/java/io/javalin/util/HttpUtil.kt
@@ -10,6 +10,7 @@ import com.mashape.unirest.http.HttpMethod
 import com.mashape.unirest.http.Unirest
 import com.mashape.unirest.request.HttpRequestWithBody
 import io.javalin.Javalin
+import io.javalin.core.util.Header
 import org.apache.http.impl.client.HttpClients
 
 class HttpUtil(javalin: Javalin) {
@@ -26,5 +27,7 @@ class HttpUtil(javalin: Javalin) {
     fun getBody(path: String) = Unirest.get(origin + path).asString().body
     fun post(path: String) = Unirest.post(origin + path)
     fun call(method: HttpMethod, pathname: String) = HttpRequestWithBody(method, origin + pathname).asString()
+    fun htmlGet(path: String) = Unirest.get(origin + path).header(Header.ACCEPT, "text/html").asString()
+    fun jsonGet(path: String) = Unirest.get(origin + path).header(Header.ACCEPT, "application/json").asString()
 
 }


### PR DESCRIPTION
There are two main ways of doing routing for a SPA, hash/fragment (`#`) and push-state. When the user navigates the SPA you'll end up with one of two URL patterns: 

```
myapp.com/#/users/tipsy // hash
myapp.com/users/tipsy // pushstate
```

Currently there isn't any elegant way of handling these client side routes in Javalin. A common pattern is to redirect 404's to the apps entry-point (`index.html`). Another pattern is to route all requests without extensions to the entry point (won't work if you're hosting your API on the same service.

This PR adds a `enableSinglePageMode(path, filePath)`. This would return the content of `filePath` for all calls that would normally result in a 404 on the `path` (given that the client making the call accepts HTML). It would not involve a redirect.

HTML request/response:

```
GET /users/tipsy
Accept: text/html
```
```
HTTP/1.1 200

<single page file>
```
JSON request/response:
```
GET /users/tipsy
Accept: application/json
```
```
HTTP/1.1 404

{404 error object}
```