### PR TITLE
Bugfix/579 test to show completion exception not un wrapped

### DIFF
--- a/src/main/java/io/javalin/http/JavalinServlet.kt
+++ b/src/main/java/io/javalin/http/JavalinServlet.kt
@@ -71,8 +71,7 @@ class JavalinServlet(val config: JavalinConfig) {
             if (res.isCommitted || ctx.resultStream() == null) return // nothing to write
             val resultStream = ctx.resultStream()!!
             if (res.getHeader(Header.ETAG) != null || (config.autogenerateEtags && type == HandlerType.GET)) {
-                val serverEtag = res.getHeader(Header.ETAG)
-                        ?: Util.getChecksumAndReset(resultStream) // calculate if not set
+                val serverEtag = res.getHeader(Header.ETAG) ?: Util.getChecksumAndReset(resultStream) // calculate if not set
                 res.setHeader(Header.ETAG, serverEtag)
                 if (serverEtag == req.getHeader(Header.IF_NONE_MATCH)) {
                     res.status = 304
@@ -105,10 +104,8 @@ class JavalinServlet(val config: JavalinConfig) {
             val asyncContext = req.startAsync().apply { timeout = config.asyncRequestTimeout }
             ctx.resultFuture()!!.exceptionally { throwable ->
                 if (throwable is Exception) {
-                    if (throwable is CompletionException) {
-                        if (throwable.cause is Exception) {
-                            exceptionMapper.handle(throwable.cause as Exception, ctx);
-                        }
+                    if (throwable is CompletionException && throwable.cause is Exception) {
+                            exceptionMapper.handle(throwable.cause as Exception, ctx)
                     } else {
                         exceptionMapper.handle(throwable, ctx)
                     }

--- a/src/test/java/io/javalin/TestFuture.kt
+++ b/src/test/java/io/javalin/TestFuture.kt
@@ -1,10 +1,7 @@
 package io.javalin
 
-import com.sun.xml.internal.ws.util.CompletedFuture
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.ComparisonFailure
 import org.junit.Test
-import java.lang.UnsupportedOperationException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
@@ -102,7 +99,7 @@ class TestFuture {
 
 
     private fun getFailingFuture(failure: Throwable): CompletableFuture<String> {
-        return CompletableFuture.supplyAsync({throw failure})
+        return CompletableFuture.supplyAsync({ throw failure })
     }
 
 }

--- a/src/test/java/io/javalin/TestHttpResponseExceptions.kt
+++ b/src/test/java/io/javalin/TestHttpResponseExceptions.kt
@@ -143,20 +143,6 @@ class TestHttpResponseExceptions {
     }
 
     @Test
-    fun `throwing unexpected exception in future works`() = TestUtil.test { app, http ->
-        app.get("/throwing-future-route") { ctx -> ctx.result(getUnexpectedThrowingFuture()) }
-        app.exception(CompletionException::class.java) { exception, ctx -> ctx.result(exception.cause?.message!!) }
-        assertThat(http.get("/throwing-future-route").body).isEqualTo("Unexpected message")
-    }
-
-    private fun getUnexpectedThrowingFuture() = CompletableFuture.supplyAsync {
-        if (true) {
-            throw IllegalStateException("Unexpected message")
-        }
-        "Result"
-    }
-
-    @Test
     fun `default content type affects http response errors`() = TestUtil.test(Javalin.create { it.defaultContentType = "application/json" }) { app, http ->
         app.get("/content-type") { throw ForbiddenResponse() }
         val response = http.get("/content-type")


### PR DESCRIPTION
* Add test to show failure to unwrap exception.
* Unwrap CompletionException on failure for async result.
* remove test that shows CompletionException not unwrapped.

Now unwraps completion exception on failure from async result this makes it much easier to write exception handlers as no longer need to manually unwrap the cause from the CompletionException.