### PR TITLE
[plugins] Configure metrics using a MeterRegistry

### DIFF
--- a/src/main/java/io/javalin/plugin/metrics/MicrometerPlugin.kt
+++ b/src/main/java/io/javalin/plugin/metrics/MicrometerPlugin.kt
@@ -4,14 +4,14 @@ import io.javalin.Javalin
 import io.javalin.core.plugin.Plugin
 import io.javalin.core.util.OptionalDependency
 import io.javalin.core.util.Util
+import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.binder.jetty.JettyServerThreadPoolMetrics
 import io.micrometer.core.instrument.binder.jetty.JettyStatisticsMetrics
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import org.eclipse.jetty.server.handler.StatisticsHandler
 
-class MicrometerPlugin @JvmOverloads constructor(val registry: CompositeMeterRegistry = Metrics.globalRegistry) : Plugin {
+class MicrometerPlugin @JvmOverloads constructor(val registry: MeterRegistry = Metrics.globalRegistry) : Plugin {
     override fun apply(app: Javalin) {
         app.server()?.server()?.let { server ->
             Util.ensureDependencyPresent(OptionalDependency.MICROMETER)


### PR DESCRIPTION
This change allows the `MicrometerPlugin` to be configured with a `MeterRegistry` making it easier to use. 

Currently the plugin can only be configured by providing a `CompositeMeterRegistry` rather than the super-type [`MeterRegistry`](https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.2.0). 

Unless a user already has a `CompositeMeterRegistry`, they need to wrap a `MeterRegistry` in one, which is inconvenient. 

Additionally, `JettyStatisticsMetrics#monitor` and `JettyServerThreadPoolMetrics#bindTo` only require an instance of a `MeterRegistry` so it appears safe to start using the super-type (unless I have overlooked something?)
