### PR TITLE
[openapi] Fix problems with nested objects and add option to ignore endpoint

### DIFF
--- a/src/main/java/io/javalin/core/util/RouteOverviewUtil.kt
+++ b/src/main/java/io/javalin/core/util/RouteOverviewUtil.kt
@@ -12,6 +12,9 @@ import io.javalin.core.event.WsHandlerMetaInfo
 import io.javalin.core.security.Role
 import io.javalin.http.Context
 import io.javalin.http.Handler
+import io.javalin.plugin.openapi.annotations.ContentType
+import io.javalin.plugin.openapi.annotations.OpenApi
+import io.javalin.plugin.openapi.annotations.OpenApiResponse
 
 data class RouteOverviewConfig(val path: String, val roles: Set<Role>)
 
@@ -25,6 +28,12 @@ class RouteOverviewRenderer(val app: Javalin) : Handler {
         app.events { it.wsHandlerAdded { handlerInfo -> wsHandlerMetaInfoList.add(handlerInfo) } }
     }
 
+    @OpenApi(
+            summary = "Get an overview of all the routes in the application",
+            responses = [
+                OpenApiResponse("200", contentType = ContentType.HTML)
+            ]
+    )
     override fun handle(ctx: Context) {
         ctx.html(RouteOverviewUtil.createHtmlOverview(handlerMetaInfoList, wsHandlerMetaInfoList))
     }

--- a/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
+++ b/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
@@ -6,7 +6,6 @@ import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.annotations.OpenApi
-import io.javalin.plugin.openapi.annotations.OpenApiResponse
 import io.swagger.v3.oas.models.OpenAPI
 
 class OpenApiHandler(app: Javalin, val options: OpenApiOptions) : Handler {
@@ -24,11 +23,7 @@ class OpenApiHandler(app: Javalin, val options: OpenApiOptions) : Handler {
             packagePrefixesToScan = options.packagePrefixesToScan
     ))
 
-    @OpenApi(
-            responses = [
-                OpenApiResponse("200", contentType = ContentType.JSON)
-            ]
-    )
+    @OpenApi(ignore = true)
     override fun handle(ctx: Context) {
         ctx.contentType(ContentType.JSON)
         ctx.result(options.toJsonMapper.map(createOpenAPISchema()))

--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
@@ -7,6 +7,8 @@ import kotlin.reflect.KClass
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.FIELD)
 annotation class OpenApi(
+        /** Ignore the endpoint in the open api documentation */
+        val ignore: Boolean = false,
         val summary: String = NULL_STRING,
         val description: String = NULL_STRING,
         val operationId: String = NULL_STRING,

--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApiMapping.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApiMapping.kt
@@ -12,6 +12,8 @@ fun OpenApi.asOpenApiDocumentation(): OpenApiDocumentation {
     val documentation = OpenApiDocumentation()
     val annotation = this
 
+    documentation.isIgnored = annotation.ignore
+
     documentation.operation { it.applyAnnotation(annotation) }
 
     annotation.cookies.forEach { documentation.applyParamAnnotation("cookie", it) }

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedParameter.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedParameter.kt
@@ -12,5 +12,5 @@ class DocumentedParameter(
 fun Parameter.applyDocumentedParameter(documentedParameter: DocumentedParameter) {
     `in` = documentedParameter.`in`
     name = documentedParameter.name
-    schema = findSchema(documentedParameter.type)
+    schema = findSchema(documentedParameter.type)?.main
 }

--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.models.parameters.RequestBody
 import io.swagger.v3.oas.models.responses.ApiResponse
 
 class OpenApiDocumentation {
+    var isIgnored: Boolean = false
     val operationUpdaterList = mutableListOf<OpenApiUpdater<Operation>>()
     val requestBodyList = mutableListOf<OpenApiUpdater<RequestBody>>()
     val parameterUpdaterListMapping = mutableMapOf<String, MutableList<OpenApiUpdater<Parameter>>>()
@@ -19,6 +20,9 @@ class OpenApiDocumentation {
 
     fun hasRequestBodies(): Boolean = requestBodyList.isNotEmpty()
     fun hasResponses(): Boolean = responseUpdaterListMapping.values.flatten().isNotEmpty()
+
+    /** Hide the endpoint in the documentation */
+    fun ignore() = apply { isIgnored = true }
 
     // --- OPERATION ---
     fun operation(applyUpdates: ApplyUpdates<Operation>) = apply {

--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
@@ -94,7 +94,7 @@ class OpenApiDocumentation {
     fun uploadedFile(name: String, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
         val schema = ObjectSchema().apply {
             properties = mapOf(
-                    name to findSchema(ByteArray::class.java)
+                    name to findSchema(ByteArray::class.java)?.main
             )
         }
         body(schema, "multipart/form-data", openApiUpdater)
@@ -109,7 +109,7 @@ class OpenApiDocumentation {
     fun uploadedFiles(name: String, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
         val schema = ObjectSchema().apply {
             properties = mapOf(
-                    name to ArraySchema().items(findSchema(ByteArray::class.java))
+                    name to ArraySchema().items(findSchema(ByteArray::class.java)?.main)
             )
         }
         body(schema, "multipart/form-data", openApiUpdater)

--- a/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
@@ -29,6 +29,7 @@ fun Components.applyMetaInfoList(handlerMetaInfoList: List<HandlerMetaInfo>) {
 
 fun Paths.applyMetaInfoList(handlerMetaInfoList: List<HandlerMetaInfo>, options: CreateSchemaOptions) {
     handlerMetaInfoList
+            .filter { it.extractDocumentation()?.let { !it.isIgnored } ?: true }
             .groupBy { it.path }
             .forEach { (url, metaInfos) ->
                 val pathParser = PathParser(url)

--- a/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt
@@ -3,7 +3,15 @@ package io.javalin.plugin.openapi.external
 import io.swagger.v3.core.converter.ModelConverters
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.examples.Example
-import io.swagger.v3.oas.models.media.*
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.BooleanSchema
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.DateSchema
+import io.swagger.v3.oas.models.media.DateTimeSchema
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
 import io.swagger.v3.oas.models.parameters.Parameter
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -13,35 +21,33 @@ import java.util.*
 // The original functions are in https://github.com/derveloper/kotlin-openapi3-dsl/blob/master/src/main/kotlin/cc/vileda/openapi/dsl/OpenApiDsl.kt
 // I needed to create a copy of all the inline functions, as it is not possible to call kotlin inline function from java code
 
+internal fun <T> Components.schema(clazz: Class<T>) {
+    schema(clazz) {}
+}
+
 internal fun <T> Components.schema(clazz: Class<T>, init: Schema<*>.() -> Unit) {
     if (schemas == null) {
         schemas = mutableMapOf()
     }
     val schema = findSchema(clazz)
-    schema!!.init()
-    schemas.put(clazz.simpleName, schema)
-}
-
-internal fun <T> Components.schema(clazz: Class<T>) {
-    if (schemas == null) {
-        schemas = mutableMapOf()
+    schema?.main?.init()
+    schema?.all?.forEach { (key, schema) ->
+        schemas[key] = schema
     }
-    val schema = findSchema(clazz)
-    schemas.put(clazz.simpleName, schema)
 }
 
 internal fun <T> Parameter.schema(clazz: Class<T>, init: Schema<*>.() -> Unit) {
-    schema = findSchema(clazz)
+    schema = findSchema(clazz)?.main
     schema.init()
 }
 
 internal fun <T> Parameter.schema(clazz: Class<T>) {
-    schema = findSchema(clazz)
+    schema = findSchema(clazz)?.main
 }
 
 internal fun <T> mediaType(clazz: Class<T>): MediaType {
     val mediaType = MediaType()
-    val modelSchema = findSchema(clazz)
+    val modelSchema = findSchema(clazz)?.main
     mediaType.schema = modelSchema
     return mediaType
 }
@@ -88,23 +94,36 @@ internal fun <T> Content.mediaTypeArrayOf(clazz: Class<T>, name: String) {
     addMediaType(name, mediaTypeArray)
 }
 
-internal fun <T> findSchema(clazz: Class<T>): Schema<*>? {
-    return getEnumSchema(clazz) ?: when (clazz) {
-        String::class.java -> StringSchema()
-        Boolean::class.java -> BooleanSchema()
-        java.lang.Boolean::class.java -> BooleanSchema()
-        Int::class.java -> IntegerSchema()
-        Integer::class.java -> IntegerSchema()
-        List::class.java -> ArraySchema()
-        Long::class.java -> IntegerSchema().format("int64")
-        BigDecimal::class.java -> IntegerSchema().format("")
-        Date::class.java -> DateSchema()
-        LocalDate::class.java -> DateSchema()
-        LocalDateTime::class.java -> DateTimeSchema()
+internal data class FindSchemaResponse(
+        /** The main schema that is requested */
+        val main: Schema<*>,
+        /** All schemas that are used by the main schema */
+        val all: Map<String, Schema<*>> = mapOf()
+)
+
+internal fun <T> findSchema(clazz: Class<T>): FindSchemaResponse? {
+    getEnumSchema(clazz)?.let {
+        return FindSchemaResponse(it)
+    }
+    return when (clazz) {
+        String::class.java -> FindSchemaResponse(StringSchema())
+        Boolean::class.java -> FindSchemaResponse(BooleanSchema())
+        java.lang.Boolean::class.java -> FindSchemaResponse(BooleanSchema())
+        Int::class.java -> FindSchemaResponse(IntegerSchema())
+        Integer::class.java -> FindSchemaResponse(IntegerSchema())
+        List::class.java -> FindSchemaResponse(ArraySchema())
+        Long::class.java -> FindSchemaResponse(IntegerSchema().format("int64"))
+        BigDecimal::class.java -> FindSchemaResponse(IntegerSchema().format(""))
+        Date::class.java -> FindSchemaResponse(DateSchema())
+        LocalDate::class.java -> FindSchemaResponse(DateSchema())
+        LocalDateTime::class.java -> FindSchemaResponse(DateTimeSchema())
         /* BEGIN Custom classes */
-        ByteArray::class.java -> StringSchema().format("binary")
+        ByteArray::class.java -> FindSchemaResponse(StringSchema().format("binary"))
         /* END Custom classes */
-        else -> ModelConverters.getInstance().read(clazz)[clazz.simpleName]
+        else -> {
+            val schemas = ModelConverters.getInstance().readAll(clazz)
+            schemas[clazz.simpleName]?.let { FindSchemaResponse(it, schemas) }
+        }
     }
 }
 

--- a/src/main/java/io/javalin/plugin/openapi/ui/ReDocRenderer.kt
+++ b/src/main/java/io/javalin/plugin/openapi/ui/ReDocRenderer.kt
@@ -5,9 +5,7 @@ import io.javalin.core.util.Util
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.plugin.openapi.OpenApiOptions
-import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.annotations.OpenApi
-import io.javalin.plugin.openapi.annotations.OpenApiResponse
 import org.intellij.lang.annotations.Language
 
 class ReDocOptions(path: String) : OpenApiUiOptions<ReDocOptions>(path) {
@@ -15,11 +13,7 @@ class ReDocOptions(path: String) : OpenApiUiOptions<ReDocOptions>(path) {
 }
 
 internal class ReDocRenderer(private val openApiOptions: OpenApiOptions) : Handler {
-    @OpenApi(
-            responses = [
-                OpenApiResponse("200", contentType = ContentType.HTML)
-            ]
-    )
+    @OpenApi(ignore = true)
     override fun handle(ctx: Context) {
         val reDocOptions = openApiOptions.reDoc!!
         val docsPath = openApiOptions.getFullDocumentationUrl(ctx)

--- a/src/main/java/io/javalin/plugin/openapi/ui/SwaggerRenderer.kt
+++ b/src/main/java/io/javalin/plugin/openapi/ui/SwaggerRenderer.kt
@@ -5,9 +5,7 @@ import io.javalin.core.util.Util
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.plugin.openapi.OpenApiOptions
-import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.annotations.OpenApi
-import io.javalin.plugin.openapi.annotations.OpenApiResponse
 import org.intellij.lang.annotations.Language
 
 class SwaggerOptions(path: String) : OpenApiUiOptions<SwaggerOptions>(path) {
@@ -15,11 +13,7 @@ class SwaggerOptions(path: String) : OpenApiUiOptions<SwaggerOptions>(path) {
 }
 
 internal class SwaggerRenderer(private val openApiOptions: OpenApiOptions) : Handler {
-    @OpenApi(
-            responses = [
-                OpenApiResponse("200", contentType = ContentType.HTML)
-            ]
-    )
+    @OpenApi(ignore = true)
     override fun handle(ctx: Context) {
         val swaggerUiOptions = openApiOptions.swagger!!
         val docsPath = openApiOptions.getFullDocumentationUrl(ctx)

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -37,7 +37,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
 
-class User(val name: String)
+class Address(val street: String, val number: Int)
+
+class User(val name: String, val address: Address? = null)
 
 fun createComplexExampleBaseConfiguration() = openapiDsl {
     info {

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -191,6 +191,8 @@ class TestOpenApi {
                 .result<Unit>("200")
         app.get("/resources/*", documented(getResourcesDocumentation) {})
 
+        app.get("/ignored", documented(document().ignore()) {})
+
         val actual = JavalinOpenApi.createSchema(app)
 
         assertThat(actual.asJsonString()).isEqualTo(complexExampleJson)

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -124,6 +124,10 @@ fun getUploadsHandler(ctx: Context) {
 )
 fun getResources(ctx: Context) {
 }
+
+@OpenApi(ignore = true)
+fun getIgnore(ctx: Context) {
+}
 // endregion complexExampleWithAnnotationsHandler
 // region handler types
 class ClassHandler : Handler {
@@ -159,6 +163,7 @@ class TestOpenApiAnnotations {
         app.get("/upload", ::getUploadHandler)
         app.get("/uploads", ::getUploadsHandler)
         app.get("/resources/*", ::getResources)
+        app.get("/ignore", ::getIgnore)
 
         val actual = JavalinOpenApi.createSchema(app)
 

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -117,17 +117,6 @@ val provideRouteExampleJson = """
       "version": "1.0.0"
     },
     "paths": {
-      "/docs/swagger.json": {
-        "get": {
-          "summary": "Get docs swagger.json",
-          "operationId": "getDocsSwagger.json",
-          "responses" : {
-            "200" : {
-              "description" : "OK"
-            }
-          }
-        }
-      },
       "/test": {
         "get": {
           "summary": "Get test",

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -36,6 +36,29 @@ val userOpenApiSchema = """
    "properties":{
       "name":{
          "type":"string"
+      },
+      "address":{
+          "$ref": "#/components/schemas/Address"
+      }
+   }
+}
+""".formatJson()
+
+@Language("JSON")
+val addressOpenApiSchema = """
+{
+   "required": [
+      "number",
+      "street"
+   ],
+   "type":"object",
+   "properties": {
+      "street": {
+         "type": "string"
+      },
+      "number": {
+         "type": "integer",
+         "format": "int32"
       }
    }
 }
@@ -368,6 +391,7 @@ val complexExampleJson = """
   },
   "components": {
     "schemas": {
+      "Address": $addressOpenApiSchema,
       "User": $userOpenApiSchema
     },
     "securitySchemes": {
@@ -473,6 +497,7 @@ val crudExampleJson = """
   },
   "components": {
     "schemas": {
+      "Address": $addressOpenApiSchema,
       "User": $userOpenApiSchema
     }
   }
@@ -523,6 +548,7 @@ val defaultOperationExampleJson = """
   },
   "components": {
     "schemas": {
+      "Address": $addressOpenApiSchema,
       "User": $userOpenApiSchema
     }
   }


### PR DESCRIPTION
* I realised that the schema generation doesn't work correctly with nested objects, so I fixed that.
* The documentation included the path to the schema itself and the swagger ui. I don't think that they should be included in the api documentation. So I added the option to ignore specific handlers, to remove these paths.
* I added some openapi documentation to the RouteOverview
