### PR TITLE
Validate session handler on start (#391)

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -233,7 +233,7 @@ public class Javalin {
      */
     public Javalin sessionHandler(@NotNull Supplier<SessionHandler> sessionHandler) {
         ensureActionIsPerformedBeforeServerStart("Setting a custom session handler");
-        jettySessionHandler = sessionHandler.get();
+        jettySessionHandler = Util.INSTANCE.getValidSessionHandlerOrThrow(sessionHandler);
         return this;
     }
 

--- a/src/main/java/io/javalin/core/util/Util.kt
+++ b/src/main/java/io/javalin/core/util/Util.kt
@@ -7,11 +7,13 @@
 package io.javalin.core.util
 
 import io.javalin.InternalServerErrorResponse
+import org.eclipse.jetty.server.session.SessionHandler
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.URL
 import java.util.*
+import java.util.function.Supplier
 import java.util.zip.Adler32
 import java.util.zip.CheckedInputStream
 
@@ -121,4 +123,16 @@ object Util {
         }
         return false
     }
+
+    fun getValidSessionHandlerOrThrow(sessionHandlerSupplier: Supplier<SessionHandler>): SessionHandler {
+        val uuid = UUID.randomUUID().toString()
+        val sessionHandler = sessionHandlerSupplier.get()
+        try {
+            sessionHandler.isIdInUse(uuid)
+            return sessionHandler
+        } catch (e: Exception) {
+            throw IllegalStateException("Could not look up dummy session ID in store. Misconfigured session handler", e)
+        }
+    }
+
 }


### PR DESCRIPTION
Chose `IllegalStateException` as this was also used other places for similar (boot time check) things.

Merely looking up a random UUID should be "non-intrusive" enough so that it's acceptable that the application does this on boot.