### PR TITLE
Check for kotlin class when using Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-kotlin</artifactId>
+          <version>2.9.4.1</version>
+          <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
             <version>2.0</version>

--- a/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -8,6 +8,7 @@ package io.javalin.core.util
 
 enum class OptionalDependency(val displayName: String, val testClass: String, val groupId: String, val artifactId: String, val version: String) {
     JACKSON("Jackson", "com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6"),
+    JACKSON_KT("JacksonKt", "com.fasterxml.jackson.module.kotlin.KotlinModule", "com.fasterxml.jackson.module", "jackson-module-kotlin", "2.9.4.1"),
     VELOCITY("Velocity", "org.apache.velocity.app.VelocityEngine", "org.apache.velocity", "velocity-engine-core", "2.0"),
     FREEMARKER("Freemarker", "freemarker.template.Configuration", "org.freemarker", "freemarker", "2.3.28"),
     THYMELEAF("Thymeleaf", "org.thymeleaf.TemplateEngine", "org.thymeleaf", "thymeleaf", "3.0.9.RELEASE"),

--- a/src/main/java/io/javalin/core/util/Util.kt
+++ b/src/main/java/io/javalin/core/util/Util.kt
@@ -109,4 +109,15 @@ object Util {
 
     fun getResource(path: String): URL? = this.javaClass.classLoader.getResource(path)
 
+    fun isKotlinClass(clazz: Class<*>): Boolean {
+      try {
+        for (annotation in clazz.declaredAnnotations) {
+          // Note: annotation.simpleClass can be used if kotlin-reflect is available.
+          if (annotation.annotationClass.toString().contains("kotlin.Metadata")) {
+            return true
+          }
+        }
+      } catch (ignored: Exception) {}
+      return false
+    }
 }

--- a/src/main/java/io/javalin/json/JavalinJackson.kt
+++ b/src/main/java/io/javalin/json/JavalinJackson.kt
@@ -33,11 +33,14 @@ object JavalinJackson {
 
     fun <T> fromJson(json: String, clazz: Class<T>): T {
         Util.ensureDependencyPresent(OptionalDependency.JACKSON)
+        if (Util.isKotlinClass(clazz)) {
+            Util.ensureDependencyPresent(OptionalDependency.JACKSON_KT)
+        }
         return getObjectMapper().readValue(json, clazz)
     }
 
     private fun createObjectMapper(): ObjectMapper = try {
-        val className = "com.fasterxml.jackson.module.kotlin.KotlinModule"
+        val className = OptionalDependency.JACKSON_KT.testClass
         ObjectMapper().registerModule(Class.forName(className).getConstructor().newInstance() as Module)
     } catch (e: ClassNotFoundException) {
         ObjectMapper()


### PR DESCRIPTION
I took a stab at checking for "kotlin.Metadata" and adding an extra dependency check for `jackson-module-kotlin`.

It seemed to work for this test case. When the `jackson-module-kotlin` dependency is missing an error message is printed to the JVM console (not returned to the client though). When the dependency exists, the application runs correctly.
```kotlin
data class User(val id: Int, val name: String, val sign: String)

fun main(args: Array<String>) {
    val data = mutableMapOf(
        1 to User(1, "will", "Aries"),
        2 to User(2, "corey", "Virgo")
    )

    // Create a server and start it.
    val app = Javalin.create().start(7000)

    // Endpoint handlers
    app.get("/") { ctx -> ctx.result("Hello World") }

    app.get("/user/:id") { ctx ->
      val id = ctx.pathParam("id").toInt()
      data[id]?.let {
        ctx.json(it)
      } ?: ctx.json("not found")
    }

    app.put("/user/create") { ctx ->
      val user = ctx.validatedBody<User>()
          .check({ !data.containsKey(it.id) }, errorMessage = "This user id already exists.")
          .getOrThrow()
      data[user.id] = user
      ctx.status(201).result("User created successfully: $user")
    }
}
```