### PR TITLE
Add missing nullability annotations to the Java interfaces

### DIFF
--- a/src/main/java/io/javalin/ErrorHandler.java
+++ b/src/main/java/io/javalin/ErrorHandler.java
@@ -6,6 +6,8 @@
 
 package io.javalin;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * A handler for use with {@link Javalin#error(int, ErrorHandler)}.
  * Is triggered by [{@link Context#status()}] codes at the end of the request lifecycle.
@@ -15,5 +17,5 @@ package io.javalin;
  */
 @FunctionalInterface
 public interface ErrorHandler {
-    void handle(Context ctx);
+    void handle(@NotNull Context ctx);
 }

--- a/src/main/java/io/javalin/ExceptionHandler.java
+++ b/src/main/java/io/javalin/ExceptionHandler.java
@@ -6,6 +6,8 @@
 
 package io.javalin;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * A handler for use with {@link Javalin#exception(Class, ExceptionHandler)}.
  * Is triggered when exceptions are thrown by a {@link Handler}.
@@ -15,5 +17,5 @@ package io.javalin;
  */
 @FunctionalInterface
 public interface ExceptionHandler<T extends Exception> {
-    void handle(T exception, Context ctx);
+    void handle(@NotNull T exception, @NotNull Context ctx);
 }

--- a/src/main/java/io/javalin/Handler.java
+++ b/src/main/java/io/javalin/Handler.java
@@ -6,6 +6,8 @@
 
 package io.javalin;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Main interface for endpoint actions. A handler has a void return type,
  * so you have to use {@link Context#result} to return data to the client.
@@ -15,5 +17,5 @@ package io.javalin;
  */
 @FunctionalInterface
 public interface Handler {
-    void handle(Context ctx) throws Exception;
+    void handle(@NotNull Context ctx) throws Exception;
 }

--- a/src/main/java/io/javalin/RequestLogger.java
+++ b/src/main/java/io/javalin/RequestLogger.java
@@ -6,6 +6,8 @@
 
 package io.javalin;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Interface for logging requests.
  *
@@ -14,5 +16,5 @@ package io.javalin;
  */
 @FunctionalInterface
 public interface RequestLogger {
-    void handle(Context ctx, Float executionTimeMs) throws Exception;
+    void handle(@NotNull Context ctx, @NotNull Float executionTimeMs) throws Exception;
 }

--- a/src/main/java/io/javalin/rendering/FileRenderer.java
+++ b/src/main/java/io/javalin/rendering/FileRenderer.java
@@ -7,6 +7,8 @@
 package io.javalin.rendering;
 
 import io.javalin.Context;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Map;
 
 /**
@@ -14,5 +16,5 @@ import java.util.Map;
  */
 @FunctionalInterface
 public interface FileRenderer {
-    String render(String filePath, Map<String, Object> model);
+    String render(@NotNull String filePath, @NotNull Map<String, Object> model);
 }

--- a/src/main/java/io/javalin/security/AccessManager.java
+++ b/src/main/java/io/javalin/security/AccessManager.java
@@ -9,6 +9,8 @@ package io.javalin.security;
 import io.javalin.Context;
 import io.javalin.Handler;
 import io.javalin.core.HandlerType;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Set;
 
 /**
@@ -22,5 +24,5 @@ import java.util.Set;
  */
 @FunctionalInterface
 public interface AccessManager {
-    void manage(Handler handler, Context ctx, Set<Role> permittedRoles) throws Exception;
+    void manage(@NotNull Handler handler, @NotNull Context ctx, @NotNull Set<Role> permittedRoles) throws Exception;
 }

--- a/src/main/java/io/javalin/websocket/BinaryMessageHandler.java
+++ b/src/main/java/io/javalin/websocket/BinaryMessageHandler.java
@@ -6,7 +6,9 @@
 
 package io.javalin.websocket;
 
+import org.jetbrains.annotations.NotNull;
+
 @FunctionalInterface
 public interface BinaryMessageHandler {
-    void handle(WsSession session, Byte[] msg, int offset, int length);
+    void handle(@NotNull WsSession session, @NotNull Byte[] msg, int offset, int length);
 }

--- a/src/main/java/io/javalin/websocket/CloseHandler.java
+++ b/src/main/java/io/javalin/websocket/CloseHandler.java
@@ -7,8 +7,9 @@
 package io.javalin.websocket;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @FunctionalInterface
 public interface CloseHandler {
-    void handle(@NotNull WsSession session, int statusCode, @NotNull String reason) throws Exception;
+    void handle(@NotNull WsSession session, int statusCode, @Nullable String reason) throws Exception;
 }

--- a/src/main/java/io/javalin/websocket/CloseHandler.java
+++ b/src/main/java/io/javalin/websocket/CloseHandler.java
@@ -6,7 +6,9 @@
 
 package io.javalin.websocket;
 
+import org.jetbrains.annotations.NotNull;
+
 @FunctionalInterface
 public interface CloseHandler {
-    void handle(WsSession session, int statusCode, String reason) throws Exception;
+    void handle(@NotNull WsSession session, int statusCode, @NotNull String reason) throws Exception;
 }

--- a/src/main/java/io/javalin/websocket/ConnectHandler.java
+++ b/src/main/java/io/javalin/websocket/ConnectHandler.java
@@ -6,7 +6,9 @@
 
 package io.javalin.websocket;
 
+import org.jetbrains.annotations.NotNull;
+
 @FunctionalInterface
 public interface ConnectHandler {
-    void handle(WsSession session) throws Exception;
+    void handle(@NotNull WsSession session) throws Exception;
 }

--- a/src/main/java/io/javalin/websocket/ErrorHandler.java
+++ b/src/main/java/io/javalin/websocket/ErrorHandler.java
@@ -7,8 +7,9 @@
 package io.javalin.websocket;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @FunctionalInterface
 public interface ErrorHandler {
-    void handle(@NotNull WsSession session, @NotNull Throwable throwable) throws Exception;
+    void handle(@NotNull WsSession session, @Nullable Throwable throwable) throws Exception;
 }

--- a/src/main/java/io/javalin/websocket/ErrorHandler.java
+++ b/src/main/java/io/javalin/websocket/ErrorHandler.java
@@ -6,7 +6,9 @@
 
 package io.javalin.websocket;
 
+import org.jetbrains.annotations.NotNull;
+
 @FunctionalInterface
 public interface ErrorHandler {
-    void handle(WsSession session, Throwable throwable) throws Exception;
+    void handle(@NotNull WsSession session, @NotNull Throwable throwable) throws Exception;
 }

--- a/src/main/java/io/javalin/websocket/MessageHandler.java
+++ b/src/main/java/io/javalin/websocket/MessageHandler.java
@@ -6,7 +6,9 @@
 
 package io.javalin.websocket;
 
+import org.jetbrains.annotations.NotNull;
+
 @FunctionalInterface
 public interface MessageHandler {
-    void handle(WsSession session, String msg) throws Exception;
+    void handle(@NotNull WsSession session, @NotNull String msg) throws Exception;
 }

--- a/src/test/java/io/javalin/routeoverview/TestRouteOverview_Kotlin.kt
+++ b/src/test/java/io/javalin/routeoverview/TestRouteOverview_Kotlin.kt
@@ -62,6 +62,6 @@ class ClassHandlers {
 }
 
 class HandlerImplementation : Handler {
-    override fun handle(ctx: Context?) {
+    override fun handle(ctx: Context) {
     }
 }


### PR DESCRIPTION
I annotated everything with `@NotNull` that did not have an annotation yet in the java interfaces.
Two spots actually expect a nullable type for one parameter each. I annotated them with `@Nullable` from the `org.jetbrains.annotations` package.

One "Test" did not compile because he actually expected a nullable context. I changed that single location to expect a non-null context.