### PR TITLE
Target Java 8 bytecode with Kotlin (fixes #434)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.2.71</kotlin.version>
-        <kotlin.compiler.jvmTarget>1.6</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     </properties>
 


### PR DESCRIPTION
As discussed in #434, this pull request configures the Kotlin compiler to target Java 8 bytecode.