### PR TITLE
Small startup usability improvement

### DIFF
--- a/src/main/java/io/javalin/core/util/JettyServerUtil.kt
+++ b/src/main/java/io/javalin/core/util/JettyServerUtil.kt
@@ -96,7 +96,7 @@ object JettyServerUtil {
             })
         }.start()
 
-        log.info("Jetty is listening on: " + server.connectors.map { it as ServerConnector; (if (it.protocols.contains("ssl")) "https" else "http") + "://${it.host ?: "localhost"}:${it.localPort}" })
+        log.info("Jetty is listening on: " + server.connectors.map { it as ServerConnector; (if (it.protocols.contains("ssl")) "https" else "http") + "://${it.host ?: "localhost"}:${it.localPort}${contextPath}" })
 
         return (server.connectors[0] as ServerConnector).localPort
     }


### PR DESCRIPTION
For user klicking in their IDE on the link which is displayed on startup ("Jetty is listening on...") now honors default context path