### PR TITLE
[core] Add ability to get handler path (excluding AFTER handlers)

### DIFF
--- a/src/main/java/io/javalin/Context.kt
+++ b/src/main/java/io/javalin/Context.kt
@@ -33,6 +33,7 @@ open class Context(private val servletRequest: HttpServletRequest, private val s
     // @formatter:off
     @get:JvmSynthetic @set:JvmSynthetic internal var inExceptionHandler = false
     @get:JvmSynthetic @set:JvmSynthetic internal var matchedPath = ""
+    @get:JvmSynthetic @set:JvmSynthetic internal var endpointHandlerPath = ""
     @get:JvmSynthetic @set:JvmSynthetic internal var pathParamMap = mapOf<String, String>()
     @get:JvmSynthetic @set:JvmSynthetic internal var splatList = listOf<String>()
     @get:JvmSynthetic @set:JvmSynthetic internal var handlerType = HandlerType.BEFORE
@@ -231,6 +232,15 @@ open class Context(private val servletRequest: HttpServletRequest, private val s
      * matchedPath() will return /users/:user-id
      */
     fun matchedPath() = matchedPath
+
+    /**
+     * Gets the path that Javalin used to match this request (excluding any AFTER handlers)
+     */
+    fun endpointHandlerPath() = if (handlerType != HandlerType.BEFORE) {
+        endpointHandlerPath
+    } else {
+        throw IllegalStateException("Cannot access the endpoint handler path in a 'BEFORE' handler")
+    }
 
     /** Gets the request method. */
     fun method(): String = servletRequest.method

--- a/src/main/java/io/javalin/core/util/ContextUtil.kt
+++ b/src/main/java/io/javalin/core/util/ContextUtil.kt
@@ -23,6 +23,9 @@ object ContextUtil {
         pathParamMap = handlerEntry.extractPathParams(requestUri)
         splatList = handlerEntry.extractSplats(requestUri)
         handlerType = handlerEntry.type
+        if (handlerType != HandlerType.AFTER) {
+            endpointHandlerPath = handlerEntry.path
+        }
     }
 
     fun splitKeyValueStringAndGroupByKey(string: String): Map<String, List<String>> {

--- a/src/test/java/io/javalin/TestRequest.kt
+++ b/src/test/java/io/javalin/TestRequest.kt
@@ -237,6 +237,15 @@ class TestRequest {
     }
 
     @Test
+    fun `endpointHandlerPath() returns the path used to match the request (excluding any AFTER handlers)`() = TestUtil.test { app, http ->
+        app.before { }
+        app.get("/matched/:path-param") { }
+        app.get("/matched/:another-path-param") { }
+        app.after { ctx -> ctx.result(ctx.endpointHandlerPath()) }
+        assertThat(http.getBody("/matched/p1"), `is`("/matched/:path-param"))
+    }
+
+    @Test
     fun `servlet-context is not null`() = TestUtil.test { app, http ->
         app.get("/") { ctx -> ctx.result(if (ctx.req.servletContext != null) "not-null" else "null") }
         assertThat(http.getBody("/"), `is`("not-null"))


### PR DESCRIPTION
I'd like to do some book keeping in an AFTER handler, but I'm unable to get the path of the handler that previously matched. It always resolves to "*" within the AFTER handler.

This PR adds a new context method that solves the issue. I left the original method untouched for backwards compatibility.
