### PR TITLE
[openapi] Add OpenAPI schema generation (#254)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -95,10 +96,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-          <groupId>com.fasterxml.jackson.module</groupId>
-          <artifactId>jackson-module-kotlin</artifactId>
-          <version>${jackson.version}</version>
-          <optional>true</optional>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
@@ -152,6 +153,18 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>1.1.3</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>2.0.7</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>cc.vileda</groupId>
+            <artifactId>kotlin-openapi3-dsl</artifactId>
+            <version>0.20.1</version>
             <optional>true</optional>
         </dependency>
         <!-- END Optional dependencies -->

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -13,32 +13,25 @@ import io.javalin.core.Extension;
 import io.javalin.core.JavalinConfig;
 import io.javalin.core.JavalinServer;
 import io.javalin.core.JettyUtil;
-import io.javalin.core.event.EventListener;
-import io.javalin.core.event.EventManager;
-import io.javalin.core.event.HandlerMetaInfo;
-import io.javalin.core.event.JavalinEvent;
-import io.javalin.core.event.WsHandlerMetaInfo;
+import io.javalin.core.event.*;
 import io.javalin.core.security.AccessManager;
 import io.javalin.core.security.Role;
 import io.javalin.core.util.Util;
-import io.javalin.http.Context;
-import io.javalin.http.ErrorHandler;
-import io.javalin.http.ExceptionHandler;
-import io.javalin.http.Handler;
-import io.javalin.http.HandlerType;
-import io.javalin.http.JavalinServlet;
+import io.javalin.http.*;
 import io.javalin.http.sse.SseClient;
 import io.javalin.http.sse.SseHandler;
 import io.javalin.websocket.JavalinWsServlet;
 import io.javalin.websocket.WsExceptionHandler;
 import io.javalin.websocket.WsHandler;
 import io.javalin.websocket.WsHandlerType;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Consumer;
+import io.swagger.v3.oas.models.OpenAPI;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
 
 @SuppressWarnings("unchecked")
 public class Javalin {
@@ -104,6 +97,17 @@ public class Javalin {
     // Get JavalinServlet (for use in standalone mode)
     public JavalinServlet servlet() {
         return this.servlet;
+    }
+
+    /**
+     * Create the OpenApi Schema of this instance. Call this method after all the handler are registered.
+     * This requires that the "enableOpenApi" option is enabled otherwise an IllegalStateException is thrown.
+     */
+    public OpenAPI createOpenAPISchema() {
+        if (this.config.inner.openApiHandler == null) {
+            throw new IllegalStateException("You need to activate the \"enableOpenApi\" option before you can create the OpenAPI schema");
+        }
+        return this.config.inner.openApiHandler.createOpenAPISchema();
     }
 
     /**

--- a/src/main/java/io/javalin/core/PathParser.kt
+++ b/src/main/java/io/javalin/core/PathParser.kt
@@ -10,7 +10,7 @@ import io.javalin.http.util.ContextUtil
 
 class PathParser(path: String) {
 
-    private val segments: List<PathSegment> = path.split("/")
+    internal val segments: List<PathSegment> = path.split("/")
             .filter { it.isNotEmpty() }
             .map {
                 when {
@@ -20,7 +20,7 @@ class PathParser(path: String) {
                 }
             }
 
-    private val pathParamNames = segments.filterIsInstance<PathSegment.Parameter>().map { it.name }
+    internal val pathParamNames = segments.filterIsInstance<PathSegment.Parameter>().map { it.name }
 
     private val matchRegex = "^/${segments.joinToString("/") { it.asRegexString() }}/?$".toRegex()
 

--- a/src/main/java/io/javalin/plugin/openapi/CreateBaseConfiguration.java
+++ b/src/main/java/io/javalin/plugin/openapi/CreateBaseConfiguration.java
@@ -1,0 +1,13 @@
+package io.javalin.plugin.openapi;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Create the base open api configuration.
+ * This function will be called before the creation of every schema.
+ */
+@FunctionalInterface
+public interface CreateBaseConfiguration {
+    @NotNull OpenAPI create();
+}

--- a/src/main/java/io/javalin/plugin/openapi/JavalinOpenApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/JavalinOpenApi.kt
@@ -1,0 +1,49 @@
+package io.javalin.plugin.openapi
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.javalin.core.event.HandlerMetaInfo
+import io.javalin.plugin.openapi.utils.applyMetaInfoList
+import io.javalin.plugin.openapi.utils.updateComponents
+import io.javalin.plugin.openapi.utils.updatePaths
+import io.swagger.v3.core.converter.ModelConverters
+import io.swagger.v3.core.jackson.ModelResolver
+import io.swagger.v3.oas.models.OpenAPI
+
+class CreateSchemaOptions(
+        val objectMapper: ObjectMapper,
+        val handlerMetaInfoList: List<HandlerMetaInfo>,
+
+        /**
+         * Create the base open api configuration.
+         * This function will be called before the creation of every schema.
+         */
+        val createBaseConfiguration: CreateBaseConfiguration
+)
+
+object JavalinOpenApi {
+    fun createSchema(options: CreateSchemaOptions): OpenAPI {
+        val baseConfiguration = options.createBaseConfiguration.create()
+        return runWithObjectMapper(options.objectMapper) {
+            baseConfiguration.apply {
+                updateComponents {
+                    applyMetaInfoList(options.handlerMetaInfoList)
+                }
+                updatePaths {
+                    applyMetaInfoList(options.handlerMetaInfoList)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * This function temporary sets the ModelResolve to the given object mapper.
+ * This is required, so the classes are correctly parse to OpenAPI schemas
+ */
+private fun <T> runWithObjectMapper(objectMapper: ObjectMapper, run: () -> T): T {
+    val modelResolver = ModelResolver(objectMapper)
+    ModelConverters.getInstance().addConverter(modelResolver)
+    val result = run()
+    ModelConverters.getInstance().removeConverter(modelResolver)
+    return result
+}

--- a/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
+++ b/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
@@ -1,0 +1,26 @@
+package io.javalin.plugin.openapi
+
+import io.javalin.Javalin
+import io.javalin.core.event.HandlerMetaInfo
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import io.javalin.plugin.json.JavalinJackson
+import io.swagger.v3.oas.models.OpenAPI
+
+class OpenApiHandler(app: Javalin, val options: OpenApiOptions) : Handler {
+    private val handlerMetaInfoList = mutableListOf<HandlerMetaInfo>()
+
+    init {
+        app.events { it.handlerAdded { handlerInfo -> handlerMetaInfoList.add(handlerInfo) } }
+    }
+
+    fun createOpenAPISchema(): OpenAPI = JavalinOpenApi.createSchema(CreateSchemaOptions(
+            handlerMetaInfoList = handlerMetaInfoList,
+            objectMapper = JavalinJackson.getObjectMapper(),
+            createBaseConfiguration = options.createBaseConfiguration
+    ))
+
+    override fun handle(ctx: Context) {
+        ctx.json(createOpenAPISchema())
+    }
+}

--- a/src/main/java/io/javalin/plugin/openapi/OpenApiOptions.kt
+++ b/src/main/java/io/javalin/plugin/openapi/OpenApiOptions.kt
@@ -1,0 +1,9 @@
+package io.javalin.plugin.openapi
+
+import io.javalin.core.security.Role
+
+class OpenApiOptions @JvmOverloads constructor(
+        val path: String? = null,
+        val roles: Set<Role> = setOf(),
+        val createBaseConfiguration: CreateBaseConfiguration
+)

--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
@@ -1,0 +1,75 @@
+package io.javalin.plugin.openapi.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Provide metadata for the generation of the open api documentation to the annotated Handler.
+ */
+@Target(AnnotationTarget.FUNCTION)
+annotation class OpenApi(
+        val summary: String = NULL_STRING,
+        val description: String = NULL_STRING,
+        val operationId: String = NULL_STRING,
+        val deprecated: Boolean = false,
+        val tags: Array<String> = [],
+        val cookies: Array<OpenApiParam> = [],
+        val headers: Array<OpenApiParam> = [],
+        val pathParams: Array<OpenApiParam> = [],
+        val queryParams: Array<OpenApiParam> = [],
+        val requestBodies: Array<OpenApiRequestBody> = [],
+        val fileUploads: Array<OpenApiFileUpload> = [],
+        val responses: Array<OpenApiResponse> = []
+)
+
+@Target()
+annotation class OpenApiResponse(
+        val status: String,
+
+        val returnType: KClass<*> = NULL_CLASS::class,
+
+        val contentType: String = ContentType.AUTODETECT,
+
+        /** Whenever the returnType should be wrapped in an array */
+        val isArray: Boolean = false,
+
+        val description: String = NULL_STRING
+)
+
+@Target()
+annotation class OpenApiParam(
+        val name: String,
+        val type: KClass<*> = String::class,
+        val description: String = NULL_STRING,
+        val deprecated: Boolean = false,
+        val required: Boolean = false,
+        val allowEmptyValue: Boolean = false
+)
+
+@Target()
+annotation class OpenApiRequestBody(
+        val type: KClass<*>,
+        val contentType: String = ContentType.AUTODETECT,
+        val required: Boolean = false,
+        val description: String = NULL_STRING
+)
+
+@Target()
+annotation class OpenApiFileUpload(
+        val name: String,
+        val isArray: Boolean = false,
+        val description: String = NULL_STRING,
+        val required: Boolean = false
+)
+
+
+/** Null string because annotations do not support null values */
+const val NULL_STRING = "io.javalin.plugin.openapi This string represents a null value and shouldn't be used"
+
+/** Null class because annotations do not support null values */
+class NULL_CLASS
+
+object ContentType {
+    const val JSON = "application/json"
+    const val HTML = "text/html"
+    const val AUTODETECT = "AUTODETECT - Will be replaced later"
+}

--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApiMapping.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApiMapping.kt
@@ -1,0 +1,137 @@
+package io.javalin.plugin.openapi.annotations
+
+import io.javalin.plugin.openapi.dsl.DocumentedContent
+import io.javalin.plugin.openapi.dsl.DocumentedParameter
+import io.javalin.plugin.openapi.dsl.DocumentedResponse
+import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.parameters.RequestBody
+import kotlin.reflect.KClass
+
+fun OpenApi.asOpenApiDocumentation(): OpenApiDocumentation {
+    val documentation = OpenApiDocumentation()
+    val annotation = this
+
+    documentation.operation { it.applyAnnotation(annotation) }
+
+    annotation.cookies.forEach { documentation.applyParamAnnotation("cookie", it) }
+    annotation.headers.forEach { documentation.applyParamAnnotation("header", it) }
+    annotation.pathParams.forEach { documentation.applyParamAnnotation("path", it) }
+    annotation.queryParams.forEach { documentation.applyParamAnnotation("query", it) }
+
+    annotation.requestBodies.forEach { requestBody ->
+        documentation.body(requestBody.type.java, requestBody.contentType.correctNullValue()) { it.applyAnnotation(requestBody) }
+    }
+
+    annotation.fileUploads.forEach { fileUpload ->
+        if (fileUpload.isArray) {
+            documentation.uploadedFiles(name = fileUpload.name) { it.applyAnnotation(fileUpload) }
+        } else {
+            documentation.uploadedFile(name = fileUpload.name) { it.applyAnnotation(fileUpload) }
+        }
+    }
+
+    annotation.responses.forEach { documentation.applyResponseAnnotation(it) }
+
+    return documentation
+}
+
+private fun resolveNullValueFromContentType(returnType: KClass<*>, contentType: String): KClass<out Any> {
+    return if (returnType == NULL_CLASS::class) {
+        if (contentType.startsWith("text/")) {
+            // Default for text/html, etc is string
+            String::class
+        } else {
+            // Default for everything else is unit
+            Unit::class
+        }
+    } else {
+        returnType
+    }
+}
+
+private fun Operation.applyAnnotation(annotation: OpenApi) {
+    if (annotation.description.isNotNullString()) {
+        this.description = annotation.description
+    }
+    if (annotation.summary.isNotNullString()) {
+        this.summary = annotation.summary
+    }
+    if (annotation.operationId.isNotNullString()) {
+        this.operationId = annotation.operationId
+    }
+    if (annotation.deprecated) {
+        this.deprecated = annotation.deprecated
+    }
+    annotation.tags.forEach { tag -> this.addTagsItem(tag) }
+}
+
+private fun RequestBody.applyAnnotation(annotation: OpenApiRequestBody) {
+    if (annotation.required) {
+        this.required = annotation.required
+    }
+    if (annotation.description.isNotNullString()) {
+        this.description = annotation.description
+    }
+}
+
+private fun RequestBody.applyAnnotation(annotation: OpenApiFileUpload) {
+    if (annotation.required) {
+        this.required = annotation.required
+    }
+    if (annotation.description.isNotNullString()) {
+        this.description = annotation.description
+    }
+}
+
+private fun OpenApiDocumentation.applyResponseAnnotation(it: OpenApiResponse) {
+    val documentation = this
+    val returnType = resolveNullValueFromContentType(it.returnType, it.contentType)
+    val returnTypeIsUnit = returnType == Unit::class
+    documentation.result(
+            documentedResponse = DocumentedResponse(
+                    status = it.status,
+                    content = if (returnTypeIsUnit) null else DocumentedContent(
+                            returnType = returnType.java,
+                            isArray = it.isArray,
+                            contentType = it.contentType
+                    )
+            ),
+            applyUpdates = { responseDocumentation ->
+                if (it.description.isNotNullString()) {
+                    responseDocumentation.description = it.description
+                }
+            }
+    )
+}
+
+private fun OpenApiDocumentation.applyParamAnnotation(`in`: String, param: OpenApiParam) {
+    val documentation = this
+    documentation.param(
+            documentedParameter = createDocumentedParam(`in`, param),
+            applyUpdates = { paramDocumentation ->
+                if (param.description.isNotNullString()) {
+                    paramDocumentation.description = param.description
+                }
+                if (param.required) {
+                    paramDocumentation.required = param.required
+                }
+                if (param.deprecated) {
+                    paramDocumentation.deprecated = param.deprecated
+                }
+                if (param.allowEmptyValue) {
+                    paramDocumentation.allowEmptyValue = param.allowEmptyValue
+                }
+            }
+    )
+}
+
+private fun createDocumentedParam(`in`: String, param: OpenApiParam) = DocumentedParameter(
+        `in` = `in`,
+        name = param.name,
+        type = param.type.java
+)
+
+private fun String.isNullString() = this == NULL_STRING
+private fun String.isNotNullString() = !this.isNullString()
+private fun String.correctNullValue(): String? = if (this.isNullString()) null else this

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt
@@ -1,0 +1,108 @@
+package io.javalin.plugin.openapi.dsl
+
+import io.javalin.plugin.openapi.annotations.ContentType
+import io.javalin.plugin.openapi.external.*
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+class DocumentedContent(
+        returnType: Class<*>,
+        isArray: Boolean,
+        contentType: String? = null,
+        val schema: Schema<*>? = null
+) {
+    val contentType: String= if (contentType == null || contentType == ContentType.AUTODETECT) {
+        returnType.guessContentType()
+    } else {
+        contentType
+    }
+
+    private val returnTypeIsArray = returnType.isArray
+
+    private val isNotByteArray = if (schema == null) {
+        returnType != ByteArray::class.java
+    } else {
+        schema.type == "string" && schema.format == "application/octet-stream"
+    }
+
+    val returnType = when {
+        returnTypeIsArray && isNotByteArray -> returnType.componentType!!
+        else -> returnType
+    }
+
+    val isArray = if (schema == null) {
+        returnTypeIsArray && isNotByteArray || isArray
+    } else {
+        schema.type == "array"
+    }
+
+    /** This constructor overrides the schema directly. The returnType won't be used anymore */
+    constructor(schema: Schema<*>, contentType: String) : this(
+            Object::class.java,
+            schema.type == "array",
+            contentType,
+            schema
+    )
+
+    fun isNonRefType(): Boolean = if (schema == null) {
+        returnType in nonRefTypes
+    } else {
+        true
+    }
+}
+
+/**
+ * Try to determine the content type based on the class
+ */
+fun Class<*>.guessContentType(): String =
+        when (this) {
+            String::class.java -> "text/plain"
+            ByteArray::class.java -> "application/octet-stream"
+            else -> "application/json"
+        }
+
+/**
+ * A set of types that should be inlined, instead of creating a reference, in the OpenApi documentation
+ */
+val nonRefTypes = setOf(
+        String::class.java,
+        Boolean::class.java,
+        Int::class.java,
+        Integer::class.java,
+        List::class.java,
+        Long::class.java,
+        BigDecimal::class.java,
+        Date::class.java,
+        LocalDate::class.java,
+        LocalDateTime::class.java,
+        ByteArray::class.java
+)
+
+fun Content.applyDocumentedContent(documentedContent: DocumentedContent) {
+    when {
+        documentedContent.schema != null -> addMediaType(
+                documentedContent.contentType,
+                MediaType().apply { schema = documentedContent.schema }
+        )
+        documentedContent.isNonRefType() -> when {
+            documentedContent.isArray -> mediaTypeArrayOf(documentedContent.returnType, documentedContent.contentType)
+            else -> mediaType(documentedContent.returnType, documentedContent.contentType)
+        }
+        else -> when {
+            documentedContent.isArray -> mediaTypeArrayOfRef(documentedContent.returnType, documentedContent.contentType)
+            else -> mediaTypeRef(documentedContent.returnType, documentedContent.contentType)
+        }
+    }
+}
+
+fun Components.applyDocumentedContent(documentedResponse: DocumentedContent) {
+    if (!documentedResponse.isNonRefType()) {
+        schema(documentedResponse.returnType)
+    }
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedCrudHandler.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedCrudHandler.kt
@@ -1,0 +1,19 @@
+package io.javalin.plugin.openapi.dsl
+
+import io.javalin.apibuilder.CrudHandler
+import io.javalin.http.Context
+
+class DocumentedCrudHandler(
+        val crudHandlerDocumentation: OpenApiCrudHandlerDocumentation,
+        private val crudHandler: CrudHandler
+) : CrudHandler {
+    override fun getAll(ctx: Context) = crudHandler.getAll(ctx)
+
+    override fun getOne(ctx: Context, resourceId: String) = crudHandler.getOne(ctx, resourceId)
+
+    override fun create(ctx: Context) = crudHandler.create(ctx)
+
+    override fun update(ctx: Context, resourceId: String) = crudHandler.update(ctx, resourceId)
+
+    override fun delete(ctx: Context, resourceId: String) = crudHandler.delete(ctx, resourceId)
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedHandler.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedHandler.kt
@@ -1,0 +1,11 @@
+package io.javalin.plugin.openapi.dsl
+
+import io.javalin.http.Context
+import io.javalin.http.Handler
+
+class DocumentedHandler(
+        val documentation: OpenApiDocumentation,
+        private val handler: Handler
+) : Handler {
+    override fun handle(ctx: Context) = handler.handle(ctx)
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedParameter.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedParameter.kt
@@ -1,0 +1,16 @@
+package io.javalin.plugin.openapi.dsl
+
+import io.javalin.plugin.openapi.external.findSchema
+import io.swagger.v3.oas.models.parameters.Parameter
+
+class DocumentedParameter(
+        val `in`: String,
+        val name: String,
+        val type: Class<*>
+)
+
+fun Parameter.applyDocumentedParameter(documentedParameter: DocumentedParameter) {
+    `in` = documentedParameter.`in`
+    name = documentedParameter.name
+    schema = findSchema(documentedParameter.type)
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedRequestBody.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedRequestBody.kt
@@ -1,0 +1,19 @@
+package io.javalin.plugin.openapi.dsl
+
+import io.javalin.plugin.openapi.utils.updateContent
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.parameters.RequestBody
+
+class DocumentedRequestBody(
+        val content: DocumentedContent
+)
+
+fun RequestBody.applyDocumentedRequestBody(documentedRequestBody: DocumentedRequestBody) {
+    updateContent {
+        applyDocumentedContent(documentedRequestBody.content)
+    }
+}
+
+fun Components.applyDocumentedRequestBody(documentedRequestBody: DocumentedRequestBody) {
+    applyDocumentedContent(documentedRequestBody.content)
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedResponse.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedResponse.kt
@@ -1,0 +1,26 @@
+package io.javalin.plugin.openapi.dsl
+
+import io.javalin.plugin.openapi.utils.updateContent
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.responses.ApiResponse
+
+class DocumentedResponse(
+        val status: String,
+        val content: DocumentedContent?
+)
+
+
+fun ApiResponse.applyDocumentedResponse(documentedResponse: DocumentedResponse) {
+    description = ""
+    if (documentedResponse.content != null) {
+        updateContent {
+            applyDocumentedContent(documentedResponse.content)
+        }
+    }
+}
+
+fun Components.applyDocumentedResponse(documentedResponse: DocumentedResponse) {
+    if (documentedResponse.content != null) {
+        applyDocumentedContent(documentedResponse.content)
+    }
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiBuilder.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiBuilder.kt
@@ -1,0 +1,49 @@
+@file:JvmName("OpenApiBuilder")
+
+package io.javalin.plugin.openapi.dsl
+
+import io.javalin.apibuilder.CrudHandler
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import io.javalin.plugin.openapi.annotations.OpenApi
+import io.javalin.plugin.openapi.annotations.asOpenApiDocumentation
+import java.lang.reflect.Method
+
+/** Creates an instance of the OpenApiDocumentation */
+fun document() = OpenApiDocumentation()
+
+/** Creates an instance of the OpenApiCrudHandlerDocumentation */
+fun documentCrud() = OpenApiCrudHandlerDocumentation()
+
+/** Creates a documented Handler with a lambda */
+fun documented(documentation: OpenApiDocumentation, handle: (ctx: Context) -> Unit) = DocumentedHandler(
+        documentation,
+        Handler { ctx -> handle(ctx) }
+)
+
+/** Creates a documented Handler */
+fun documented(documentation: OpenApiDocumentation, handler: Handler) = DocumentedHandler(
+        documentation,
+        handler
+)
+
+/** Creates a documented CrudHandler */
+fun documented(documentation: OpenApiCrudHandlerDocumentation, handler: CrudHandler) = DocumentedCrudHandler(documentation, handler)
+
+/**
+ * Moves the documentation from the annotation to a DocumentedHandler.
+ * If the method is not documented, just returns the handler.
+ */
+fun moveDocumentationFromAnnotationToHandler(javaClass: Class<*>, methodName: String, handler: Handler): Handler {
+    val method = javaClass.declaredMethods.find { it.name === methodName } ?: throw NoSuchMethodException(methodName)
+    return moveDocumentationFromAnnotationToHandler(method, handler)
+}
+
+/**
+ * Moves the documentation from the annotation to a DocumentedHandler.
+ * If the method is not documented, just returns the handler.
+ */
+fun moveDocumentationFromAnnotationToHandler(methodWithAnnotation: Method, handler: Handler): Handler {
+    val openApi: OpenApi? = methodWithAnnotation.getDeclaredAnnotation(OpenApi::class.java)
+    return openApi?.asOpenApiDocumentation()?.let { documented(it, handler) } ?: handler
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiCrudHandlerDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiCrudHandlerDocumentation.kt
@@ -1,0 +1,29 @@
+package io.javalin.plugin.openapi.dsl
+
+data class OpenApiCrudHandlerDocumentation(
+        var getAllDocumentation: OpenApiDocumentation = OpenApiDocumentation(),
+        var getOneDocumentation: OpenApiDocumentation = OpenApiDocumentation(),
+        var createDocumentation: OpenApiDocumentation = OpenApiDocumentation(),
+        var updateDocumentation: OpenApiDocumentation = OpenApiDocumentation(),
+        var deleteDocumentation: OpenApiDocumentation = OpenApiDocumentation()
+) {
+    fun getAll(doc: OpenApiDocumentation) = apply {
+        this.getAllDocumentation = doc
+    }
+
+    fun getOne(doc: OpenApiDocumentation) = apply {
+        this.getOneDocumentation = doc
+    }
+
+    fun create(doc: OpenApiDocumentation) = apply {
+        this.createDocumentation = doc
+    }
+
+    fun update(doc: OpenApiDocumentation) = apply {
+        this.updateDocumentation = doc
+    }
+
+    fun delete(doc: OpenApiDocumentation) = apply {
+        this.deleteDocumentation = doc
+    }
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
@@ -1,0 +1,256 @@
+package io.javalin.plugin.openapi.dsl
+
+import io.javalin.plugin.openapi.external.findSchema
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.parameters.Parameter
+import io.swagger.v3.oas.models.parameters.RequestBody
+import io.swagger.v3.oas.models.responses.ApiResponse
+
+class OpenApiDocumentation {
+    val operationUpdaterList = mutableListOf<OpenApiUpdater<Operation>>()
+    val requestBodyList = mutableListOf<OpenApiUpdater<RequestBody>>()
+    val parameterUpdaterListMapping = mutableMapOf<String, MutableList<OpenApiUpdater<Parameter>>>()
+    val responseUpdaterListMapping = mutableMapOf<String, MutableList<OpenApiUpdater<ApiResponse>>>()
+    val componentsUpdaterList = mutableListOf<OpenApiUpdater<Components>>()
+
+    fun hasRequestBodies(): Boolean = requestBodyList.isNotEmpty()
+    fun hasResponses(): Boolean = responseUpdaterListMapping.values.flatten().isNotEmpty()
+
+    // --- OPERATION ---
+    fun operation(applyUpdates: ApplyUpdates<Operation>) = apply {
+        operation(createUpdater(applyUpdates))
+    }
+
+    fun operation(openApiUpdater: OpenApiUpdater<Operation>) = apply {
+        operationUpdaterList.add(openApiUpdater)
+    }
+
+    // --- PATH PARAM ---
+    inline fun <reified T> pathParam(name: String, noinline applyUpdates: ApplyUpdates<Parameter>? = null): OpenApiDocumentation = apply {
+        pathParam(name, T::class.java, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun pathParam(name: String, clazz: Class<*>, openApiUpdater: OpenApiUpdater<Parameter>? = null) = apply {
+        val documentedQueryParameter = DocumentedParameter("path", name, clazz)
+        param(documentedQueryParameter, openApiUpdater)
+    }
+
+    // --- QUERY PARAM ---
+    inline fun <reified T> queryParam(name: String, noinline applyUpdates: ApplyUpdates<Parameter>? = null): OpenApiDocumentation = apply {
+        queryParam(name, T::class.java, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun queryParam(name: String, clazz: Class<*>, openApiUpdater: OpenApiUpdater<Parameter>? = null) = apply {
+        val documentedQueryParameter = DocumentedParameter("query", name, clazz)
+        param(documentedQueryParameter, openApiUpdater)
+    }
+
+    // --- HEADER ---
+    inline fun <reified T> header(name: String, noinline applyUpdates: ApplyUpdates<Parameter>? = null): OpenApiDocumentation = apply {
+        header(name, T::class.java, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun header(name: String, clazz: Class<*>, openApiUpdater: OpenApiUpdater<Parameter>? = null) = apply {
+        val documentedQueryParameter = DocumentedParameter("header", name, clazz)
+        param(documentedQueryParameter, openApiUpdater)
+    }
+
+    // --- COOKIE ---
+    inline fun <reified T> cookie(name: String, noinline applyUpdates: ApplyUpdates<Parameter>? = null): OpenApiDocumentation = apply {
+        cookie(name, T::class.java, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun cookie(name: String, clazz: Class<*>, openApiUpdater: OpenApiUpdater<Parameter>? = null) = apply {
+        val documentedQueryParameter = DocumentedParameter("cookie", name, clazz)
+        param(documentedQueryParameter, openApiUpdater)
+    }
+
+    // --- PARAM ---
+    fun param(documentedParameter: DocumentedParameter, applyUpdates: ApplyUpdates<Parameter>? = null) = apply {
+        param(documentedParameter, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun param(documentedParameter: DocumentedParameter, openApiUpdater: OpenApiUpdater<Parameter>? = null) = apply {
+        val parameterUpdaterList = parameterUpdaterListMapping.getOrSetDefault(documentedParameter.name, mutableListOf())
+        parameterUpdaterList.add { it.applyDocumentedParameter(documentedParameter) }
+        parameterUpdaterList.addIfNotNull(openApiUpdater)
+    }
+
+    // --- UPLOADED FILE ---
+    fun uploadedFile(name: String, applyUpdates: ApplyUpdates<RequestBody>? = null) = apply {
+        uploadedFile(name, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun uploadedFile(name: String, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
+        val schema = ObjectSchema().apply {
+            properties = mapOf(
+                    name to findSchema(ByteArray::class.java)
+            )
+        }
+        body(schema, "multipart/form-data", openApiUpdater)
+    }
+
+    // --- UPLOADED FILES ---
+    fun uploadedFiles(name: String, applyUpdates: ApplyUpdates<RequestBody>? = null) = apply {
+        uploadedFiles(name, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun uploadedFiles(name: String, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
+        val schema = ObjectSchema().apply {
+            properties = mapOf(
+                    name to ArraySchema().items(findSchema(ByteArray::class.java))
+            )
+        }
+        body(schema, "multipart/form-data", openApiUpdater)
+    }
+
+    // --- BODY ---
+    inline fun <reified T> body(contentType: String? = null, noinline applyUpdates: ApplyUpdates<RequestBody>? = null) = apply {
+        body(T::class.java, contentType, applyUpdates)
+    }
+
+    fun body(returnType: Class<*>, contentType: String? = null, applyUpdates: ApplyUpdates<RequestBody>? = null) = apply {
+        body(returnType, contentType, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun body(returnType: Class<*>, contentType: String? = null, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
+        val documentedContent = DocumentedContent(returnType, false, contentType)
+        val documentedBody = DocumentedRequestBody(documentedContent)
+        body(documentedBody, openApiUpdater)
+    }
+
+    @JvmOverloads
+    fun body(schema: Schema<*>, contentType: String, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
+        val documentedContent = DocumentedContent(schema, contentType)
+        val documentedBody = DocumentedRequestBody(documentedContent)
+        body(documentedBody, openApiUpdater)
+    }
+
+    @JvmOverloads
+    fun body(documentedBody: DocumentedRequestBody, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
+        componentsUpdaterList.add { it.applyDocumentedRequestBody(documentedBody) }
+        requestBodyList.add { it.applyDocumentedRequestBody(documentedBody) }
+        requestBodyList.addIfNotNull(openApiUpdater)
+    }
+
+    // --- BODY AS BYTES ---
+    @JvmOverloads
+    fun bodyAsBytes(contentType: String? = null, applyUpdates: ApplyUpdates<RequestBody>?) = apply {
+        bodyAsBytes(contentType, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun bodyAsBytes(contentType: String? = null, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
+        body(ByteArray::class.java, contentType, openApiUpdater)
+    }
+
+    // --- JSON ARRAY ---
+    inline fun <reified T> jsonArray(status: String, noinline applyUpdates: ApplyUpdates<ApiResponse>? = null) = apply {
+        jsonArray(status, T::class.java, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun jsonArray(status: String, returnType: Class<*>, openApiUpdater: OpenApiUpdater<ApiResponse>? = null) = apply {
+        val documentedContent = DocumentedContent(returnType, true, "application/json")
+        val documentedResponse = DocumentedResponse(status, documentedContent)
+        result(documentedResponse, openApiUpdater)
+    }
+
+    // --- JSON ---
+    inline fun <reified T> json(status: String, noinline applyUpdates: ApplyUpdates<ApiResponse>? = null) = apply {
+        json(status, T::class.java, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun json(status: String, returnType: Class<*>, openApiUpdater: OpenApiUpdater<ApiResponse>? = null) = apply {
+        val documentedContent = DocumentedContent(returnType, false, "application/json")
+        val documentedResponse = DocumentedResponse(status, documentedContent)
+        result(documentedResponse, openApiUpdater)
+    }
+
+    // --- HTML ---
+    fun html(status: String, applyUpdates: ApplyUpdates<ApiResponse>? = null) = apply {
+        html(status, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun html(status: String, openApiUpdater: OpenApiUpdater<ApiResponse>? = null) = apply {
+        val documentedContent = DocumentedContent(String::class.java, false, "text/html")
+        val documentedResponse = DocumentedResponse(status, documentedContent)
+        result(documentedResponse, openApiUpdater)
+    }
+
+    // --- RESULT ---
+    inline fun <reified T> result(status: String, noinline applyUpdates: ApplyUpdates<ApiResponse>? = null) = apply {
+        result(status, T::class.java, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun result(status: String, returnType: Class<*>? = null, openApiUpdater: OpenApiUpdater<ApiResponse>? = null) = apply {
+        val documentedContent = if (returnType == null || returnType == Unit::class.java) {
+            null
+        } else {
+            DocumentedContent(returnType, false)
+        }
+        val documentedResponse = DocumentedResponse(status, documentedContent)
+        result(documentedResponse, openApiUpdater)
+    }
+
+    inline fun <reified T> result(status: String, contentType: String?, noinline applyUpdates: ApplyUpdates<ApiResponse>? = null) = apply {
+        result(status, T::class.java, contentType, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun result(status: String, returnType: Class<*>?, contentType: String?, openApiUpdater: OpenApiUpdater<ApiResponse>? = null) = apply {
+        val documentedContent = if (returnType == null || returnType == Unit::class.java) {
+            null
+        } else {
+            DocumentedContent(returnType, false, contentType)
+        }
+        val documentedResponse = DocumentedResponse(status, documentedContent)
+        result(documentedResponse, openApiUpdater)
+    }
+
+    fun result(documentedResponse: DocumentedResponse, applyUpdates: ApplyUpdates<ApiResponse>? = null) = apply {
+        result(documentedResponse, createUpdaterIfNotNull(applyUpdates))
+    }
+
+    @JvmOverloads
+    fun result(documentedResponse: DocumentedResponse, openApiUpdater: OpenApiUpdater<ApiResponse>? = null) = apply {
+        val responseUpdaterList = responseUpdaterListMapping.getOrSetDefault(documentedResponse.status, mutableListOf())
+        componentsUpdaterList.add { it.applyDocumentedResponse(documentedResponse) }
+        responseUpdaterList.add { it.applyDocumentedResponse(documentedResponse) }
+        responseUpdaterList.addIfNotNull(openApiUpdater)
+    }
+}
+
+private fun <T> MutableList<OpenApiUpdater<T>>.add(applyUpdates: ApplyUpdates<T>) {
+    val list = this
+    list.add(createUpdater(applyUpdates))
+}
+
+private fun <T> MutableList<T>.addIfNotNull(item: T?) {
+    val list = this
+    item?.let { list.add(item) }
+}
+
+private fun <K, T> MutableMap<K, T>.getOrSetDefault(key: K, default: T): T {
+    val value = this[key]
+    if (value == null) {
+        this[key] = default
+        return default
+    }
+    return value
+}

--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiUpdater.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiUpdater.kt
@@ -1,0 +1,16 @@
+package io.javalin.plugin.openapi.dsl
+
+@FunctionalInterface
+interface OpenApiUpdater<T> {
+    fun applyUpdates(value: T)
+}
+
+typealias ApplyUpdates<T> = (value: T) -> Unit
+
+fun <T> createUpdaterIfNotNull(function: ApplyUpdates<T>?) = function?.let { createUpdater(it) }
+
+fun <T> createUpdater(function: ApplyUpdates<T>) = object : OpenApiUpdater<T> {
+    override fun applyUpdates(value: T) = function(value)
+}
+
+fun <T> List<OpenApiUpdater<T>>.applyAllUpdates(value: T) = this.forEach { it.applyUpdates(value) }

--- a/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt
@@ -1,0 +1,132 @@
+package io.javalin.plugin.openapi.external
+
+import io.swagger.v3.core.converter.ModelConverters
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.examples.Example
+import io.swagger.v3.oas.models.media.*
+import io.swagger.v3.oas.models.parameters.Parameter
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+// The original functions are in https://github.com/derveloper/kotlin-openapi3-dsl/blob/master/src/main/kotlin/cc/vileda/openapi/dsl/OpenApiDsl.kt
+// I needed to create a copy of all the inline functions, as it is not possible to call kotlin inline function from java code
+
+fun <T> Components.schema(clazz: Class<T>, init: Schema<*>.() -> Unit) {
+    if (schemas == null) {
+        schemas = mutableMapOf()
+    }
+    val schema = findSchema(clazz)
+    schema!!.init()
+    schemas.put(clazz.simpleName, schema)
+}
+
+fun <T> Components.schema(clazz: Class<T>) {
+    if (schemas == null) {
+        schemas = mutableMapOf()
+    }
+    val schema = findSchema(clazz)
+    schemas.put(clazz.simpleName, schema)
+}
+
+fun <T> Parameter.schema(clazz: Class<T>, init: Schema<*>.() -> Unit) {
+    schema = findSchema(clazz)
+    schema.init()
+}
+
+fun <T> Parameter.schema(clazz: Class<T>) {
+    schema = findSchema(clazz)
+}
+
+fun <T> mediaType(clazz: Class<T>): MediaType {
+    val mediaType = MediaType()
+    val modelSchema = findSchema(clazz)
+    mediaType.schema = modelSchema
+    return mediaType
+}
+
+/**
+ * This helper is not in the original library.
+ * Because it is not possible to create a list instance of an unknown type we need a separate method for that.
+ */
+fun mediaTypeOfList(): MediaType {
+    val mediaType = MediaType()
+    val modelSchema = ArraySchema()
+    mediaType.schema = modelSchema
+    return mediaType
+}
+
+fun <T> mediaTypeRef(clazz: Class<T>): MediaType {
+    val mediaType = MediaType()
+    mediaType.schema = Schema<T>()
+    mediaType.schema.`$ref` = clazz.simpleName
+    return mediaType
+}
+
+fun <T> Content.mediaTypeRef(clazz: Class<T>, name: String) {
+    val mediaType = mediaTypeRef(clazz)
+    addMediaType(name, mediaType)
+}
+
+fun <T> Content.mediaType(clazz: Class<T>, name: String) {
+    val mediaType = mediaType(clazz)
+    addMediaType(name, mediaType)
+}
+
+fun <T> Content.mediaTypeArrayOfRef(clazz: Class<T>, name: String) {
+    val mediaTypeArray = mediaTypeOfList()
+    val mediaTypeObj = mediaTypeRef(clazz)
+    (mediaTypeArray.schema as ArraySchema).items(mediaTypeObj.schema)
+    addMediaType(name, mediaTypeArray)
+}
+
+fun <T> Content.mediaTypeArrayOf(clazz: Class<T>, name: String) {
+    val mediaTypeArray = mediaTypeOfList()
+    val mediaTypeObj = mediaType(clazz)
+    (mediaTypeArray.schema as ArraySchema).items(mediaTypeObj.schema)
+    addMediaType(name, mediaTypeArray)
+}
+
+fun <T> findSchema(clazz: Class<T>): Schema<*>? {
+    return getEnumSchema(clazz) ?: when (clazz) {
+        String::class.java -> StringSchema()
+        Boolean::class.java -> BooleanSchema()
+        java.lang.Boolean::class.java -> BooleanSchema()
+        Int::class.java -> IntegerSchema()
+        Integer::class.java -> IntegerSchema()
+        List::class.java -> ArraySchema()
+        Long::class.java -> IntegerSchema().format("int64")
+        BigDecimal::class.java -> IntegerSchema().format("")
+        Date::class.java -> DateSchema()
+        LocalDate::class.java -> DateSchema()
+        LocalDateTime::class.java -> DateTimeSchema()
+        /* BEGIN Custom classes */
+        ByteArray::class.java -> StringSchema().format("binary")
+        /* END Custom classes */
+        else -> ModelConverters.getInstance().read(clazz)[clazz.simpleName]
+    }
+}
+
+fun <T> getEnumSchema(clazz: Class<T>): Schema<*>? {
+    val values = clazz.enumConstants ?: return null
+
+    val schema = StringSchema()
+    for (enumVal in values) {
+        schema.addEnumItem(enumVal.toString())
+    }
+    return schema
+}
+
+
+fun <T> MediaType.example(clazz: Class<T>, value: T, init: Example.() -> Unit) {
+    if (examples == null) {
+        examples = mutableMapOf()
+    }
+
+    val example = Example()
+    example.value = value
+    example.init()
+    examples[clazz.simpleName] = example
+}
+

--- a/src/main/java/io/javalin/plugin/openapi/utils/extractDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/utils/extractDocumentation.kt
@@ -1,0 +1,56 @@
+package io.javalin.plugin.openapi.utils
+
+import io.javalin.core.event.HandlerMetaInfo
+import io.javalin.plugin.openapi.dsl.DocumentedHandler
+import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
+import io.javalin.plugin.openapi.annotations.OpenApi
+import io.javalin.plugin.openapi.annotations.asOpenApiDocumentation
+import java.util.logging.Logger
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.javaMethod
+
+fun HandlerMetaInfo.extractDocumentation(): OpenApiDocumentation? {
+    return if (handler is DocumentedHandler) {
+        handler.documentation
+    } else {
+        val openApiAnnotation: OpenApi? = getOpenApiAnnotationFromKotlin() ?: getOpenApiAnnotationFromJava()
+        openApiAnnotation?.asOpenApiDocumentation()
+    }
+}
+
+private fun HandlerMetaInfo.getOpenApiAnnotationFromKotlin(): OpenApi? {
+    return try {
+        // It is required to work access private fields, because kotlin wraps
+        // the lambda into a "SAM" class and we need to access the original lambda
+        // with the annotations
+        val functionValue = getFieldValue(handler, "function") as KFunction<*>
+        val javaMethod = functionValue.javaMethod!!
+        javaMethod.getAnnotation(OpenApi::class.java)
+    } catch (e: NoSuchFieldException) {
+        null
+    } catch (e: Error) {
+        return if (e::class.qualifiedName == "kotlin.reflect.jvm.internal.KotlinReflectionInternalError") {
+            Logger.getGlobal()
+                    .warning("Local functions, lambdas, anonymous functions and local variables with @OpenApi annotations are currently not supported. " +
+                            "The annotation of the handler for \"$httpMethod $path\" will be ignored. To fix this, move the handler into a global function.")
+            null
+        } else {
+            throw e
+        }
+    }
+}
+
+private fun HandlerMetaInfo.getOpenApiAnnotationFromJava(): OpenApi? {
+    return try {
+        val method = handler::class.java.getDeclaredMethod("handle")
+        method.getAnnotation(OpenApi::class.java)
+    } catch (e: NoSuchMethodException) {
+        null
+    }
+}
+
+private fun getFieldValue(obj: Any, fieldName: String): Any {
+    val field = obj::class.java.getDeclaredField(fieldName)
+    field.isAccessible = true
+    return field.get(obj)
+}

--- a/src/main/java/io/javalin/plugin/openapi/utils/openApiBuilderDSL.kt
+++ b/src/main/java/io/javalin/plugin/openapi/utils/openApiBuilderDSL.kt
@@ -1,0 +1,153 @@
+/**
+ * This file contains helper methods which convert javalin concepts
+ * to OpenApi documentation.
+ */
+package io.javalin.plugin.openapi.utils
+
+import cc.vileda.openapi.dsl.parameter
+import cc.vileda.openapi.dsl.requestBody
+import cc.vileda.openapi.dsl.response
+import cc.vileda.openapi.dsl.responses
+import io.javalin.core.PathParser
+import io.javalin.core.PathSegment
+import io.javalin.core.event.HandlerMetaInfo
+import io.javalin.http.HandlerType
+import io.javalin.plugin.openapi.dsl.applyAllUpdates
+import io.javalin.plugin.openapi.external.schema
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.PathItem
+import io.swagger.v3.oas.models.Paths
+
+fun Components.applyMetaInfoList(handlerMetaInfoList: List<HandlerMetaInfo>) {
+    handlerMetaInfoList
+            .mapNotNull { it.extractDocumentation() }
+            .flatMap { it.componentsUpdaterList }
+            .applyAllUpdates(this)
+}
+
+fun Paths.applyMetaInfoList(handlerMetaInfoList: List<HandlerMetaInfo>) {
+    handlerMetaInfoList
+            .groupBy { it.path }
+            .forEach { (url, metaInfos) ->
+                val pathParser = PathParser(url)
+                updatePath(pathParser.getOpenApiUrl()) {
+                    applyMetaInfoList(pathParser, metaInfos)
+                }
+            }
+}
+
+fun PathParser.getOpenApiUrl(): String {
+    val segmentsString = segments
+            .joinToString("/") {
+                when (it) {
+                    is PathSegment.Normal -> it.content
+                    /*
+                     * At the moment, OpenApi does not support wildcards. So we just leave it as it is.
+                     * Once it is implemented we can change this.
+                     */
+                    is PathSegment.Wildcard -> "*"
+                    is PathSegment.Parameter -> "{${it.name}}"
+                }
+            }
+    return "/$segmentsString"
+}
+
+fun PathItem.applyMetaInfoList(path: PathParser, handlerMetaInfoList: List<HandlerMetaInfo>) {
+    handlerMetaInfoList
+            .forEach { metaInfo ->
+                val pathItemHttpMethod = metaInfo.httpMethod.asPathItemHttpMethod() ?: return@forEach
+                operation(pathItemHttpMethod, Operation().apply {
+                    applyMetaInfo(path, metaInfo)
+                })
+            }
+}
+
+
+fun Operation.applyMetaInfo(path: PathParser, metaInfo: HandlerMetaInfo) {
+    operationId = metaInfo.createDefaultOperationId(path)
+    summary = metaInfo.createDefaultSummary(path)
+    if (path.pathParamNames.isNotEmpty()) {
+        path.pathParamNames.forEach { pathParamName ->
+            parameter {
+                name = pathParamName
+                `in` = "path"
+                required = true
+                schema(String::class.java)
+            }
+        }
+    }
+
+    metaInfo.extractDocumentation()?.let { documentation ->
+        documentation.parameterUpdaterListMapping
+                .values
+                .forEach { updaters ->
+                    parameter {
+                        updaters.applyAllUpdates(this)
+                    }
+                }
+
+        if (documentation.hasRequestBodies()) {
+            requestBody {
+                documentation.requestBodyList.applyAllUpdates(this)
+            }
+        }
+
+        if (documentation.hasResponses()) {
+            responses {
+                documentation.responseUpdaterListMapping
+                        .forEach { name, updater ->
+                            response(name) {
+                                updater.applyAllUpdates(this)
+                            }
+                        }
+            }
+        }
+        documentation.operationUpdaterList.applyAllUpdates(this)
+    }
+}
+
+fun HandlerType.asPathItemHttpMethod(): PathItem.HttpMethod? = when (this) {
+    HandlerType.GET -> PathItem.HttpMethod.GET
+    HandlerType.PUT -> PathItem.HttpMethod.PUT
+    HandlerType.POST -> PathItem.HttpMethod.POST
+    HandlerType.DELETE -> PathItem.HttpMethod.DELETE
+    HandlerType.OPTIONS -> PathItem.HttpMethod.OPTIONS
+    HandlerType.HEAD -> PathItem.HttpMethod.HEAD
+    HandlerType.PATCH -> PathItem.HttpMethod.PATCH
+    HandlerType.TRACE -> PathItem.HttpMethod.TRACE
+    else -> null
+}
+
+private fun HandlerMetaInfo.createDefaultOperationId(path: PathParser): String {
+    val metaInfo = this
+    val lowerCaseMethod = metaInfo.httpMethod.toString().toLowerCase()
+    val capitalizedPath = path.asReadableWords().joinToString("") { it.capitalize() }
+    return lowerCaseMethod + capitalizedPath
+}
+
+private fun HandlerMetaInfo.createDefaultSummary(path: PathParser): String {
+    val metaInfo = this
+    val capitalizedMethod = metaInfo.httpMethod.toString().toLowerCase().capitalize()
+    return (listOf(capitalizedMethod) + path.asReadableWords()).joinToString(" ") { it.trim() }
+}
+
+private fun PathParser.asReadableWords(): List<String> {
+    val words = mutableListOf<String>()
+    segments.forEach { segment ->
+        when (segment) {
+            is PathSegment.Normal -> words.add(segment.content)
+            is PathSegment.Wildcard -> words.addAll(arrayOf("with", "wildcard"))
+            is PathSegment.Parameter -> {
+                words.add("with")
+                words.add(segment.name
+                        .split("-")
+                        .map { it.toLowerCase() }
+                        .mapIndexed { index, s -> if (index > 0) s.capitalize() else s }
+                        .joinToString("")
+                )
+            }
+        }
+    }
+    return words
+}

--- a/src/main/java/io/javalin/plugin/openapi/utils/openApiUpdaterDSL.kt
+++ b/src/main/java/io/javalin/plugin/openapi/utils/openApiUpdaterDSL.kt
@@ -1,0 +1,36 @@
+/**
+ * This file contains helper methods to update openapi items without overriding the original
+ */
+package io.javalin.plugin.openapi.utils
+
+import io.swagger.v3.oas.models.*
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.parameters.RequestBody
+import io.swagger.v3.oas.models.responses.ApiResponse
+
+internal fun OpenAPI.updateComponents(apply: Components.() -> Unit) {
+    components = components ?: Components()
+    components.apply(apply)
+}
+
+internal fun OpenAPI.updatePaths(apply: Paths.() -> Unit) {
+    paths = paths ?: Paths()
+    paths.apply(apply)
+}
+
+internal fun Paths.updatePath(name: String, apply: PathItem.() -> Unit) {
+    if (get(name) == null) {
+        addPathItem(name, PathItem())
+    }
+    get(name)!!.apply(apply)
+}
+
+internal fun RequestBody.updateContent(apply: Content.() -> Unit) {
+    content = content ?: Content()
+    content.apply(apply)
+}
+
+internal fun ApiResponse.updateContent(apply: Content.() -> Unit) {
+    content = content ?: Content()
+    content.apply(apply)
+}

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -1,0 +1,285 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+package io.javalin.openapi
+
+import cc.vileda.openapi.dsl.*
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.javalin.Javalin
+import io.javalin.TestUtil
+import io.javalin.apibuilder.ApiBuilder.crud
+import io.javalin.apibuilder.CrudHandler
+import io.javalin.http.Context
+import io.javalin.plugin.json.JavalinJackson
+import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
+import io.javalin.plugin.openapi.dsl.document
+import io.javalin.plugin.openapi.dsl.documentCrud
+import io.javalin.plugin.openapi.dsl.documented
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Before
+import org.junit.Test
+
+class User(val name: String)
+
+fun createComplexExampleBaseConfiguration() = openapiDsl {
+    info {
+        title = "Example"
+        version = "1.0.0"
+    }
+    server {
+        url = "https://app.example"
+        description = "My example app"
+    }
+    paths {
+        path("/unimplemented") {
+            get {
+                summary = "This path is not implemented in javalin"
+            }
+        }
+        path("/user") {
+            description = "Some additional information for the /user endpoint"
+        }
+    }
+    components {
+        securityScheme {
+            type = SecurityScheme.Type.HTTP
+            scheme = "basic"
+        }
+    }
+    security {
+        addList("http")
+    }
+    tag {
+        name = "user"
+        description = "User operations"
+    }
+    externalDocs {
+        description = "Find more info here"
+        url = "https://external-documentation.info"
+    }
+}
+
+class TestOpenApi {
+    @Before
+    fun resetObjectMapper() {
+        JavalinJackson.configure(
+                jacksonObjectMapper()
+                        .enable(SerializationFeature.INDENT_OUTPUT)
+                        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        )
+    }
+
+    @Test
+    fun `createOpenApiSchema() work with complexExample and dsl`() {
+        val app = Javalin.create {
+            it.enableOpenApi(::createComplexExampleBaseConfiguration)
+        }
+
+        val getUserDocumentation = document()
+                .operation {
+                    it.description = "Get a specific user"
+                    it.summary = "Get current user"
+                    it.operationId = "getCurrentUser"
+                    it.deprecated = true
+                    it.addTagsItem("user")
+                }
+                .json<User>("200") {
+                    it.description = "Request successful"
+                }
+        app.get("/user", documented(getUserDocumentation) {
+            it.json(User(name = "Jim"))
+        })
+
+        val getUsersDocumentation = document()
+                .operation {
+                    it.addTagsItem("user")
+                }
+                .cookie<String>("my-cookie") {
+                    it.description = "My cookie"
+                }
+                .header<String>("x-my-header") {
+                    it.description = "My header"
+                }
+                .pathParam<String>("my-path-param") {
+                    it.description = "My path param"
+                }
+                .queryParam<String>("name") {
+                    it.description = "The name of the users you want to filter"
+                    it.required = true
+                    it.deprecated = true
+                    it.allowEmptyValue = true
+                }
+                .queryParam<Int>("age")
+                .jsonArray<User>("200")
+        app.get("/users", documented(getUsersDocumentation) {
+            val myCookie = it.cookie("my-cookie")
+            val myHeader = it.cookie("x-my-header")
+            val nameFilter = it.queryParam("name")
+            val ageFilter = it.queryParam("age")
+            it.json(listOf(User(name = "Jim")))
+        })
+
+        val getUsers2Documentation = document()
+                .operation {
+                    it.addTagsItem("user")
+                }
+                .json<Array<User>>("200")
+        app.get("/users2", documented(getUsers2Documentation) { it.json(listOf(User(name = "Jim"))) })
+
+        val putUserDocumentation = document()
+                .operation {
+                    it.addTagsItem("user")
+                }
+                .body<String> {
+                    it.description = "body description"
+                    it.required = true
+                }
+                .body<User>()
+                .bodyAsBytes()
+                .bodyAsBytes("image/png")
+        app.put("/user", documented(putUserDocumentation) {
+            val userString = it.body()
+            val user = it.bodyAsClass(User::class.java)
+            val userAsBytes = it.bodyAsBytes()
+            val userImage = it.bodyAsBytes()
+        })
+
+        val getStringDocumentation = OpenApiDocumentation()
+                .result<String>("200")
+        app.get("/string", documented(getStringDocumentation) {
+            it.result("Hello")
+        })
+
+        val getHomepageDocumentation = OpenApiDocumentation()
+                .html("200") {
+                    it.description = "My Homepage"
+                }
+        app.get("/homepage", documented(getHomepageDocumentation) {
+            it.html("<p>Hello World</p>")
+        })
+
+        val getUploadDocumentation = OpenApiDocumentation()
+                .uploadedFile("file") {
+                    it.description = "MyFile"
+                    it.required = true
+                }
+        app.get("/upload", documented(getUploadDocumentation) {
+            it.uploadedFile("file")
+        })
+
+        val getUploadsDocumentation = OpenApiDocumentation()
+                .uploadedFiles("files") {
+                    it.description = "MyFiles"
+                    it.required = true
+                }
+        app.get("/uploads", documented(getUploadsDocumentation) {
+            it.uploadedFiles("files")
+        })
+
+        val getResourcesDocumentation = OpenApiDocumentation()
+                .result<Unit>("200")
+        app.get("/resources/*", documented(getResourcesDocumentation) {})
+
+        val actual = app.createOpenAPISchema()
+
+        assertThat(actual.asJsonString()).isEqualTo(complexExampleJson)
+    }
+
+    @Test
+    fun `createOpenApiSchema() work with crudHandler and dsl`() {
+        val app = Javalin.create {
+            it.enableOpenApi { OpenAPI().info(Info().title("Example").version("1.0.0")) }
+        }
+
+        val userCrudHandlerDocumentation = documentCrud()
+                .getOne(document().json<User>("200"))
+                .getAll(document().jsonArray<User>("200"))
+
+
+        class UserCrudHandler : CrudHandler {
+            override fun getAll(ctx: Context) {
+            }
+
+            override fun getOne(ctx: Context, resourceId: String) {
+            }
+
+            override fun create(ctx: Context) {
+            }
+
+            override fun update(ctx: Context, resourceId: String) {
+            }
+
+            override fun delete(ctx: Context, resourceId: String) {
+            }
+        }
+
+        app.routes {
+            crud("users/:user-id", documented(userCrudHandlerDocumentation, UserCrudHandler()))
+        }
+
+        val actual = app.createOpenAPISchema()
+
+        assertThat(actual.asJsonString()).isEqualTo(crudExampleJson)
+    }
+
+    @Test
+    fun `createOpenApiSchema() throw error if enableOpenApi is not activated`() {
+        val app = Javalin.create()
+
+        val getUserDocumentation = document().result<User>("200")
+        app.get("/user", documented(getUserDocumentation) { it.json(User(name = "Jim")) })
+
+        app.put("/user") {}
+
+        assertThatExceptionOfType(IllegalStateException::class.java)
+                .isThrownBy {
+                    app.createOpenAPISchema()
+                }
+                .withMessage("You need to activate the \"enableOpenApi\" option before you can create the OpenAPI schema")
+    }
+
+    @Test
+    fun `enableOpenApi() provide get route if path is given`() {
+        TestUtil.test(Javalin.create {
+            it.enableOpenApi(
+                    "/docs/swagger.json",
+                    Info().apply {
+                        title = "Example"
+                        version = "1.0.0"
+                    }
+            )
+        }) { app, http ->
+            app.get("/test") {}
+
+            val actual = http.jsonGet("/docs/swagger.json").body
+
+            assertThat(actual).isEqualTo(provideRouteExampleJson)
+        }
+    }
+
+    @Test
+    fun `enableOpenApi() provide get route if path is given with baseConfiguration`() {
+        TestUtil.test(Javalin.create {
+            it.enableOpenApi("/docs/swagger.json") {
+                OpenAPI().info(Info().apply {
+                    title = "Example"
+                    version = "1.0.0"
+                })
+            }
+        }) { app, http ->
+            app.get("/test") {}
+
+            val actual = http.jsonGet("/docs/swagger.json").body
+
+            assertThat(actual).isEqualTo(provideRouteExampleJson)
+        }
+    }
+}

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -1,0 +1,199 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+package io.javalin.openapi
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.javalin.Javalin
+import io.javalin.apibuilder.ApiBuilder.crud
+import io.javalin.apibuilder.CrudHandler
+import io.javalin.http.Context
+import io.javalin.plugin.json.JavalinJackson
+import io.javalin.plugin.openapi.annotations.*
+import io.swagger.v3.oas.models.info.Info
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+// region complexExampleWithAnnotationsHandler
+@OpenApi(
+        description = "Get a specific user",
+        summary = "Get current user",
+        operationId = "getCurrentUser",
+        deprecated = true,
+        tags = ["user"],
+        responses = [
+            OpenApiResponse(status = "200", returnType = User::class, description = "Request successful")
+        ]
+)
+fun getUserHandler(ctx: Context) {
+}
+
+@OpenApi(
+        tags = ["user"],
+        cookies = [
+            OpenApiParam(name = "my-cookie", type = String::class, description = "My cookie")
+        ],
+        headers = [
+            OpenApiParam(name = "x-my-header", type = String::class, description = "My header")
+        ],
+        pathParams = [
+            OpenApiParam(name = "my-path-param", type = String::class, description = "My path param")
+        ],
+        queryParams = [
+            OpenApiParam(
+                    name = "name",
+                    type = String::class,
+                    description = "The name of the users you want to filter",
+                    required = true,
+                    deprecated = true,
+                    allowEmptyValue = true
+            ),
+            OpenApiParam(name = "age", type = Int::class)
+        ],
+        responses = [
+            OpenApiResponse(status = "200", returnType = User::class, isArray = true)
+        ]
+)
+fun getUsersHandler(ctx: Context) {
+}
+
+@OpenApi(
+        tags = ["user"],
+        responses = [
+            OpenApiResponse(status = "200", returnType = Array<User>::class)
+        ]
+)
+fun getUsers2Handler(ctx: Context) {
+}
+
+@OpenApi(
+        tags = ["user"],
+        requestBodies = [
+            OpenApiRequestBody(type = String::class, required = true, description = "body description"),
+            OpenApiRequestBody(type = User::class),
+            OpenApiRequestBody(type = ByteArray::class),
+            OpenApiRequestBody(type = ByteArray::class, contentType = "image/png")
+        ]
+)
+fun putUserHandler(ctx: Context) {
+}
+
+@OpenApi(
+        responses = [
+            OpenApiResponse(status = "200", returnType = String::class)
+        ]
+)
+fun getStringHandler(ctx: Context) {
+}
+
+@OpenApi(
+        responses = [
+            OpenApiResponse(status = "200", contentType = ContentType.HTML, description = "My Homepage")
+        ]
+)
+fun getHomepageHandler(ctx: Context) {
+}
+
+@OpenApi(
+        fileUploads = [
+            OpenApiFileUpload(name = "file", description = "MyFile", required = true)
+        ]
+)
+fun getUploadHandler(ctx: Context) {
+}
+
+@OpenApi(
+        fileUploads = [
+            OpenApiFileUpload(name = "files", description = "MyFiles", isArray = true, required = true)
+        ]
+)
+fun getUploadsHandler(ctx: Context) {
+}
+
+@OpenApi(
+        responses = [
+            OpenApiResponse(status = "200")
+        ]
+)
+fun getResources(ctx: Context) {
+}
+// endregion complexExampleWithAnnotationsHandler
+
+class TestOpenApiAnnotations {
+    @Before
+    fun resetObjectMapper() {
+        JavalinJackson.configure(
+                jacksonObjectMapper()
+                        .enable(SerializationFeature.INDENT_OUTPUT)
+                        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        )
+    }
+
+    @Test
+    fun `createOpenApiSchema() work with complexExample and annotations`() {
+        val app = Javalin.create {
+            it.enableOpenApi(::createComplexExampleBaseConfiguration)
+        }
+
+        app.get("/user", ::getUserHandler)
+        app.get("/users", ::getUsersHandler)
+        app.get("/users2", ::getUsers2Handler)
+        app.put("/user", ::putUserHandler)
+        app.get("/string", ::getStringHandler)
+        app.get("/homepage", ::getHomepageHandler)
+        app.get("/upload", ::getUploadHandler)
+        app.get("/uploads", ::getUploadsHandler)
+        app.get("/resources/*", ::getResources)
+
+        val actual = app.createOpenAPISchema()
+
+        assertThat(actual.asJsonString()).isEqualTo(complexExampleJson)
+    }
+
+    @Test
+    fun `createOpenApiSchema() work with crudHandler and annotations`() {
+        val app = Javalin.create {
+            it.enableOpenApi(Info().title("Example").version("1.0.0"))
+        }
+
+        class UserCrudHandlerWithAnnotations : CrudHandler {
+            @OpenApi(
+                    responses = [
+                        OpenApiResponse("200", returnType = User::class, isArray = true)
+                    ]
+            )
+            override fun getAll(ctx: Context) {
+            }
+
+            @OpenApi(
+                    responses = [
+                        OpenApiResponse("200", returnType = User::class)
+                    ]
+            )
+            override fun getOne(ctx: Context, resourceId: String) {
+            }
+
+            override fun create(ctx: Context) {
+            }
+
+            override fun update(ctx: Context, resourceId: String) {
+            }
+
+            override fun delete(ctx: Context, resourceId: String) {
+            }
+        }
+
+        app.routes {
+            crud("users/:user-id", UserCrudHandlerWithAnnotations())
+        }
+
+        val actual = app.createOpenAPISchema()
+
+        assertThat(actual.asJsonString()).isEqualTo(crudExampleJson)
+    }
+}

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -1,0 +1,442 @@
+/**
+ * This file contains the json definitions required for the test
+ */
+package io.javalin.openapi
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.javalin.plugin.json.JavalinJackson
+import io.swagger.v3.oas.models.OpenAPI
+import org.intellij.lang.annotations.Language
+
+fun String.formatJson(): String {
+    val node = JavalinJackson.fromJson(this, JsonNode::class.java)
+    return JavalinJackson.toJson(node)
+}
+
+fun OpenAPI.asJsonString(): String = JavalinJackson.toJson(this)
+
+// This variable is needed for the jsons. That's how I can avoid the ugly """${"$"}""".
+val ref = "\$ref"
+
+@Language("JSON")
+val userOpenApiSchema = """
+{
+   "required":[
+      "name"
+   ],
+   "type":"object",
+   "properties":{
+      "name":{
+         "type":"string"
+      }
+   }
+}
+""".formatJson()
+
+@Language("JSON")
+val complexExampleUsersGetResponsesJson = """
+{
+  "200": {
+    "description": "",
+    "content": {
+      "application/json": {
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/User"
+          }
+        }
+      }
+    }
+  }
+}
+""".formatJson()
+
+@Language("JSON")
+val provideRouteExampleJson = """
+  {
+    "openapi": "3.0.1",
+    "info": {
+      "title": "Example",
+      "version": "1.0.0"
+    },
+    "paths": {
+      "/docs/swagger.json": {
+        "get": {
+          "summary": "Get docs swagger.json",
+          "operationId": "getDocsSwagger.json"
+        }
+      },
+      "/test": {
+        "get": {
+          "summary": "Get test",
+          "operationId": "getTest"
+        }
+      }
+    },
+    "components": {}
+  }
+""".formatJson()
+
+@Language("JSON")
+val complexExampleJson = """
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Example",
+    "version": "1.0.0"
+  },
+  "externalDocs": {
+    "description": "Find more info here",
+    "url": "https://external-documentation.info"
+  },
+  "servers": [
+    {
+      "url": "https://app.example",
+      "description": "My example app"
+    }
+  ],
+  "security": [
+    {
+      "http": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "user",
+      "description": "User operations"
+    }
+  ],
+  "paths": {
+    "/unimplemented": {
+      "get": {
+        "summary": "This path is not implemented in javalin"
+      }
+    },
+    "/user": {
+      "description": "Some additional information for the /user endpoint",
+      "get": {
+        "tags": ["user"],
+        "summary": "Get current user",
+        "description": "Get a specific user",
+        "operationId": "getCurrentUser",
+        "responses": {
+          "200": {
+            "description": "Request successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Put user",
+        "operationId": "putUser",
+        "requestBody": {
+          "description": "body description",
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "image/png": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get users",
+        "operationId": "getUsers",
+        "parameters": [
+          {
+            "name": "my-cookie",
+            "in": "cookie",
+            "description": "My cookie",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-my-header",
+            "in": "header",
+            "description": "My header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "my-path-param",
+            "in": "path",
+            "description": "My path param",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name of the users you want to filter",
+            "required": true,
+            "deprecated": true,
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "age",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": $complexExampleUsersGetResponsesJson
+      }
+    },
+    "/users2": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get users2",
+        "operationId": "getUsers2",
+        "responses": $complexExampleUsersGetResponsesJson
+      }
+    },
+    "/string": {
+      "get": {
+        "summary": "Get string",
+        "operationId": "getString",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/homepage": {
+      "get": {
+        "summary": "Get homepage",
+        "operationId": "getHomepage",
+        "responses": {
+          "200": {
+            "description": "My Homepage",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/upload": {
+      "get": {
+        "summary": "Get upload",
+        "operationId": "getUpload",
+        "requestBody": {
+          "description": "MyFile",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/uploads": {
+      "get": {
+        "summary": "Get uploads",
+        "operationId": "getUploads",
+        "requestBody": {
+          "description": "MyFiles",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/resources/*": {
+      "get": {
+        "summary": "Get resources with wildcard",
+        "operationId": "getResourcesWithWildcard",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": $userOpenApiSchema
+    },
+    "securitySchemes": {
+      "http": {
+        "type": "HTTP",
+        "scheme": "basic"
+      }
+    }
+  }
+}
+""".formatJson()
+
+
+@Language("JSON")
+val crudExampleJson = """
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Example",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{user-id}": {
+      "get": {
+        "summary": "Get users with userId",
+        "operationId": "getUsersWithUserId",
+        "parameters": [
+          {
+            "name": "user-id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete users with userId",
+        "operationId": "deleteUsersWithUserId",
+        "parameters": [
+          {
+            "name": "user-id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "patch": {
+        "summary": "Patch users with userId",
+        "operationId": "patchUsersWithUserId",
+        "parameters": [
+          {
+            "name": "user-id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/users": {
+      "get": {
+        "summary": "Get users",
+        "operationId": "getUsers",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Post users",
+        "operationId": "postUsers"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": $userOpenApiSchema
+    }
+  }
+}
+""".formatJson()


### PR DESCRIPTION
I added a plugin to generate OpenApi Definitions from the Javalin Code. Examples can be found in the Test.

## Api
### Configuration
To activate the plugin, the user has to enable the configuration
```kotlin
val app = Javalin.create { config ->
    config.enableOpenApi(
        Info().title("Example").version("1.0.0")
    )
}
```

The user can give an optional path, which create a GET route to the json.
```kotlin
val app = Javalin.create { config ->
    config.enableOpenApi(
        "docs/swagger.json",
        Info().title("Example").version("1.0.0")
    )
}
```

### Usage
There is now a higher order function, that allow to decorate a handler with metadata.
For example an api like this
```kotlin
app.get("/user") { ctx ->
    val name = ctx.queryParam("name")!!
    ctx.json(User(name = name))
}
```

can be documented like the following
```kotlin
app.get("/user", documented { ctx ->
    val name = ctx.queryParam("name")!!
    ctx.json(User(name = name))
}
        .queryParam<String>("name")
        .json<User>("200") {
            it.description = "Request successful"
        }
)
```

The api of the documentation matches the context api. To provide further information, a callback can be provided which can update the OpenApi metadata (See json response in example).

I added support for the complete Javalin Api.

### Access Schema directly
I also added a method on the javalin instance, which allows to get the schema directly. 
```kotlin
val mySchema = app.createOpenAPISchema()
```

