### PR TITLE
Fix for pebble's issue with immutable context maps

### DIFF
--- a/src/main/java/io/javalin/http/Context.kt
+++ b/src/main/java/io/javalin/http/Context.kt
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture
 import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import kotlin.collections.HashMap
 
 /**
  * Provides access to functions for handling the request and response
@@ -436,7 +437,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
      * Determines the correct rendering-function based on the file extension.
      */
     @JvmOverloads
-    fun render(filePath: String, model: Map<String, Any?> = emptyMap()): Context {
+    fun render(filePath: String, model: Map<String, Any?> = HashMap()): Context {
         return html(JavalinRenderer.renderBasedOnExtension(filePath, model, this))
     }
 

--- a/src/main/java/io/javalin/http/Context.kt
+++ b/src/main/java/io/javalin/http/Context.kt
@@ -437,7 +437,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
      * Determines the correct rendering-function based on the file extension.
      */
     @JvmOverloads
-    fun render(filePath: String, model: Map<String, Any?> = HashMap()): Context {
+    fun render(filePath: String, model: Map<String, Any?> = mutableMapOf()): Context {
         return html(JavalinRenderer.renderBasedOnExtension(filePath, model, this))
     }
 

--- a/src/test/java/io/javalin/TestTemplates.kt
+++ b/src/test/java/io/javalin/TestTemplates.kt
@@ -97,6 +97,12 @@ class TestTemplates {
     }
 
     @Test
+    fun `pebble empty context map work`() = TestUtil.test { app, http ->
+        app.get("/hello2") { ctx -> ctx.render("templates/pebble/test-empty-context-map.peb") }
+        assertThat(http.getBody("/hello2")).isNotEqualTo("Internal server error")
+    }
+
+    @Test
     fun `pebble custom engines work`() = TestUtil.test { app, http ->
         app.get("/hello") { ctx -> ctx.render("templates/pebble/test.peb") }
         assertThat(http.getBody("/hello")).isEqualTo("<h1></h1>")

--- a/src/test/resources/templates/pebble/test-empty-context-map.peb
+++ b/src/test/resources/templates/pebble/test-empty-context-map.peb
@@ -1,0 +1,5 @@
+{% set message = 'Hello world' %}
+
+{% block content %}
+    {{ message }}
+{% endblock %}


### PR DESCRIPTION
This PR swaps the default `emptyMap()` model on the `Context.render` method with a `HashMap()`.

This fixes #644