### PR TITLE
[swagger] Add javadoc-swagger-generator

### DIFF
--- a/src/main/java/io/javalin/core/util/SwaggerGenerator.kt
+++ b/src/main/java/io/javalin/core/util/SwaggerGenerator.kt
@@ -1,0 +1,55 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin.core.util
+
+import java.io.File
+
+data class EndpointData(
+        var description: MutableList<String> = mutableListOf(),
+        var path: String = "",
+        val pathParams: MutableList<Pair<String, String>> = mutableListOf(),
+        val queryParams: MutableList<Pair<String, String>> = mutableListOf(),
+        val formParams: MutableList<Pair<String, String>> = mutableListOf(),
+        var result: String = ""
+)
+
+object SwaggerGenerator {
+
+    fun generateFromSourceFiles() = generateFromDirectory("src")
+
+    fun generateFromDirectory(path: String) = generateSwagger(File(path).walkTopDown().filter { it.isFile }.toSet())
+
+    private fun generateSwagger(files: Set<File>) = files.forEach { currentFile ->
+        Regex("/\\*\\*([\\s\\S]*?)\\*/")
+                .findAll(currentFile.readText())
+                .map { it.groupValues[0] }
+                .filter { it.contains("@path ") }
+                .forEach { javadoc ->
+                    val data = EndpointData()
+                    javadoc.lines().asSequence()
+                            .filter { it.length > 3 } // content
+                            .map { it.substring(3) } // remove margin
+                            .forEach { line ->
+                                when {
+                                    line.startsWith("@path ") -> data.path = line.split(" ")[1]
+                                    line.startsWith("@pathParam ") -> data.pathParams.add(line.split(" ", limit = 3).let { it[1] to it[2] })
+                                    line.startsWith("@queryParam ") -> data.queryParams.add(line.split(" ", limit = 3).let { it[1] to it[2] })
+                                    line.startsWith("@formParam ") -> data.formParams.add(line.split(" ", limit = 3).let { it[1] to it[2] })
+                                    line.startsWith("@result") -> data.result = line.split(" ")[1]
+                                    else -> data.description.add(line)
+                                }
+                            }
+                    println(data.description.joinToString(" "))
+                    println(data.path)
+                    println(data.pathParams)
+                    println(data.queryParams)
+                    println(data.formParams)
+                    println(data.result)
+                }
+    }
+
+}

--- a/src/test/java/io/javalin/TestSwaggerGenerator.kt
+++ b/src/test/java/io/javalin/TestSwaggerGenerator.kt
@@ -1,0 +1,35 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin
+
+import io.javalin.core.util.SwaggerGenerator
+
+/**
+ * My very nice description.
+ * It can be multiple lines,
+ * because why not!
+ *
+ * @path /users/:user-id
+ * @pathParam user-id a very nice description
+ * @queryParam my-query-param some other description
+ * @formParam my-form-param a terrible description
+ * @result SerializeableObject object
+ */
+
+/**
+ * My other nice description. It's just a single line.
+ *
+ * @path /users/:user-id
+ * @pathParam user-id a very nice description
+ * @queryParam my-query-param some other description
+ * @formParam my-form-param a terrible description
+ * @result SerializeableObject object
+ */
+
+fun main(args: Array<String>) {
+    SwaggerGenerator.generateFromSourceFiles()
+}


### PR DESCRIPTION
This is a very rough PR. Currently it just parses this:

```
/**
 * My very nice description.
 * It can be multiple lines,
 * because why not!
 *
 * @path /users/:user-id
 * @pathParam user-id a very nice description
 * @queryParam my-query-param some other description
 * @formParam my-form-param a terrible description
 * @result SerializeableObject object
 */
```

Into this:

```
description:    My very nice description. It can be multiple lines, because why not!
path:           /users/:user-id
path-params:    [(user-id, a very nice description)]
query-params:   [(my-query-param, some other description)]
form-params:    [(my-form-param, a terrible description)]
return-type:    SerializeableObject
```

The idea is to use this information, together with some global settings, to produce a full swagger spec.

If we make this feature complete, we should probably not merge it into Javalin, but release it as a separate javadoc-swagger-generator project. 

Alternatively we can make an annotation: 

```java
@SwaggerApi(
        description = "My other nice description. It's just a single line.",
        path = "/users/:user-id",
        pathParams = [
            PathParam("user-id", "a very nice description"),
            PathParam("other-id", "another description")
        ],
        queryParams = [QueryParam("my-query-param", "some other description")],
        formParams = [FormParam("my-form-param", "a terrible description")],
        result = SerializeableObject.class
)
```