### PR TITLE
Enable usage of context path in EmbeddedJavalin

### DIFF
--- a/src/main/java/io/javalin/EmbeddedJavalin.kt
+++ b/src/main/java/io/javalin/EmbeddedJavalin.kt
@@ -47,7 +47,6 @@ class EmbeddedJavalin : Javalin(null, null) {
             resourceHandler = null // no jetty here
     )
 
-    override fun contextPath(contextPath: String) = notAvailable("contextPath()")
     override fun enableStaticFiles(classpathPath: String) = notAvailable("enableStaticFiles()")
     override fun enableWebJars() = notAvailable("enableWebJars()")
     override fun port() = notAvailable("port()")


### PR DESCRIPTION
Came across this when embedding Javalin into a vaddin flow app, as far as I can tell there is nothing that interacts with jetting when removing the override like this.

Would save me a ton of time to be able to drop the common prefixes I'm having to add to every route.