### PR TITLE
[openapi] update api for request body and content types

### DIFF
--- a/src/main/java/io/javalin/core/util/RouteOverviewUtil.kt
+++ b/src/main/java/io/javalin/core/util/RouteOverviewUtil.kt
@@ -14,6 +14,7 @@ import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.annotations.OpenApi
+import io.javalin.plugin.openapi.annotations.OpenApiContent
 import io.javalin.plugin.openapi.annotations.OpenApiResponse
 
 data class RouteOverviewConfig(val path: String, val roles: Set<Role>)
@@ -31,7 +32,7 @@ class RouteOverviewRenderer(val app: Javalin) : Handler {
     @OpenApi(
             summary = "Get an overview of all the routes in the application",
             responses = [
-                OpenApiResponse("200", contentType = ContentType.HTML)
+                OpenApiResponse("200", content = [OpenApiContent(type = ContentType.HTML)])
             ]
     )
     override fun handle(ctx: Context) {

--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
@@ -18,7 +18,7 @@ annotation class OpenApi(
         val headers: Array<OpenApiParam> = [],
         val pathParams: Array<OpenApiParam> = [],
         val queryParams: Array<OpenApiParam> = [],
-        val requestBodies: Array<OpenApiRequestBody> = [],
+        val requestBody: OpenApiRequestBody = OpenApiRequestBody([]),
         val fileUploads: Array<OpenApiFileUpload> = [],
         val responses: Array<OpenApiResponse> = [],
         /**
@@ -36,10 +36,7 @@ annotation class OpenApi(
 @Target()
 annotation class OpenApiResponse(
         val status: String,
-        val returnType: KClass<*> = NULL_CLASS::class,
-        val contentType: String = ContentType.AUTODETECT,
-        /** Whenever the returnType should be wrapped in an array */
-        val isArray: Boolean = false,
+        val content: Array<OpenApiContent> = [],
         val description: String = NULL_STRING
 )
 
@@ -55,8 +52,7 @@ annotation class OpenApiParam(
 
 @Target()
 annotation class OpenApiRequestBody(
-        val type: KClass<*>,
-        val contentType: String = ContentType.AUTODETECT,
+        val content: Array<OpenApiContent>,
         val required: Boolean = false,
         val description: String = NULL_STRING
 )
@@ -69,6 +65,13 @@ annotation class OpenApiFileUpload(
         val required: Boolean = false
 )
 
+@Target()
+annotation class OpenApiContent(
+        val from: KClass<*> = NULL_CLASS::class,
+        /** Whenever the schema should be wrapped in an array */
+        val isArray: Boolean = false,
+        val type: String = ContentType.AUTODETECT
+)
 
 /** Null string because annotations do not support null values */
 const val NULL_STRING = "-- This string represents a null value and shouldn't be used --"
@@ -94,5 +97,6 @@ enum class HttpMethod {
 }
 
 data class PathInfo(val path: String, val method: HttpMethod)
+
 val OpenApi.pathInfo get() = PathInfo(path, method)
 

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedRequestBody.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedRequestBody.kt
@@ -4,15 +4,17 @@ import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.parameters.RequestBody
 
 class DocumentedRequestBody(
-        val content: DocumentedContent
+        val content: List<DocumentedContent>
 )
 
 fun RequestBody.applyDocumentedRequestBody(documentedRequestBody: DocumentedRequestBody) {
-    updateContent {
-        applyDocumentedContent(documentedRequestBody.content)
+    if (documentedRequestBody.content.isNotEmpty()) {
+        updateContent {
+            documentedRequestBody.content.forEach { applyDocumentedContent(it) }
+        }
     }
 }
 
 fun Components.applyDocumentedRequestBody(documentedRequestBody: DocumentedRequestBody) {
-    applyDocumentedContent(documentedRequestBody.content)
+    documentedRequestBody.content.forEach { applyDocumentedContent(it) }
 }

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedResponse.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedResponse.kt
@@ -6,22 +6,20 @@ import org.eclipse.jetty.http.HttpStatus
 
 class DocumentedResponse(
         val status: String,
-        val content: DocumentedContent?
+        val content: List<DocumentedContent>
 )
 
 fun DocumentedResponse.getStatusMessage() = status.toIntOrNull()?.let { HttpStatus.getMessage(it) } ?: ""
 
 fun ApiResponse.applyDocumentedResponse(documentedResponse: DocumentedResponse) {
-    description = documentedResponse.getStatusMessage()
-    if (documentedResponse.content != null) {
+    description = description ?: documentedResponse.getStatusMessage()
+    if (documentedResponse.content.isNotEmpty()) {
         updateContent {
-            applyDocumentedContent(documentedResponse.content)
+            documentedResponse.content.forEach { applyDocumentedContent(it) }
         }
     }
 }
 
 fun Components.applyDocumentedResponse(documentedResponse: DocumentedResponse) {
-    if (documentedResponse.content != null) {
-        applyDocumentedContent(documentedResponse.content)
-    }
+    documentedResponse.content.forEach { applyDocumentedContent(it) }
 }

--- a/src/test/java/io/javalin/examples/HelloWorldSwagger.java
+++ b/src/test/java/io/javalin/examples/HelloWorldSwagger.java
@@ -14,6 +14,7 @@ import io.javalin.plugin.openapi.OpenApiOptions;
 import io.javalin.plugin.openapi.OpenApiPlugin;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import io.javalin.plugin.openapi.ui.ReDocOptions;
@@ -49,7 +50,7 @@ class ExampleController {
             @OpenApiParam(name = "my-query-param")
         },
         responses = {
-            @OpenApiResponse(status = "201", returnType = String.class)
+            @OpenApiResponse(status = "201", content = @OpenApiContent(from = String.class))
         }
     )
     public static void create(Context ctx) {

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -30,6 +30,7 @@ import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
 import io.javalin.plugin.openapi.dsl.document
 import io.javalin.plugin.openapi.dsl.documentCrud
 import io.javalin.plugin.openapi.dsl.documented
+import io.javalin.plugin.openapi.dsl.documentedContent
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityScheme
@@ -97,6 +98,7 @@ class TestOpenApi {
                 .json<User>("200") {
                     it.description = "Request successful"
                 }
+                .result("200", documentedContent<User>("application/xml"))
         app.get("/user", documented(getUserDocumentation) {
             it.json(User(name = "Jim"))
         })
@@ -145,7 +147,8 @@ class TestOpenApi {
                     it.description = "body description"
                     it.required = true
                 }
-                .body<User>()
+                .body<User>("application/json")
+                .body<User>("application/xml")
                 .bodyAsBytes()
                 .bodyAsBytes("image/png")
         app.put("/user", documented(putUserDocumentation) {

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -15,6 +15,7 @@ import io.javalin.plugin.openapi.OpenApiOptions
 import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.annotations.OpenApi
+import io.javalin.plugin.openapi.annotations.OpenApiContent
 import io.javalin.plugin.openapi.annotations.OpenApiFileUpload
 import io.javalin.plugin.openapi.annotations.OpenApiParam
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody
@@ -29,7 +30,13 @@ import org.junit.Test
         deprecated = true,
         tags = ["user"],
         responses = [
-            OpenApiResponse(status = "200", returnType = User::class, description = "Request successful")
+            OpenApiResponse(
+                    status = "200",
+                    content = [
+                        OpenApiContent(User::class),
+                        OpenApiContent(User::class, type = "application/xml")
+                    ],
+                    description = "Request successful")
         ]
 )
 fun getUserHandler(ctx: Context) {
@@ -58,7 +65,7 @@ fun getUserHandler(ctx: Context) {
             OpenApiParam(name = "age", type = Int::class)
         ],
         responses = [
-            OpenApiResponse(status = "200", returnType = User::class, isArray = true)
+            OpenApiResponse(status = "200", content = [OpenApiContent(User::class, isArray = true)])
         ]
 )
 fun getUsersHandler(ctx: Context) {
@@ -67,7 +74,7 @@ fun getUsersHandler(ctx: Context) {
 @OpenApi(
         tags = ["user"],
         responses = [
-            OpenApiResponse(status = "200", returnType = Array<User>::class)
+            OpenApiResponse(status = "200", content = [OpenApiContent(Array<User>::class)])
         ]
 )
 fun getUsers2Handler(ctx: Context) {
@@ -75,19 +82,24 @@ fun getUsers2Handler(ctx: Context) {
 
 @OpenApi(
         tags = ["user"],
-        requestBodies = [
-            OpenApiRequestBody(type = String::class, required = true, description = "body description"),
-            OpenApiRequestBody(type = User::class),
-            OpenApiRequestBody(type = ByteArray::class),
-            OpenApiRequestBody(type = ByteArray::class, contentType = "image/png")
-        ]
+        requestBody = OpenApiRequestBody(
+                required = true,
+                description = "body description",
+                content = [
+                    OpenApiContent(String::class),
+                    OpenApiContent(User::class),
+                    OpenApiContent(User::class, type = "application/xml"),
+                    OpenApiContent(ByteArray::class),
+                    OpenApiContent(ByteArray::class, type = "image/png")
+                ]
+        )
 )
 fun putUserHandler(ctx: Context) {
 }
 
 @OpenApi(
         responses = [
-            OpenApiResponse(status = "200", returnType = String::class)
+            OpenApiResponse(status = "200", content = [OpenApiContent(String::class)])
         ]
 )
 fun getStringHandler(ctx: Context) {
@@ -95,7 +107,7 @@ fun getStringHandler(ctx: Context) {
 
 @OpenApi(
         responses = [
-            OpenApiResponse(status = "200", contentType = ContentType.HTML, description = "My Homepage")
+            OpenApiResponse(status = "200", content = [OpenApiContent(type = ContentType.HTML)], description = "My Homepage")
         ]
 )
 fun getHomepageHandler(ctx: Context) {
@@ -128,6 +140,7 @@ fun getResources(ctx: Context) {
 @OpenApi(ignore = true)
 fun getIgnore(ctx: Context) {
 }
+
 // endregion complexExampleWithAnnotationsHandler
 // region handler types
 class ClassHandler : Handler {
@@ -175,7 +188,7 @@ class TestOpenApiAnnotations {
         class UserCrudHandlerWithAnnotations : CrudHandler {
             @OpenApi(
                     responses = [
-                        OpenApiResponse("200", returnType = User::class, isArray = true)
+                        OpenApiResponse("200", content = [OpenApiContent(User::class, isArray = true)])
                     ]
             )
             override fun getAll(ctx: Context) {
@@ -183,7 +196,7 @@ class TestOpenApiAnnotations {
 
             @OpenApi(
                     responses = [
-                        OpenApiResponse("200", returnType = User::class)
+                        OpenApiResponse("200", content = [OpenApiContent(User::class)])
                     ]
             )
             override fun getOne(ctx: Context, resourceId: String) {

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations_Java.java
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations_Java.java
@@ -10,6 +10,7 @@ import io.javalin.plugin.openapi.OpenApiOptions;
 import io.javalin.plugin.openapi.OpenApiPlugin;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class JavaCrudHandler implements CrudHandler {
     @OpenApi(
         responses = {
-            @OpenApiResponse(status = "200", returnType = User.class, isArray = true)
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = User.class, isArray = true))
         }
     )
     @Override
@@ -31,7 +32,7 @@ class JavaCrudHandler implements CrudHandler {
 
     @OpenApi(
         responses = {
-            @OpenApiResponse(status = "200", returnType = User.class)
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = User.class))
         }
     )
     @Override
@@ -58,7 +59,7 @@ class JavaCrudHandler implements CrudHandler {
 class GetAllHandler implements Handler {
     @OpenApi(
         responses = {
-            @OpenApiResponse(status = "200", returnType = User.class, isArray = true)
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = User.class, isArray = true))
         }
     )
     @Override
@@ -69,7 +70,7 @@ class GetAllHandler implements Handler {
 class GetOneHandler implements Handler {
     @OpenApi(
         responses = {
-            @OpenApiResponse(status = "200", returnType = User.class)
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = User.class))
         }
     )
     @Override

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -178,6 +178,11 @@ val complexExampleJson = """
                 "schema": {
                   "$ref": "#/components/schemas/User"
                 }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
               }
             }
           }
@@ -197,6 +202,11 @@ val complexExampleJson = """
               }
             },
             "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
               "schema": {
                 "$ref": "#/components/schemas/User"
               }


### PR DESCRIPTION
@tipsy As discussed I updated the RequestBody Annotation api. I used the opportunity to provide a better abstraction for the `content` of a request or response. The updated API is a little bit more powerful. For details please check the updated tests.