### PR TITLE
Added configuration entry to ignore case sensitivity on paths

### DIFF
--- a/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/src/main/java/io/javalin/core/JavalinConfig.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.Nullable;
 // @formatter:off
 public class JavalinConfig {
 
+    public boolean autoLowercaseUrl = false;
     public boolean dynamicGzip = true;
     public boolean autogenerateEtags = false;
     public boolean prefer405over404 = false;

--- a/src/main/java/io/javalin/core/JavalinServlet.kt
+++ b/src/main/java/io/javalin/core/JavalinServlet.kt
@@ -28,7 +28,7 @@ class JavalinServlet(private val appAttributes: Map<Class<*>, Any>, val config: 
 
         val req = CachedRequestWrapper(servletRequest, config.requestCacheSize) // cached for reading multiple times
         val type = HandlerType.fromServletRequest(req)
-        val requestUri = req.requestURI.removePrefix(req.contextPath)
+        val requestUri = if (config.autoLowercaseUrl) req.requestURI.removePrefix(req.contextPath).toLowerCase() else req.requestURI.removePrefix(req.contextPath)
         val ctx = Context(req, res, appAttributes)
 
         fun tryWithExceptionMapper(func: () -> Unit) = exceptionMapper.catchException(ctx, func)

--- a/src/test/java/io/javalin/TestConfiguration.kt
+++ b/src/test/java/io/javalin/TestConfiguration.kt
@@ -50,6 +50,7 @@ class TestConfiguration {
             // Misc
             it.accessManager { handler, ctx, permittedRoles -> }
             it.showJavalinBanner = false
+            it.autoLowercaseUrl = true
         }.start()
         assertThat(app.server.started).isTrue()
         app.stop()

--- a/src/test/java/io/javalin/TestRouting.kt
+++ b/src/test/java/io/javalin/TestRouting.kt
@@ -94,4 +94,11 @@ class TestRouting {
         http.enableUnirestRedirects()
     }
 
+    @Test
+    fun `autoLowercaseUrl works`() = TestUtil.test(Javalin.create { it.autoLowercaseUrl = true }) { app, http ->
+        app.get("/lowercasetest") {}
+        assertThat(http.get("/LOWERCASETEST").status).isEqualTo(200)
+        assertThat(http.get("/lOWercaSETEst").status).isEqualTo(200)
+        assertThat(http.get("/lowercasetest").status).isEqualTo(200)
+    }
 }


### PR DESCRIPTION
To ignore cases, `autoLowercaseUrl` needs to be set to `true` in the JavalinConfig.