### PR TITLE
Fix wildcards in crud

### DIFF
--- a/src/main/java/io/javalin/apibuilder/ApiBuilder.java
+++ b/src/main/java/io/javalin/apibuilder/ApiBuilder.java
@@ -372,9 +372,9 @@ public class ApiBuilder {
         path = path.startsWith("/") ? path : "/" + path;
         String resourceBase = path.split("/")[1];
         String resourceId = path.split("/")[2];
+        staticInstance().get(prefixPath(path), ctx -> crudHandler.getOne(ctx, ctx.pathParam(resourceId)), permittedRoles);
         staticInstance().get(prefixPath(resourceBase), crudHandler::getAll, permittedRoles);
         staticInstance().post(prefixPath(resourceBase), crudHandler::create, permittedRoles);
-        staticInstance().get(prefixPath(path), ctx -> crudHandler.getOne(ctx, ctx.pathParam(resourceId)), permittedRoles);
         staticInstance().patch(prefixPath(path), ctx -> crudHandler.update(ctx, ctx.pathParam(resourceId)), permittedRoles);
         staticInstance().delete(prefixPath(path), ctx -> crudHandler.delete(ctx, ctx.pathParam(resourceId)), permittedRoles);
     }

--- a/src/test/java/io/javalin/TestApiBuilder.kt
+++ b/src/test/java/io/javalin/TestApiBuilder.kt
@@ -147,6 +147,27 @@ class TestApiBuilder {
         assertThat(Unirest.delete(http.origin + "/s/users/myUser").asString().status, `is`(204))
     }
 
+    @Test
+    fun `CrudHandler works with wildcards`() = TestUtil.test { app, http ->
+        app.routes {
+            path("/s") {
+                crud("/*/:user-id", UserController())
+            }
+            crud("*/:user-id", UserController())
+        }
+        assertThat(Unirest.get(http.origin + "/users").asString().body, `is`("All my users"))
+        assertThat(Unirest.post(http.origin + "/users").asString().status, `is`(201))
+        assertThat(Unirest.get(http.origin + "/users/myUser").asString().body, `is`("My single user: myUser"))
+        assertThat(Unirest.patch(http.origin + "/users/myUser").asString().status, `is`(204))
+        assertThat(Unirest.delete(http.origin + "/users/myUser").asString().status, `is`(204))
+
+        assertThat(Unirest.get(http.origin + "/s/users").asString().body, `is`("All my users"))
+        assertThat(Unirest.post(http.origin + "/s/users").asString().status, `is`(201))
+        assertThat(Unirest.get(http.origin + "/s/users/myUser").asString().body, `is`("My single user: myUser"))
+        assertThat(Unirest.patch(http.origin + "/s/users/myUser").asString().status, `is`(204))
+        assertThat(Unirest.delete(http.origin + "/s/users/myUser").asString().status, `is`(204))
+    }
+
     class UserController : CrudHandler {
 
         override fun getAll(ctx: Context) {


### PR DESCRIPTION
Fixes #337

This allows using wildcards in `ApiBuilder::crud` paths without
`CrudHandler::getAll` being called for singular `get` calls.