### PR TITLE
 Handle validator throwing null

### DIFF
--- a/src/main/java/io/javalin/validation/JavalinValidation.kt
+++ b/src/main/java/io/javalin/validation/JavalinValidation.kt
@@ -9,7 +9,7 @@ package io.javalin.validation
 class ConversionException(className: String) : IllegalArgumentException("Can't convert to $className. Register a converter using JavalinValidation#register.")
 
 object JavalinValidation {
-    val converters = mutableMapOf<Class<*>, (String) -> Any>(
+    val converters = mutableMapOf<Class<*>, (String) -> Any?>(
             java.lang.Boolean::class.java to { s -> s.toBoolean() },
             java.lang.Double::class.java to { s -> s.toDouble() },
             java.lang.Float::class.java to { s -> s.toFloat() },
@@ -25,5 +25,5 @@ object JavalinValidation {
     )
 
     @JvmStatic
-    fun register(clazz: Class<*>, converter: (String) -> Any) = converters.put(clazz, converter)
+    fun register(clazz: Class<*>, converter: (String) -> Any?) = converters.put(clazz, converter)
 }

--- a/src/main/java/io/javalin/validation/Validator.kt
+++ b/src/main/java/io/javalin/validation/Validator.kt
@@ -28,7 +28,8 @@ open class Validator<T>(val value: T, val messagePrefix: String = "Value") {
         fun <T> create(clazz: Class<T>, value: String?, messagePrefix: String = "Value"): Validator<T> {
             if (value == null || value.isEmpty()) throw BadRequestResponse("$messagePrefix cannot be null or empty")
             return Validator(try {
-                JavalinValidation.converters[clazz]?.invoke(value) ?: throw ConversionException(clazz.simpleName)
+                val validator = JavalinValidation.converters[clazz] ?: throw ConversionException(clazz.simpleName)
+                validator.invoke(value) ?: throw NullPointerException()
             } catch (e: Exception) {
                 if (e is ConversionException) throw e
                 throw BadRequestResponse("$messagePrefix is not a valid ${clazz.simpleName}")

--- a/src/test/java/io/javalin/validation/TestValidation.kt
+++ b/src/test/java/io/javalin/validation/TestValidation.kt
@@ -94,6 +94,13 @@ class TestValidation {
     }
 
     @Test
+    fun `test custom converter returns null`() = TestUtil.test { app, http ->
+        JavalinValidation.register(Instant::class.java) { null }
+        app.get("/instant") { it.queryParam<Instant>("from").get() }
+        assertThat(http.get("/instant?from=1262347200000").status).isEqualTo(400)
+    }
+
+    @Test
     fun `test default converters`() {
         assertThat(Validator.create(Boolean::class.java, "true").get() is Boolean).isTrue()
         assertThat(Validator.create(Double::class.java, "1.2").get() is Double).isTrue()


### PR DESCRIPTION
This checks this existence of a validator and the result of a validator separately.  This prevents the wrong error message if a registered validator returns null.  Fixes #535

This got a little awkward so let me know if this is the best way to handle it.  It looks like the issue is really only for Java applications.  The original implementation said a validator could only return non-null `Any` values.  So in Kotlin you could never get this issue since null types are strictly known at compile time.   However Java has no such language restriction.  So a Java validator could return null and Kotlin had no way of checking nullability so it allowed it.

In order to make the Kotlin compiler play nice with Java I had to switch the converter map to `Any?` and then separate the original elvis statement into two.  If I left it as `Any` then the second elvis statement would complain saying it would never be null, which is not true for Java. 

Hope all that makes sense.   I'm still relatively new to Kotlin and Kotlin/Java interoperability, so if there is a better way please let me know.