### PR TITLE
fix getOrNull error when there are rules and value is null

### DIFF
--- a/src/main/java/io/javalin/core/validation/Validator.kt
+++ b/src/main/java/io/javalin/core/validation/Validator.kt
@@ -22,10 +22,10 @@ open class Validator<T>(val value: T?, val messagePrefix: String = "Value") {
 
     fun get(): T = getOrNull() ?: throw BadRequestResponse("$messagePrefix cannot be null or empty")
 
-    fun getOrNull(): T? = rules
-            .find { value == null || !it.test.invoke(value) }
-            ?.let { throw BadRequestResponse(it.invalidMessage) }
-            ?: value
+    fun getOrNull(): T? {
+        if (value == null)  return null
+        return rules.find { !it.test.invoke(value) }?.let { throw BadRequestResponse(it.invalidMessage) } ?: value
+    }
 
     companion object {
         @JvmStatic

--- a/src/test/java/io/javalin/TestValidation.kt
+++ b/src/test/java/io/javalin/TestValidation.kt
@@ -149,4 +149,35 @@ class TestValidation {
 
         assertThat(http.get("/").status).isEqualTo(200)
     }
+
+    @Test
+    fun `test optional query param value with check`() = TestUtil.test { app, http ->
+        app.get("/") { ctx ->
+            val id: Int? = ctx.queryParam<Int>("id")
+                    .check( { it > 10 }, "id was not greater than 10")
+                    .getOrNull()
+
+            if (id != null) {
+                ctx.result(id.toString())
+            }
+        }
+
+        // Test valid param
+        http.get("/?id=20").apply {
+            assertThat(status).isEqualTo(200)
+            assertThat(body).isEqualTo("20")
+        }
+
+        // Test invalid param
+        http.get("/?id=4").apply {
+            assertThat(status).isEqualTo(400)
+            assertThat(body).isEqualTo("Query parameter 'id' with value '4' invalid - id was not greater than 10")
+        }
+
+        // test valid missing param
+        http.get("/").apply {
+            assertThat(status).isEqualTo(200)
+            assertThat(body).isEqualTo("")
+        }
+    }
 }


### PR DESCRIPTION
This may fix #655, but confirmation is required from the reporter to make sure this bug is related to their own specific issue.

If a query param validator has rules and the value is null, you would get a 400.  This fix should correctly return the null value.