### PR TITLE
Update to solve issue #352 (Support for passing CompletableFuture to Context.json())

### DIFF
--- a/src/main/java/io/javalin/Context.kt
+++ b/src/main/java/io/javalin/Context.kt
@@ -508,6 +508,17 @@ open class Context(private val servletRequest: HttpServletRequest, private val s
     }
 
     /**
+     * Serializes the object resulting from the completion of the given future
+     * to a JSON-string using JavalinJson and sets it as the context result.
+     * JavalinJson can be configured to use any mapping library.
+     * Sets content type to application/json.
+     */
+    fun json(future: CompletableFuture<*>): Context {
+        return contentType("application/json")
+                .result(future.thenApply { obj -> JavalinJson.toJsonMapper.map(obj) })
+    }
+
+    /**
      * Renders a file with specified values and sets it as the context result.
      * Also sets content-type to text/html.
      * Determines the correct rendering-function based on the file extension.

--- a/src/test/java/io/javalin/TestFuture.kt
+++ b/src/test/java/io/javalin/TestFuture.kt
@@ -18,6 +18,12 @@ class TestFuture {
     }
 
     @Test
+    fun `hello future world json`() = TestUtil.test { app, http ->
+        app.get("/test-future-json") { ctx -> ctx.json(getFuture("JSON result")) }
+        assertThat(http.getBody("/test-future-json"), `is`("\"JSON result\""))
+    }
+
+    @Test
     fun `after-handlers run after future is resolved`() = TestUtil.test { app, http ->
         app.get("/test-future") { ctx -> ctx.result(getFuture("Not result")) }
         app.after { ctx -> ctx.result("Overwritten by after-handler") }

--- a/src/test/kotlin/io/javalin/examples/HelloWorldAsync.kt
+++ b/src/test/kotlin/io/javalin/examples/HelloWorldAsync.kt
@@ -7,16 +7,27 @@
 package io.javalin.examples
 
 import io.javalin.Javalin
+import io.javalin.apibuilder.ApiBuilder.get
+import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 fun main(args: Array<String>) {
-    Javalin.create().apply {
-        get("/") { ctx ->
+    val app = Javalin.create().enableDebugLogging().start(7070)
+
+    app.routes {
+        get("/result") { ctx ->
             val future = CompletableFuture<String>()
-            Executors.newSingleThreadScheduledExecutor().schedule({ future.complete("Hello World!") }, 10, TimeUnit.MILLISECONDS)
+            Executors.newSingleThreadScheduledExecutor()
+                    .schedule({ future.complete("Hello World!") }, 10, TimeUnit.MILLISECONDS)
             ctx.result(future)
         }
-    }.start(7070)
+        get("/json") { ctx ->
+            val future = CompletableFuture<List<String>>()
+            Executors.newSingleThreadScheduledExecutor()
+                    .schedule({ future.complete(Arrays.asList("a", "b", "c")) }, 10, TimeUnit.MILLISECONDS)
+            ctx.json(future)
+        }
+    }
 }


### PR DESCRIPTION
The updates include:
- Adding function Context.json(CompletableFuture<*>)
- Updating HelloWorldAsync.kt to have one example using Context.result() and one for Context.json()
- Updating TestFuture.kt to include one case for testing the happy case of Context.json(); failure cases are already covered for Context.result() which is called by Context.json()