### PR TITLE
allow queryParams to optionally be null

### DIFF
--- a/src/main/java/io/javalin/core/validation/Validator.kt
+++ b/src/main/java/io/javalin/core/validation/Validator.kt
@@ -20,9 +20,9 @@ open class Validator<T>(val value: T?, val messagePrefix: String = "Value") {
         return this
     }
 
-    fun get(): T = orElseNull() ?: throw BadRequestResponse("$messagePrefix cannot be null or empty")
+    fun get(): T = getOrNull() ?: throw BadRequestResponse("$messagePrefix cannot be null or empty")
 
-    fun orElseNull(): T? = rules
+    fun getOrNull(): T? = rules
             .find { value == null || !it.test.invoke(value) }
             ?.let { throw BadRequestResponse(it.invalidMessage) }
             ?: value

--- a/src/test/java/io/javalin/TestValidation.kt
+++ b/src/test/java/io/javalin/TestValidation.kt
@@ -140,4 +140,13 @@ class TestValidation {
         assertThat(http.get("/").status).isEqualTo(HttpStatus.EXPECTATION_FAILED_417)
     }
 
+    @Test
+    fun `test optional query param value`() = TestUtil.test { app, http ->
+        app.get("/") { ctx ->
+            val myInt: Int? = ctx.queryParam<Int>("my-qp").orElseNull()
+            assertThat(myInt).isEqualTo(null)
+        }
+
+        assertThat(http.get("/").status).isEqualTo(200)
+    }
 }

--- a/src/test/java/io/javalin/TestValidation.kt
+++ b/src/test/java/io/javalin/TestValidation.kt
@@ -143,7 +143,7 @@ class TestValidation {
     @Test
     fun `test optional query param value`() = TestUtil.test { app, http ->
         app.get("/") { ctx ->
-            val myInt: Int? = ctx.queryParam<Int>("my-qp").orElseNull()
+            val myInt: Int? = ctx.queryParam<Int>("my-qp").getOrNull()
             assertThat(myInt).isEqualTo(null)
         }
 


### PR DESCRIPTION
Closes #637 

This PR adds the ability have nullable typed query params.

```
val myThing: MyThing? = context
    .queryParam<MyThing>("my_thing")
    .getOrNull()
```