### PR TITLE
fixed #480

### DIFF
--- a/src/main/java/io/javalin/apibuilder/ApiBuilder.java
+++ b/src/main/java/io/javalin/apibuilder/ApiBuilder.java
@@ -414,8 +414,18 @@ public class ApiBuilder {
      */
     public static void crud(@NotNull String path, @NotNull CrudHandler crudHandler, @NotNull Set<Role> permittedRoles) {
         path = path.startsWith("/") ? path : "/" + path;
-        String resourceBase = path.split("/")[1];
-        String resourceId = path.split("/")[2];
+
+        if(path.startsWith("/:")) {
+           throw new IllegalArgumentException("The provided path is missing an actual resource base, try something like '/users/:user-id'");
+        }
+
+        if(!path.contains("/:") || path.lastIndexOf("/") > path.lastIndexOf("/:")) {
+            throw new IllegalArgumentException("The path for the crud handler expects a path-parameter at the end of the provided path e.g. '/users/:user-id'");
+        }
+
+        final String SEPARATOR = "/:";
+        String resourceBase = path.substring(0, path.lastIndexOf(SEPARATOR));
+        String resourceId = path.substring(path.lastIndexOf(SEPARATOR) + SEPARATOR.length());
         staticInstance().get(prefixPath(path), ctx -> crudHandler.getOne(ctx, ctx.pathParam(resourceId)), permittedRoles);
         staticInstance().get(prefixPath(resourceBase), crudHandler::getAll, permittedRoles);
         staticInstance().post(prefixPath(resourceBase), crudHandler::create, permittedRoles);

--- a/src/test/java/io/javalin/TestApiBuilder.kt
+++ b/src/test/java/io/javalin/TestApiBuilder.kt
@@ -16,6 +16,7 @@ import io.javalin.util.TestUtil
 import io.javalin.util.TestUtil.okHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.lang.IllegalArgumentException
 
 class TestApiBuilder {
 
@@ -143,6 +144,41 @@ class TestApiBuilder {
         assertThat(Unirest.get(http.origin + "/s/users/myUser").asString().body).isEqualTo("My single user: myUser")
         assertThat(Unirest.patch(http.origin + "/s/users/myUser").asString().status).isEqualTo(204)
         assertThat(Unirest.delete(http.origin + "/s/users/myUser").asString().status).isEqualTo(204)
+    }
+
+    @Test
+    fun `CrudHandler works with long nested resources`() = TestUtil.test { app, http ->
+        app.routes {
+            crud("/foo/bar/users/:user-id", UserController())
+            path("/foo/baz") {
+                crud("/users/:user-id", UserController())
+            }
+        }
+        assertThat(Unirest.get(http.origin + "/foo/bar/users").asString().body).isEqualTo("All my users")
+        assertThat(Unirest.post(http.origin + "/foo/bar/users").asString().status).isEqualTo(201)
+        assertThat(Unirest.get(http.origin + "/foo/bar/users/myUser").asString().body).isEqualTo("My single user: myUser")
+        assertThat(Unirest.patch(http.origin + "/foo/bar/users/myUser").asString().status).isEqualTo(204)
+        assertThat(Unirest.delete(http.origin + "/foo/bar/users/myUser").asString().status).isEqualTo(204)
+
+        assertThat(Unirest.get(http.origin + "/foo/baz/users").asString().body).isEqualTo("All my users")
+        assertThat(Unirest.post(http.origin + "/foo/baz/users").asString().status).isEqualTo(201)
+        assertThat(Unirest.get(http.origin + "/foo/baz/users/myUser").asString().body).isEqualTo("My single user: myUser")
+        assertThat(Unirest.patch(http.origin + "/foo/baz/users/myUser").asString().status).isEqualTo(204)
+        assertThat(Unirest.delete(http.origin + "/foo/baz/users/myUser").asString().status).isEqualTo(204)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `CrudHandler rejects resource in the middle`() = TestUtil.test { app, http ->
+        app.routes {
+            crud("/foo/bar/:user-id/users", UserController())
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `CrudHandler rejects missing resource base`() = TestUtil.test { app, http ->
+        app.routes {
+            crud("/:user-id", UserController())
+        }
     }
 
     @Test

--- a/src/test/java/io/javalin/TestApiBuilder.kt
+++ b/src/test/java/io/javalin/TestApiBuilder.kt
@@ -175,6 +175,13 @@ class TestApiBuilder {
     }
 
     @Test(expected = IllegalArgumentException::class)
+    fun `CrudHandler rejects missing resource`() = TestUtil.test { app, http ->
+        app.routes {
+            crud("/foo/bar/users", UserController())
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
     fun `CrudHandler rejects missing resource base`() = TestUtil.test { app, http ->
         app.routes {
             crud("/:user-id", UserController())


### PR DESCRIPTION
Hi Tipsy,
I thought I give it a try and make my first contribution. I hope I got the assumptions about the crud handler right.

I assumed the following intended use:
```java
 crud("users/:user-id", new UserController());
 crud("foo/users/:user-id", new UserController()); //was prev not working -> fixed now
```

I assumed the following use should lead to an exception:
```java
 crud("/users", new UserController());
 crud("/:user-id", new UserController());
 crud("/foo/:user-id/bar", new UserController());
```

