### PR TITLE
Ignore accessManager on empty Roles

### DIFF
--- a/src/main/java/io/javalin/Context.kt
+++ b/src/main/java/io/javalin/Context.kt
@@ -41,6 +41,7 @@ open class Context(private val servletRequest: HttpServletRequest, private val s
     // @formatter:on
 
     private val cookieStore by lazy { CookieStore(cookie(CookieStore.COOKIE_NAME)) }
+    private var queryMap = mapOf<String, List<String>>()
     private var resultStream: InputStream? = null
     private var resultFuture: CompletableFuture<*>? = null
 
@@ -253,7 +254,12 @@ open class Context(private val servletRequest: HttpServletRequest, private val s
     fun queryParams(queryParam: String): List<String> = queryParamMap()[queryParam] ?: emptyList()
 
     /** Gets a map with all the query param keys and values. */
-    fun queryParamMap(): Map<String, List<String>> = ContextUtil.splitKeyValueStringAndGroupByKey(queryString() ?: "")
+    fun queryParamMap(): Map<String, List<String>> {
+        if(queryMap.isEmpty()){
+            queryMap = ContextUtil.splitKeyValueStringAndGroupByKey(queryString() ?: "")
+        }
+        return queryMap
+    }
 
     /**
      * Maps query params to values, or returns null if any of the params are null.

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -33,6 +33,7 @@ import io.javalin.websocket.WsHandler;
 import io.javalin.websocket.WsPathMatcher;
 import java.net.BindException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -371,7 +372,7 @@ public class Javalin {
      * The method must be called before {@link Javalin#start()}.
      */
     public Javalin enableRouteOverview(@NotNull String path) {
-        return enableRouteOverview(path, new HashSet<>());
+        return enableRouteOverview(path, Collections.emptySet());
     }
 
     /**
@@ -482,14 +483,14 @@ public class Javalin {
 
     private Javalin addHandler(@NotNull HandlerType handlerType, @NotNull String path, @NotNull Handler handler, @NotNull Set<Role> roles) {
         String prefixedPath = Util.prefixContextPath(contextPath, path);
-        Handler protectedHandler = handlerType.isHttpMethod() ? ctx -> accessManager.manage(handler, ctx, roles) : handler;
+        Handler protectedHandler = handlerType.isHttpMethod() && !roles.isEmpty() ? ctx -> accessManager.manage(handler, ctx, roles) : handler;
         pathMatcher.add(new HandlerEntry(handlerType, prefixedPath, protectedHandler, handler, caseSensitiveUrls));
         handlerMetaInfo.add(new HandlerMetaInfo(handlerType, prefixedPath, handler, roles));
         return this;
     }
 
     private Javalin addHandler(@NotNull HandlerType httpMethod, @NotNull String path, @NotNull Handler handler) {
-        return addHandler(httpMethod, path, handler, new HashSet<>()); // no roles set for this route (open to everyone)
+        return addHandler(httpMethod, path, handler, Collections.emptySet()); // no roles set for this route (open to everyone)
     }
 
     // HTTP verbs
@@ -733,7 +734,7 @@ public class Javalin {
         WsHandler configuredWebSocket = new WsHandler();
         ws.accept(configuredWebSocket);
         wsPathMatcher.add(new WsEntry(prefixedPath, configuredWebSocket, caseSensitiveUrls));
-        handlerMetaInfo.add(new HandlerMetaInfo(HandlerType.WEBSOCKET, prefixedPath, ws, new HashSet<>()));
+        handlerMetaInfo.add(new HandlerMetaInfo(HandlerType.WEBSOCKET, prefixedPath, ws, Collections.emptySet()));
         return this;
     }
 


### PR DESCRIPTION
This PR address two very minor issues but the OCD in me couldn't ignore. 
1) When you add a custom AccessManager then every endpoint goes through this manager if it has a Role associated to it or not.  It took my a while to figure out my AccessManager always needed a `permittedRoles.isEmpty()` check for this case.  Instead I just bypassed the manager if no roles are provided so the end user doesn't have to bother.   I also changed all the empty set creations to use the static empty set.

2) Lazily cache query param map.  I know we agreed it wasn't a huge performance hit.  But I have some endpoints that have a ton of optional filter query params.  It was eating away at me that an endpoint which could finish in 500ms was instead taking 900ms because of parameter parsing.  