### PR TITLE
Extendable static files

### DIFF
--- a/src/main/java/io/javalin/EmbeddedJavalin.kt
+++ b/src/main/java/io/javalin/EmbeddedJavalin.kt
@@ -44,7 +44,7 @@ class EmbeddedJavalin : Javalin(null, null) {
             maxRequestCacheBodySize = maxRequestCacheBodySize,
             prefer405over404 = prefer405over404,
             singlePageHandler = singlePageHandler,
-            jettyResourceHandler = null // no jetty here
+            resourceHandler = null // no jetty here
     )
 
     override fun contextPath(contextPath: String) = notAvailable("contextPath()")

--- a/src/main/java/io/javalin/core/JavalinServlet.kt
+++ b/src/main/java/io/javalin/core/JavalinServlet.kt
@@ -8,7 +8,7 @@ package io.javalin.core
 
 import io.javalin.*
 import io.javalin.core.util.*
-import io.javalin.staticfiles.JettyResourceHandler
+import io.javalin.staticfiles.ResourceHandler
 import java.io.InputStream
 import java.util.zip.GZIPOutputStream
 import javax.servlet.http.HttpServletRequest
@@ -27,7 +27,7 @@ class JavalinServlet(
         val maxRequestCacheBodySize: Long,
         val prefer405over404: Boolean,
         val singlePageHandler: SinglePageHandler,
-        val jettyResourceHandler: JettyResourceHandler?) {
+        val resourceHandler: ResourceHandler?) {
 
     fun service(servletRequest: HttpServletRequest, res: HttpServletResponse) {
 
@@ -50,7 +50,7 @@ class JavalinServlet(
                 return@tryWithExceptionMapper // return 200, there is a get handler
             }
             if (type == HandlerType.HEAD || type == HandlerType.GET) { // let Jetty check for static resources
-                if (jettyResourceHandler?.handle(req, res) == true) return@tryWithExceptionMapper
+                if (resourceHandler?.handle(req, res) == true) return@tryWithExceptionMapper
                 if (singlePageHandler.handle(ctx)) return@tryWithExceptionMapper
             }
             val availableHandlerTypes = MethodNotAllowedUtil.findAvailableHttpHandlerTypes(matcher, requestUri)

--- a/src/main/java/io/javalin/staticfiles/JettyResourceHandler.kt
+++ b/src/main/java/io/javalin/staticfiles/JettyResourceHandler.kt
@@ -20,7 +20,10 @@ import javax.servlet.http.HttpServletResponse
 data class StaticFileConfig(val path: String, val location: Location)
 enum class Location { CLASSPATH, EXTERNAL; }
 
-class JettyResourceHandler(staticFileConfig: Set<StaticFileConfig>, jettyServer: Server, private val ignoreTrailingSlashes: Boolean) {
+class JettyResourceHandler(
+        staticFileConfig: Set<StaticFileConfig>,
+        jettyServer: Server,
+        private val ignoreTrailingSlashes: Boolean) : io.javalin.staticfiles.ResourceHandler {
 
     private val log = LoggerFactory.getLogger("io.javalin.Javalin")
 
@@ -55,7 +58,7 @@ class JettyResourceHandler(staticFileConfig: Set<StaticFileConfig>, jettyServer:
         return staticFileConfig.path
     }
 
-    fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean {
+    override fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean {
         val target = httpRequest.getAttribute("jetty-target") as String
         val baseRequest = httpRequest.getAttribute("jetty-request") as Request
         for (gzipHandler in handlers) {

--- a/src/main/java/io/javalin/staticfiles/ResourceHandler.kt
+++ b/src/main/java/io/javalin/staticfiles/ResourceHandler.kt
@@ -1,0 +1,8 @@
+package io.javalin.staticfiles
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+interface ResourceHandler {
+    fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean
+}


### PR DESCRIPTION
`JettyResourceHandler` implementation does not fit my use case. I would like to be able to supply my own implementation for `JavalinServlet`.  

It would probably be a _cleaner_ solution if the entire `JettyResourceHandler` was moved behind an interface and adding a setter to the `Javalin` object. In my opinion that would be just overkill. 