### PR TITLE
[core] refactor cors, route overview and openapi to new plugin system (#577)

### DIFF
--- a/src/main/java/io/javalin/core/util/CorsPlugin.kt
+++ b/src/main/java/io/javalin/core/util/CorsPlugin.kt
@@ -1,0 +1,33 @@
+package io.javalin.core.util
+
+import io.javalin.Javalin
+import io.javalin.core.plugin.Plugin
+import io.javalin.core.security.CoreRoles
+import io.javalin.core.security.SecurityUtil.roles
+import io.javalin.http.util.CorsBeforeHandler
+import io.javalin.http.util.CorsOptionsHandler
+
+class CorsPlugin(private val origins: List<String>) : Plugin {
+    init {
+        if (origins.isEmpty()) {
+            throw IllegalArgumentException("Origins cannot be empty.")
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun forOrigins(vararg origins: String) = CorsPlugin(origins.toList())
+
+        @JvmStatic
+        fun forAllOrigins() = CorsPlugin(listOf("*"))
+    }
+
+    override fun apply(app: Javalin) {
+        if (origins.isEmpty()) {
+            return
+        }
+
+        app.before(CorsBeforeHandler(origins))
+        app.options("*", CorsOptionsHandler(), roles(CoreRoles.NO_WRAP))
+    }
+}

--- a/src/main/java/io/javalin/core/util/RouteOverviewPlugin.kt
+++ b/src/main/java/io/javalin/core/util/RouteOverviewPlugin.kt
@@ -1,0 +1,23 @@
+package io.javalin.core.util
+
+import io.javalin.Javalin
+import io.javalin.core.plugin.Plugin
+import io.javalin.core.plugin.PluginLifecycleInit
+import io.javalin.core.security.Role
+
+class RouteOverviewPlugin(
+        val config: RouteOverviewConfig
+) : Plugin, PluginLifecycleInit {
+    @JvmOverloads
+    constructor(path: String, roles: Set<Role> = setOf()) : this(RouteOverviewConfig(path, roles))
+
+    lateinit var renderer: RouteOverviewRenderer
+
+    override fun init(app: Javalin) {
+        renderer = RouteOverviewRenderer(app)
+    }
+
+    override fun apply(app: Javalin) {
+        app.get(this.config.path, renderer, this.config.roles)
+    }
+}

--- a/src/main/java/io/javalin/plugin/openapi/JavalinOpenApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/JavalinOpenApi.kt
@@ -2,6 +2,7 @@ package io.javalin.plugin.openapi
 
 import io.javalin.Javalin
 import io.javalin.core.event.HandlerMetaInfo
+import io.javalin.core.plugin.PluginNotFoundException
 import io.javalin.plugin.openapi.dsl.applyMetaInfoList
 import io.javalin.plugin.openapi.dsl.updateComponents
 import io.javalin.plugin.openapi.dsl.updatePaths
@@ -29,9 +30,12 @@ class CreateSchemaOptions(
 object JavalinOpenApi {
     @JvmStatic
     fun createSchema(javalin: Javalin): OpenAPI {
-        val handler = javalin.config.inner.openApiHandler
-        return handler?.createOpenAPISchema()
-                ?: throw IllegalStateException("You need to activate the \"enableOpenApi\" option before you can create the OpenAPI schema");
+        val handler = try {
+            javalin.config.getPlugin(OpenApiPlugin::class.java).openApiHandler
+        } catch (e: PluginNotFoundException) {
+            throw IllegalStateException("You need to register the \"OpenApiPlugin\" before you can create the OpenAPI schema")
+        }
+        return handler.createOpenAPISchema()
     }
 
     @JvmStatic

--- a/src/main/java/io/javalin/plugin/openapi/OpenApiPlugin.kt
+++ b/src/main/java/io/javalin/plugin/openapi/OpenApiPlugin.kt
@@ -1,0 +1,42 @@
+package io.javalin.plugin.openapi
+
+import io.javalin.Javalin
+import io.javalin.core.plugin.Plugin
+import io.javalin.core.plugin.PluginLifecycleInit
+import io.javalin.core.util.OptionalDependency
+import io.javalin.core.util.Util
+import io.javalin.plugin.openapi.ui.ReDocRenderer
+import io.javalin.plugin.openapi.ui.SwaggerRenderer
+
+/**
+ * Plugin for the the automatic generation of an open api schema.
+ * The schema can be extracted with [JavalinOpenApi.createSchema].
+ */
+class OpenApiPlugin(
+        private val options: OpenApiOptions
+) : Plugin, PluginLifecycleInit {
+    lateinit var openApiHandler: OpenApiHandler
+
+    override fun init(app: Javalin) {
+        openApiHandler = OpenApiHandler(app, options)
+    }
+
+    override fun apply(app: Javalin) {
+        options.path?.let { path ->
+            app.get(path, openApiHandler, options.roles)
+
+            options.swagger?.let {
+                Util.ensureDependencyPresent(OptionalDependency.SWAGGER_CORE)
+                app.get(it.path, SwaggerRenderer(options))
+            }
+
+            options.reDoc?.let {
+                app.get(it.path, ReDocRenderer(options))
+            }
+
+            if (options.swagger != null || options.reDoc != null) {
+                app.config.enableWebjars()
+            }
+        }
+    }
+}

--- a/src/test/java/io/javalin/TestConfiguration.kt
+++ b/src/test/java/io/javalin/TestConfiguration.kt
@@ -7,6 +7,7 @@
 package io.javalin
 
 import io.javalin.core.security.SecurityUtil.roles
+import io.javalin.core.util.RouteOverviewPlugin
 import io.javalin.http.staticfiles.Location
 import io.javalin.plugin.metrics.MetricsProvider
 import org.assertj.core.api.Assertions.assertThat
@@ -30,10 +31,8 @@ class TestConfiguration {
             it.defaultContentType = "text/plain"
             it.dynamicGzip = true
             it.enableCorsForAllOrigins()
-            it.enableCorsForOrigin("*", "my-origin")
             it.enableDevLogging()
-            it.enableRouteOverview("/test")
-            it.enableRouteOverview("/test", roles())
+            it.registerPlugin(RouteOverviewPlugin("/test", roles()))
             it.enableWebjars()
             it.enforceSsl = true
             it.logIfServerNotStarted = false

--- a/src/test/java/io/javalin/examples/HelloWorldSwagger.java
+++ b/src/test/java/io/javalin/examples/HelloWorldSwagger.java
@@ -11,6 +11,7 @@ import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.plugin.json.JavalinJackson;
 import io.javalin.plugin.openapi.OpenApiOptions;
+import io.javalin.plugin.openapi.OpenApiPlugin;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
@@ -31,7 +32,7 @@ public class HelloWorldSwagger {
             .swagger(new SwaggerOptions("/swagger").title("My Swagger Documentation"))
             .reDoc(new ReDocOptions("/redoc").title("My ReDoc Documentation"));
 
-        Javalin app = Javalin.create(config -> config.enableOpenApi(openApiOptions)).start(7070);
+        Javalin app = Javalin.create(config -> config.registerPlugin(new OpenApiPlugin(openApiOptions))).start(7070);
 
         app.post("/users", ExampleController::create);
 

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -25,6 +25,7 @@ import io.javalin.apibuilder.CrudHandler
 import io.javalin.http.Context
 import io.javalin.plugin.openapi.JavalinOpenApi
 import io.javalin.plugin.openapi.OpenApiOptions
+import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
 import io.javalin.plugin.openapi.dsl.document
 import io.javalin.plugin.openapi.dsl.documentCrud
@@ -80,7 +81,7 @@ class TestOpenApi {
     @Test
     fun `createSchema() work with complexExample and dsl`() {
         val app = Javalin.create {
-            it.enableOpenApi(OpenApiOptions(::createComplexExampleBaseConfiguration))
+            it.registerPlugin(OpenApiPlugin(OpenApiOptions(::createComplexExampleBaseConfiguration)))
         }
 
         val getUserDocumentation = document()
@@ -196,7 +197,7 @@ class TestOpenApi {
     @Test
     fun `createSchema() work with crudHandler and dsl`() {
         val app = Javalin.create {
-            it.enableOpenApi(OpenApiOptions { OpenAPI().info(Info().title("Example").version("1.0.0")) })
+            it.registerPlugin(OpenApiPlugin(OpenApiOptions { OpenAPI().info(Info().title("Example").version("1.0.0")) }))
         }
 
         val userCrudHandlerDocumentation = documentCrud()
@@ -243,7 +244,7 @@ class TestOpenApi {
                 .isThrownBy {
                     JavalinOpenApi.createSchema(app)
                 }
-                .withMessage("You need to activate the \"enableOpenApi\" option before you can create the OpenAPI schema")
+                .withMessage("You need to register the \"OpenApiPlugin\" before you can create the OpenAPI schema")
     }
 
     @Test
@@ -257,7 +258,7 @@ class TestOpenApi {
                     }
                 }
         val app = Javalin.create {
-            it.enableOpenApi(openApiOptions)
+            it.registerPlugin(OpenApiPlugin(openApiOptions))
         }
 
         val route2Documentation = document()
@@ -276,12 +277,12 @@ class TestOpenApi {
     @Test
     fun `enableOpenApi() provide get route if path is given`() {
         TestUtil.test(Javalin.create {
-            it.enableOpenApi(OpenApiOptions(
+            it.registerPlugin(OpenApiPlugin(OpenApiOptions(
                     Info().apply {
                         title = "Example"
                         version = "1.0.0"
                     }
-            ).path("/docs/swagger.json"))
+            ).path("/docs/swagger.json")))
         }) { app, http ->
             app.get("/test") {}
 
@@ -294,12 +295,12 @@ class TestOpenApi {
     @Test
     fun `enableOpenApi() provide get route if path is given with baseConfiguration`() {
         TestUtil.test(Javalin.create {
-            it.enableOpenApi(OpenApiOptions {
+            it.registerPlugin(OpenApiPlugin(OpenApiOptions {
                 OpenAPI().info(Info().apply {
                     title = "Example"
                     version = "1.0.0"
                 })
-            }.path("/docs/swagger.json"))
+            }.path("/docs/swagger.json")))
         }) { app, http ->
             app.get("/test") {}
 

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -12,6 +12,7 @@ import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.plugin.openapi.JavalinOpenApi
 import io.javalin.plugin.openapi.OpenApiOptions
+import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.annotations.OpenApi
 import io.javalin.plugin.openapi.annotations.OpenApiFileUpload
@@ -146,7 +147,7 @@ class TestOpenApiAnnotations {
     @Test
     fun `createOpenApiSchema() work with complexExample and annotations`() {
         val app = Javalin.create {
-            it.enableOpenApi(OpenApiOptions(::createComplexExampleBaseConfiguration))
+            it.registerPlugin(OpenApiPlugin(OpenApiOptions(::createComplexExampleBaseConfiguration)))
         }
 
         app.get("/user", ::getUserHandler)

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations_Java.java
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations_Java.java
@@ -7,6 +7,7 @@ import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.JavalinOpenApi;
 import io.javalin.plugin.openapi.OpenApiOptions;
+import io.javalin.plugin.openapi.OpenApiPlugin;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
@@ -126,7 +127,7 @@ public class TestOpenApiAnnotations_Java {
         OpenApiOptions openApiOptions = new OpenApiOptions(
             new Info().title("Example").version("1.0.0")
         );
-        Javalin app = Javalin.create(config -> config.enableOpenApi(openApiOptions));
+        Javalin app = Javalin.create(config -> config.registerPlugin(new OpenApiPlugin(openApiOptions)));
 
         app.get("/users/:user-id", new GetOneHandler());
         app.delete("/users/:user-id", new DeleteHandler());
@@ -144,7 +145,7 @@ public class TestOpenApiAnnotations_Java {
         OpenApiOptions openApiOptions = new OpenApiOptions(
             new Info().title("Example").version("1.0.0")
         );
-        Javalin app = Javalin.create(config -> config.enableOpenApi(openApiOptions));
+        Javalin app = Javalin.create(config -> config.registerPlugin(new OpenApiPlugin(openApiOptions)));
 
         app.routes(() -> ApiBuilder.crud("users/:user-id", new JavaCrudHandler()));
 

--- a/src/test/java/io/javalin/openapi/TestOpenApiUi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiUi.kt
@@ -3,6 +3,7 @@ package io.javalin.openapi
 import io.javalin.Javalin
 import io.javalin.TestUtil
 import io.javalin.plugin.openapi.OpenApiOptions
+import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.ui.ReDocOptions
 import io.javalin.plugin.openapi.ui.SwaggerOptions
 import io.swagger.v3.oas.models.info.Info
@@ -22,10 +23,10 @@ class TestOpenApiUi {
     @Test
     fun `should get swagger if activated`() {
         TestUtil.test(Javalin.create {
-            it.enableOpenApi(
+            it.registerPlugin(OpenApiPlugin(
                     createDefaultOptions()
                             .swagger(SwaggerOptions("/swagger"))
-            )
+            ))
         }) { app, http ->
             assertThat(http.get("/swagger").body).contains("<html")
         }
@@ -34,7 +35,7 @@ class TestOpenApiUi {
     @Test
     fun `should not get swagger if not activated`() {
         TestUtil.test(Javalin.create {
-            it.enableOpenApi(createDefaultOptions())
+            it.registerPlugin(OpenApiPlugin(createDefaultOptions()))
         }) { app, http ->
             assertThat(http.get("/swagger").status).isEqualTo(404)
         }
@@ -43,10 +44,10 @@ class TestOpenApiUi {
     @Test
     fun `should get reDoc if activated`() {
         TestUtil.test(Javalin.create {
-            it.enableOpenApi(
+            it.registerPlugin(OpenApiPlugin(
                     createDefaultOptions()
                             .reDoc(ReDocOptions("/redoc"))
-            )
+            ))
         }) { app, http ->
             assertThat(http.get("/redoc").body).contains("<html")
         }
@@ -55,7 +56,7 @@ class TestOpenApiUi {
     @Test
     fun `should not get reDoc if not activated`() {
         TestUtil.test(Javalin.create {
-            it.enableOpenApi(createDefaultOptions())
+            it.registerPlugin(OpenApiPlugin(createDefaultOptions()))
         }) { app, http ->
             assertThat(http.get("/redoc").status).isEqualTo(404)
         }

--- a/src/test/java/io/javalin/openapi/utils.kt
+++ b/src/test/java/io/javalin/openapi/utils.kt
@@ -5,6 +5,7 @@ package io.javalin.openapi;
 import io.javalin.Javalin
 import io.javalin.plugin.openapi.JavalinOpenApi
 import io.javalin.plugin.openapi.OpenApiOptions
+import io.javalin.plugin.openapi.OpenApiPlugin
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import org.assertj.core.api.Assertions.assertThat
@@ -15,7 +16,7 @@ fun extractSchemaForTest(initSchema: (app: Javalin) -> Unit): OpenAPI {
 }
 
 fun extractSchemaForTest(options: OpenApiOptions, initSchema: (app: Javalin) -> Unit): OpenAPI {
-    val app = Javalin.create { it.enableOpenApi(options) }
+    val app = Javalin.create { it.registerPlugin(OpenApiPlugin(options)) }
     initSchema(app)
     return JavalinOpenApi.createSchema(app)
 }

--- a/src/test/java/io/javalin/routeoverview/VisualTest.java
+++ b/src/test/java/io/javalin/routeoverview/VisualTest.java
@@ -7,6 +7,7 @@
 package io.javalin.routeoverview;
 
 import io.javalin.Javalin;
+import io.javalin.core.util.RouteOverviewPlugin;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.http.HandlerType;
@@ -30,7 +31,7 @@ public class VisualTest {
         Javalin app = Javalin.create((config) -> {
             config.contextPath = "/context-path";
             config.enableCorsForAllOrigins();
-            config.enableRouteOverview("/route-overview");
+            config.registerPlugin(new RouteOverviewPlugin("/route-overview"));
         }).start();
 
         app.get("/", ctx -> ctx.redirect("/context-path/route-overview"))

--- a/src/test/kotlin/io/javalin/examples/HelloWorldSwagger.kt
+++ b/src/test/kotlin/io/javalin/examples/HelloWorldSwagger.kt
@@ -10,6 +10,7 @@ import cc.vileda.openapi.dsl.responses
 import io.javalin.Javalin
 import io.javalin.http.Context
 import io.javalin.plugin.openapi.OpenApiOptions
+import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.dsl.document
 import io.javalin.plugin.openapi.dsl.documented
 import io.javalin.plugin.openapi.ui.ReDocOptions
@@ -75,7 +76,7 @@ fun main() {
                         response("500") { description = "Server Error" }
                     }
                 }
-        it.enableOpenApi(openApiOptions)
+        it.registerPlugin(OpenApiPlugin(openApiOptions))
     }
 
     with(app) {


### PR DESCRIPTION
@tipsy This is the first PR of refactoring. I didn't want to include everything in one PR so it doesn't get too big.

In this PR I refactored
* CORS
* RouteOverview
* OpenApi

For the last two I removed the "enable*" method from the config. I think you should use the 'registerPlugin' method for these. Just for CORS I left the "enable*" method as this feels more like a core option. Please let me know your thoughts on this change.