### PR TITLE
WsSession#queryString() improvements (fixes #419)

### DIFF
--- a/src/main/java/io/javalin/websocket/WsSession.kt
+++ b/src/main/java/io/javalin/websocket/WsSession.kt
@@ -23,7 +23,7 @@ class WsSession(val id: String, session: Session, private var pathParamMap: Map<
 
     fun send(message: String) = webSocketSession.remote.sendString(message)
     fun send(message: ByteBuffer) = webSocketSession.remote.sendBytes(message)
-    fun queryString() = webSocketSession.upgradeRequest!!.queryString
+    fun queryString(): String? = webSocketSession.upgradeRequest!!.queryString
     @JvmOverloads
     fun queryParam(queryParam: String, default: String? = null): String? = queryParams(queryParam).firstOrNull() ?: default
 

--- a/src/main/java/io/javalin/websocket/WsSession.kt
+++ b/src/main/java/io/javalin/websocket/WsSession.kt
@@ -23,7 +23,7 @@ class WsSession(val id: String, session: Session, private var pathParamMap: Map<
 
     fun send(message: String) = webSocketSession.remote.sendString(message)
     fun send(message: ByteBuffer) = webSocketSession.remote.sendBytes(message)
-    fun queryString() = webSocketSession.upgradeRequest!!.queryString
+    fun queryString() = webSocketSession.upgradeRequest!!.queryString ?: ""
     @JvmOverloads
     fun queryParam(queryParam: String, default: String? = null): String? = queryParams(queryParam).firstOrNull() ?: default
 

--- a/src/main/java/io/javalin/websocket/WsSession.kt
+++ b/src/main/java/io/javalin/websocket/WsSession.kt
@@ -23,12 +23,12 @@ class WsSession(val id: String, session: Session, private var pathParamMap: Map<
 
     fun send(message: String) = webSocketSession.remote.sendString(message)
     fun send(message: ByteBuffer) = webSocketSession.remote.sendBytes(message)
-    fun queryString() = webSocketSession.upgradeRequest!!.queryString ?: ""
+    fun queryString() = webSocketSession.upgradeRequest!!.queryString
     @JvmOverloads
     fun queryParam(queryParam: String, default: String? = null): String? = queryParams(queryParam).firstOrNull() ?: default
 
     fun queryParams(queryParam: String): List<String> = queryParamMap()[queryParam] ?: emptyList()
-    fun queryParamMap(): Map<String, List<String>> = ContextUtil.splitKeyValueStringAndGroupByKey(queryString())
+    fun queryParamMap(): Map<String, List<String>> = ContextUtil.splitKeyValueStringAndGroupByKey(queryString() ?: "")
     fun mapQueryParams(vararg keys: String): List<String>? = ContextUtil.mapKeysOrReturnNullIfAnyNulls(keys) { queryParam(it) }
     fun anyQueryParamNull(vararg keys: String): Boolean = keys.any { queryParam(it) == null }
     fun pathParam(pathParam: String): String = ContextUtil.pathParamOrThrow(pathParamMap, pathParam, matchedPath)

--- a/src/test/java/io/javalin/TestWebSocket.kt
+++ b/src/test/java/io/javalin/TestWebSocket.kt
@@ -245,6 +245,22 @@ class TestWebSocket {
         assertThat(log.size, `is`(0))
     }
 
+    @Test
+    fun `queryParamMap does not throw`() = TestUtil.test { app, _ ->
+        app.ws("/*") {ws ->
+            ws.onConnect { session ->
+                try {
+                    session.queryParamMap()
+                } catch (e: Exception) {
+                    log.add("exception queryParamMap")
+                }
+            }
+        }
+
+        connectAndDisconnect(TestClient(URI.create("ws://localhost:" + app.port() + "/path/0")))
+        assertThat(log.size, `is`(0))
+    }
+
     internal inner class TestClient : WebSocketClient {
         constructor(serverUri: URI) : super(serverUri)
         constructor(serverUri: URI, headers: Map<String, String>) : super(serverUri, Draft_6455(), headers, 0)


### PR DESCRIPTION
Nullability is now explicit and queryParam and queryParamMap now don't crash with a NPE.