### PR TITLE
[openapi] Support cross-origin requests for schema

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
+++ b/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
@@ -2,6 +2,7 @@ package io.javalin.plugin.openapi
 
 import io.javalin.Javalin
 import io.javalin.core.event.HandlerMetaInfo
+import io.javalin.core.util.Header
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.plugin.openapi.annotations.ContentType
@@ -26,6 +27,8 @@ class OpenApiHandler(app: Javalin, val options: OpenApiOptions) : Handler {
     @OpenApi(ignore = true)
     override fun handle(ctx: Context) {
         ctx.contentType(ContentType.JSON)
+        ctx.header(Header.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        ctx.header(Header.ACCESS_CONTROL_ALLOW_METHODS, "GET")
         ctx.result(options.toJsonMapper.map(createOpenAPISchema()))
     }
 }

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -316,4 +316,23 @@ class TestOpenApi {
             assertThat(actual).isEqualTo(provideRouteExampleJson)
         }
     }
+
+    @Test
+    fun `enableOpenApi() provide get route that allows cross-origin GET request`() {
+        TestUtil.test(Javalin.create {
+            it.registerPlugin(OpenApiPlugin(OpenApiOptions {
+                OpenAPI().info(Info().apply {
+                    title = "Example"
+                    version = "1.0.0"
+                })
+            }.path("/docs/swagger.json")))
+        }) { app, http ->
+            app.get("/test") {}
+
+            val actualHeaders = http.jsonGet("/docs/swagger.json").headers
+
+            assertThat(actualHeaders.getFirst("Access-Control-Allow-Origin")).isEqualTo("*")
+            assertThat(actualHeaders.getFirst("Access-Control-Allow-Methods")).isEqualTo("GET")
+        }
+    }
 }


### PR DESCRIPTION
Allow cross-origin GET requests for the generated OpenApi schema. This will allow tools such as swagger-ui to render the schema remotely.