### PR TITLE
ExceptionMapper is now affected by defaultContentType. Fixes #405

### DIFF
--- a/src/main/java/io/javalin/core/util/HttpResponseExceptionMapper.kt
+++ b/src/main/java/io/javalin/core/util/HttpResponseExceptionMapper.kt
@@ -16,7 +16,7 @@ object HttpResponseExceptionMapper {
 
     fun handleException(exception: Exception, ctx: Context) {
         val e = unwrap(exception)
-        if (ctx.header(Header.ACCEPT)?.contains("application/json") == true) {
+        if (ctx.header(Header.ACCEPT)?.contains("application/json") == true || ctx.res.contentType == "application/json") {
             ctx.status(e.status).result("""{
                 |    "title": "${e.message}",
                 |    "status": ${e.status},

--- a/src/test/java/io/javalin/TestHttpResponseExceptions.kt
+++ b/src/test/java/io/javalin/TestHttpResponseExceptions.kt
@@ -156,4 +156,18 @@ class TestHttpResponseExceptions {
         "Result"
     }
 
+    @Test
+    fun `default content type affects http response errors`() = TestUtil.test(Javalin.create().defaultContentType("application/json")) { app, http ->
+        app.get("/content-type") { throw ForbiddenResponse() }
+        val response = http.get("/content-type")
+        assertThat(response.status, `is`(HttpStatus.FORBIDDEN_403))
+        assertThat(response.headers.getFirst(Header.CONTENT_TYPE), `is`("application/json"))
+        assertThat(response.body, `is`("""{
+                |    "title": "Forbidden",
+                |    "status": 403,
+                |    "type": "https://javalin.io/documentation#forbiddenresponse",
+                |    "details": []
+                |}""".trimMargin()
+        ))
+    }
 }


### PR DESCRIPTION
I added the suggested solution from #405 with a small test.