### PR TITLE
Make immutable path matching exact

### DIFF
--- a/src/main/java/io/javalin/staticfiles/JettyResourceHandler.kt
+++ b/src/main/java/io/javalin/staticfiles/JettyResourceHandler.kt
@@ -63,7 +63,7 @@ class JettyResourceHandler(staticFileConfig: Set<StaticFileConfig>, jettyServer:
                 val resourceHandler = (gzipHandler.handler as ResourceHandler)
                 val resource = resourceHandler.getResource(target)
                 if (resource.isFile() || resource.isDirectoryWithWelcomeFile(resourceHandler, target)) {
-                    val maxAge = if (target.startsWith("/immutable") || resourceHandler is WebjarHandler) 31622400 else 0
+                    val maxAge = if (target.startsWith("/immutable/") || resourceHandler is WebjarHandler) 31622400 else 0
                     httpResponse.setHeader(Header.CACHE_CONTROL, "max-age=$maxAge")
                     gzipHandler.handle(target, baseRequest, httpRequest, httpResponse)
                     httpRequest.setAttribute("handled-as-static-file", true)


### PR DESCRIPTION
Previously Javalin would mark any file with path starting with "/immutable" as immutable; this patch requires files to be in a directory named exactly "immutable" as the docs specify.

Fixes #369.