### PR TITLE
[openapi] add a warning if an ui is configured without the schema endpoint

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/OpenApiPlugin.kt
+++ b/src/main/java/io/javalin/plugin/openapi/OpenApiPlugin.kt
@@ -21,6 +21,13 @@ class OpenApiPlugin(private val options: OpenApiOptions) : Plugin, PluginLifecyc
     }
 
     override fun apply(app: Javalin) {
+        if (options.path == null && (options.swagger != null || options.reDoc != null)) {
+            throw IllegalStateException("""
+                Swagger or ReDoc is enabled, but there is no endpoint available for the OpenApi schema.
+                Please use the `path` option of the OpenApiPlugin to set a schema endpoint.
+            """.trimIndent().replace("\n", " "))
+        }
+
         options.path?.let { path ->
             app.get(path, openApiHandler, options.roles)
 


### PR DESCRIPTION
I tested the OpenApiPlugin on a small project and I made the mistake of not configuring an endpoint for the schema, while enabling the swagger ui. The result is, that the swagger ui won't be displayed.

As I think this is an easy error to make, I added a warning so the user will be notified about this mistake.

Feel free to update the wording. We should also consider to change this to an error.