### PR TITLE
Context attributes now return nullable types

### DIFF
--- a/src/main/java/io/javalin/Context.kt
+++ b/src/main/java/io/javalin/Context.kt
@@ -207,13 +207,12 @@ class Context(private val servletRequest: HttpServletRequest, private val servle
      * Gets the specified attribute from the request.
      */
     @Suppress("UNCHECKED_CAST")
-    fun <T> attribute(attribute: String): T = servletRequest.getAttribute(attribute) as T
+    fun <T> attribute(attribute: String): T? = servletRequest.getAttribute(attribute) as? T
 
     /**
      * Gets a map with all the attribute keys and values on the request.
      */
-    @Suppress("UNCHECKED_CAST")
-    fun <T> attributeMap(): Map<String, T> = servletRequest.attributeNames.asSequence().associate { it to attribute<T>(it) }
+    fun <T> attributeMap(): Map<String, T?> = servletRequest.attributeNames.asSequence().associate { it to attribute<T>(it) }
 
     /**
      * Gets the request content length.
@@ -346,13 +345,12 @@ class Context(private val servletRequest: HttpServletRequest, private val servle
      * Gets a specific session attribute from the request.
      */
     @Suppress("UNCHECKED_CAST")
-    fun <T> sessionAttribute(attribute: String): T = servletRequest.session.getAttribute(attribute) as T
+    fun <T> sessionAttribute(attribute: String): T? = servletRequest.session.getAttribute(attribute) as? T
 
     /**
      * Gets a map of all the session attributes on the request.
      */
-    @Suppress("UNCHECKED_CAST")
-    fun <T> sessionAttributeMap(): Map<String, T> = servletRequest.session.attributeNames.asSequence().associate { it to servletRequest.session.getAttribute(it) as T }
+    fun <T> sessionAttributeMap(): Map<String, T?> = servletRequest.session.attributeNames.asSequence().associate { it to sessionAttribute<T>(it) }
 
     /**
      * Gets the request url.

--- a/src/main/java/io/javalin/core/util/LogUtil.kt
+++ b/src/main/java/io/javalin/core/util/LogUtil.kt
@@ -53,6 +53,6 @@ object LogUtil {
 
     fun startTimer(ctx: Context) = ctx.attribute("javalin-request-log-start-time", System.nanoTime())
 
-    fun executionTimeMs(ctx: Context) = (System.nanoTime() - ctx.attribute("javalin-request-log-start-time") as Long) / 1000000f
+    fun executionTimeMs(ctx: Context) = (System.nanoTime() - ctx.attribute<Long>("javalin-request-log-start-time")!!) / 1000000f
 }
 

--- a/src/test/java/io/javalin/TestRequest.kt
+++ b/src/test/java/io/javalin/TestRequest.kt
@@ -36,7 +36,7 @@ class TestRequest {
     @Test
     fun `session-attribute shorthand work`() = TestUtil.test { app, http ->
         app.get("/store-session") { ctx -> ctx.sessionAttribute("test", "tast") }
-        app.get("/read-session") { ctx -> ctx.result(ctx.sessionAttribute<String>("test")) }
+        app.get("/read-session") { ctx -> ctx.result(ctx.sessionAttribute<String>("test")!!) }
         http.getBody("/store-session")
         assertThat(http.getBody("/read-session"), `is`("tast"))
     }


### PR DESCRIPTION
Fixes #343

Session and request attributes now expressively return nullable types to
indicate that an attribute might not have been set.