### PR TITLE
[openapi] simplify default operator

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/JavalinOpenApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/JavalinOpenApi.kt
@@ -20,7 +20,7 @@ class CreateSchemaOptions(
          */
         val createBaseConfiguration: CreateBaseConfiguration,
 
-        val defaultOperation: ApplyDefaultOperation?,
+        val default: DefaultDocumentation?,
 
         val modelConverterFactory: ModelConverterFactory = JacksonModelConverterFactory,
 
@@ -45,7 +45,7 @@ object JavalinOpenApi {
         return runWithModelConverter(modelConverter) {
             baseConfiguration.apply {
                 updateComponents {
-                    applyMetaInfoList(options.handlerMetaInfoList)
+                    applyMetaInfoList(options.handlerMetaInfoList, options)
                 }
                 updatePaths {
                     applyMetaInfoList(options.handlerMetaInfoList, options)

--- a/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
+++ b/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
@@ -18,7 +18,7 @@ class OpenApiHandler(app: Javalin, val options: OpenApiOptions) : Handler {
     fun createOpenAPISchema(): OpenAPI = JavalinOpenApi.createSchema(CreateSchemaOptions(
             handlerMetaInfoList = handlerMetaInfoList,
             createBaseConfiguration = options.createBaseConfiguration,
-            defaultOperation = options.defaultOperation,
+            default = options.default,
             modelConverterFactory = options.modelConverterFactory,
             packagePrefixesToScan = options.packagePrefixesToScan
     ))

--- a/src/main/java/io/javalin/plugin/openapi/OpenApiOptions.kt
+++ b/src/main/java/io/javalin/plugin/openapi/OpenApiOptions.kt
@@ -9,7 +9,6 @@ import io.javalin.plugin.openapi.jackson.JacksonToJsonMapper
 import io.javalin.plugin.openapi.ui.ReDocOptions
 import io.javalin.plugin.openapi.ui.SwaggerOptions
 import io.swagger.v3.oas.models.OpenAPI
-import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.info.Info
 
 class OpenApiOptions constructor(val createBaseConfiguration: CreateBaseConfiguration) {
@@ -30,7 +29,7 @@ class OpenApiOptions constructor(val createBaseConfiguration: CreateBaseConfigur
      * Function that is applied to every new operation.
      * You can use this to set defaults (like a 500 response).
      */
-    var defaultOperation: ApplyDefaultOperation? = null
+    var default: DefaultDocumentation? = null
     /**
      * Creates a model converter, which converts a class to an open api schema.
      * Defaults to the jackson converter.
@@ -57,10 +56,10 @@ class OpenApiOptions constructor(val createBaseConfiguration: CreateBaseConfigur
 
     fun roles(value: Set<Role>) = apply { roles = value }
 
-    fun defaultOperation(value: ApplyDefaultOperation) = apply { defaultOperation = value }
-    fun defaultOperation(setup: (operation: Operation, documentation: OpenApiDocumentation?) -> Unit) = apply {
-        defaultOperation = object : ApplyDefaultOperation {
-            override fun setup(operation: Operation, documentation: OpenApiDocumentation?) = setup(operation, documentation)
+    fun default(value: DefaultDocumentation) = apply { default = value }
+    fun default(apply: (documentation: OpenApiDocumentation) -> Unit) = apply {
+        default = object : DefaultDocumentation {
+            override fun apply(documentation: OpenApiDocumentation) = apply(documentation)
         }
     }
 
@@ -83,6 +82,6 @@ class OpenApiOptions constructor(val createBaseConfiguration: CreateBaseConfigur
 }
 
 @FunctionalInterface
-interface ApplyDefaultOperation {
-    fun setup(operation: Operation, documentation: OpenApiDocumentation?)
+interface DefaultDocumentation {
+    fun apply(documentation: OpenApiDocumentation)
 }

--- a/src/main/java/io/javalin/plugin/openapi/dsl/extractDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/extractDocumentation.kt
@@ -1,18 +1,39 @@
 package io.javalin.plugin.openapi.dsl
 
 import io.javalin.core.event.HandlerMetaInfo
+import io.javalin.core.util.OptionalDependency
+import io.javalin.core.util.Util
 import io.javalin.core.util.lambdaField
 import io.javalin.core.util.lambdaMethod
+import io.javalin.plugin.openapi.CreateSchemaOptions
 import io.javalin.plugin.openapi.annotations.OpenApi
 import io.javalin.plugin.openapi.annotations.asOpenApiDocumentation
+import io.javalin.plugin.openapi.annotations.scanForAnnotations
 import java.util.logging.Logger
 
-fun HandlerMetaInfo.extractDocumentation(): OpenApiDocumentation? {
-    return if (handler is DocumentedHandler) {
+fun HandlerMetaInfo.extractDocumentation(options: CreateSchemaOptions): OpenApiDocumentation {
+    val documentation = if (handler is DocumentedHandler) {
         handler.documentation
     } else {
         val openApiAnnotation: OpenApi? = getOpenApiAnnotationFromReference() ?: getOpenApiAnnotationFromHandler()
         openApiAnnotation?.asOpenApiDocumentation()
+                ?: extractDocumentationWithPathScanning(options)
+                ?: document()
+    }
+
+    options.default?.apply(documentation)
+
+    return documentation
+}
+
+private fun HandlerMetaInfo.extractDocumentationWithPathScanning(options: CreateSchemaOptions): OpenApiDocumentation? {
+    if (options.packagePrefixesToScan.isEmpty()) {
+        return null
+    }
+    Util.ensureDependencyPresent(OptionalDependency.CLASS_GRAPH)
+    return getPathInfo()?.let { pathInfo ->
+        val documentationFromScan = scanForAnnotations(options.packagePrefixesToScan)
+        documentationFromScan[pathInfo]
     }
 }
 

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -12,8 +12,6 @@ import cc.vileda.openapi.dsl.info
 import cc.vileda.openapi.dsl.openapiDsl
 import cc.vileda.openapi.dsl.path
 import cc.vileda.openapi.dsl.paths
-import cc.vileda.openapi.dsl.response
-import cc.vileda.openapi.dsl.responses
 import cc.vileda.openapi.dsl.security
 import cc.vileda.openapi.dsl.securityScheme
 import cc.vileda.openapi.dsl.server
@@ -79,6 +77,8 @@ fun createComplexExampleBaseConfiguration() = openapiDsl {
         url = "https://external-documentation.info"
     }
 }
+
+data class MyError( val message: String )
 
 class TestOpenApi {
     @Test
@@ -259,9 +259,9 @@ class TestOpenApi {
         val openApiOptions = OpenApiOptions(
                 Info().title("Example").version("1.0.0")
         )
-                .defaultOperation { operation, _ ->
-                    operation.responses {
-                        response("500") { description = "Server Error" }
+                .default { documentation ->
+                    documentation.result<MyError>("500") {
+                         it.description = "Server Error"
                     }
                 }
         val app = Javalin.create {

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -517,15 +517,22 @@ val defaultOperationExampleJson = """
         "summary": "Get route1",
         "operationId": "getRoute1",
         "responses": {
-          "500": {
-            "description": "Server Error"
-          },
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MyError"
                 }
               }
             }
@@ -539,7 +546,14 @@ val defaultOperationExampleJson = """
         "operationId": "getRoute2",
         "responses": {
           "500": {
-            "description": "Server Error"
+            "description": "Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MyError"
+                }
+              }
+            }
           }
         }
       }
@@ -548,7 +562,16 @@ val defaultOperationExampleJson = """
   "components": {
     "schemas": {
       "Address": $addressOpenApiSchema,
-      "User": $userOpenApiSchema
+      "User": $userOpenApiSchema,
+      "MyError" : {
+        "required" : [ "message" ],
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string"
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/kotlin/io/javalin/examples/HelloWorldSwagger.kt
+++ b/src/test/kotlin/io/javalin/examples/HelloWorldSwagger.kt
@@ -5,10 +5,9 @@
  */
 package io.javalin.examples
 
-import cc.vileda.openapi.dsl.response
-import cc.vileda.openapi.dsl.responses
 import io.javalin.Javalin
 import io.javalin.http.Context
+import io.javalin.http.InternalServerErrorResponse
 import io.javalin.plugin.openapi.OpenApiOptions
 import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.dsl.document
@@ -71,11 +70,7 @@ fun main() {
                 .path("/swagger-docs")
                 .swagger(SwaggerOptions("/swagger").title("My Swagger Documentation"))
                 .reDoc(ReDocOptions("/redoc").title("My ReDoc Documentation"))
-                .defaultOperation { operation, _ ->
-                    operation.responses {
-                        response("500") { description = "Server Error" }
-                    }
-                }
+                .default { documentation -> documentation.json<InternalServerErrorResponse>("500") }
         it.registerPlugin(OpenApiPlugin(openApiOptions))
     }
 


### PR DESCRIPTION
The `default` option should be used to set responses that are in every request (like errors). Previously you could only configure it by manually defining the swagger definition. I updated the api so it works like the other dsl endpoints.