### PR TITLE
Stop runaway thread

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -133,6 +133,12 @@ public class Javalin {
         } catch (Exception e) {
             log.error("Failed to start Javalin");
             eventManager.fireEvent(JavalinEvent.SERVER_START_FAILED);
+
+            // only stop if Javalin instantiated default server; otherwise, the caller is responsible to stop
+            Object isDefaultServer = server.server().getAttribute("is-default-server");
+            if (isDefaultServer != null && Boolean.parseBoolean(isDefaultServer.toString())) {
+                stop();
+            }
             if (e.getMessage() != null && e.getMessage().contains("Failed to bind to")) {
                 throw new RuntimeException("Port already in use. Make sure no other process is using port " + server.getServerPort() + " and try again.", e);
             } else if (e.getMessage() != null && e.getMessage().contains("Permission denied")) {

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -88,13 +88,14 @@ class JavalinServer(val config: JavalinConfig) {
     private fun reEnableJettyLogger() = org.eclipse.jetty.util.log.Log.setLog(jettyDefaultLogger)
 
     private fun defaultServer() = Server(QueuedThreadPool(250, 8, 60_000)).apply {
-        server.addBean(LowResourceMonitor(this))
-        server.insertHandler(StatisticsHandler())
+        addBean(LowResourceMonitor(this))
+        insertHandler(StatisticsHandler())
+        setAttribute("is-default-server", true)
     }
 
     private fun defaultSessionHandler() = SessionHandler().apply { httpOnly = true }
 
-    private val ServerConnector.protocol get() = if (this.protocols.contains("ssl")) "https" else "http"
+    private val ServerConnector.protocol get() = if (protocols.contains("ssl")) "https" else "http"
 
     private fun attachJavalinHandlers(userHandler: Handler?, javalinHandlers: HandlerList) = when (userHandler) {
         null -> HandlerWrapper().apply { handler = javalinHandlers } // no custom Handler set, wrap Javalin handlers in a HandlerWrapper


### PR DESCRIPTION
If Javalin initializes a server but then fails to start, there will be a runaway thread that doesn't get shutdown.

This PR sets a variable indicating we initialized the server and should attempt to stop/kill it if we fail to start.

This relates to #492. You might want to tweak how this is implemented. Ultimately, a public variable seems unnecessary (and possibly confusing) but I had to do it this way because of packages.