### PR TITLE
Fixed small bug with uncaught exception and default content type

### DIFF
--- a/src/main/java/io/javalin/core/ExceptionMapper.kt
+++ b/src/main/java/io/javalin/core/ExceptionMapper.kt
@@ -8,6 +8,7 @@ package io.javalin.core
 
 import io.javalin.Context
 import io.javalin.ExceptionHandler
+import io.javalin.InternalServerErrorResponse
 import io.javalin.core.util.HttpResponseExceptionMapper
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -29,8 +30,7 @@ class ExceptionMapper {
             exceptionHandler.handle(exception, ctx)
         } else {
             log.warn("Uncaught exception", exception)
-            ctx.result("Internal server error")
-            ctx.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+            HttpResponseExceptionMapper.handleException(InternalServerErrorResponse(), ctx)
         }
         ctx.inExceptionHandler = false
     }

--- a/src/test/java/io/javalin/TestJson.kt
+++ b/src/test/java/io/javalin/TestJson.kt
@@ -44,7 +44,7 @@ class TestJson {
     fun `json-mapper throws when mapping unmappable object to json`() = TestUtil.test { app, http ->
         app.get("/hello") { ctx -> ctx.json(NonSerializableObject()) }
         assertThat(http.get("/hello").status, `is`(500))
-        assertThat(http.getBody("/hello"), `is`("Internal server error"))
+        assertThat(http.getBody("/hello"), `is`("{\n    \"title\": \"Internal server error\",\n    \"status\": 500,\n    \"type\": \"https://javalin.io/documentation#internalservererrorresponse\",\n    \"details\": []\n}"))
     }
 
     @Test


### PR DESCRIPTION
Test also fixed. Now handling an uncaught exception with the HttpResponseExceptionMapper (InternalServerErrorResponse). Correctly handling defaultContentType.