### PR TITLE
671 fix static files

### DIFF
--- a/src/main/java/io/javalin/core/compression/Brotli.kt
+++ b/src/main/java/io/javalin/core/compression/Brotli.kt
@@ -2,6 +2,7 @@ package io.javalin.core.compression
 
 import org.meteogroup.jbrotli.Brotli
 import org.meteogroup.jbrotli.BrotliCompressor
+import java.io.ByteArrayOutputStream
 
 import java.io.OutputStream
 
@@ -26,11 +27,12 @@ class Brotli(val level: Int = 4) {
      * @param out The target output stream
      * @param data data to compress
      */
-    fun write(out: OutputStream, data: ByteArray) {
+    fun compress(data: ByteArrayOutputStream) : ByteArray {
         //Needed because compressing small data sets sometimes yields a bigger output than the original
-        val size = if (data.size >= 8192) data.size else 8192
+        val size = if (data.size() >= 8192) data.size() else 8192
+        val input = data.toByteArray()
         val output = ByteArray(size)
-        val compressedLength = brotliCompressor.compress(brotliParameter, data, output)
-        out.write(output.copyOfRange(0, compressedLength))
+        val compressedLength = brotliCompressor.compress(brotliParameter, input, output)
+        return output.copyOfRange(0, compressedLength)
     }
 }

--- a/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
+++ b/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
@@ -25,16 +25,6 @@ class ResponseWrapperContext(request: HttpServletRequest, val config: JavalinCon
     val compressionStrategy = config.inner.compressionStrategy
 }
 
-/**
- * Class has been changed to fix a bug introduced in Javalin 3.2.0, where file resources remained partly compressed
- * after being received by the client. See the full write-up at
- *
- * The bug was first discovered when including (and responding with) large webjars (e.g. Buefy). It was caused at line 688
- * in ResourceService.java, where jetty writes content via a buffer method rather than the usual single-pass write on line 686.
- *
- * This resulted in multiple calls to our overriden write method, and as a result, each chunk of data was
- * being compressed separately.
- */
 class OutputStreamWrapper(val res: HttpServletResponse, val rwc: ResponseWrapperContext) : ServletOutputStream() {
     val interceptedDataStream = ByteArrayOutputStream() //Dummy output stream
 

--- a/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -8,6 +8,7 @@ package io.javalin.http.staticfiles
 
 import io.javalin.Javalin
 import io.javalin.core.util.Header
+import io.javalin.http.JavalinResponseWrapper
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ResourceHandler
@@ -69,6 +70,9 @@ class JettyResourceHandler : io.javalin.http.staticfiles.ResourceHandler {
                     httpResponse.contentType = null
                     handler.handle(target, baseRequest, httpRequest, httpResponse)
                     httpRequest.setAttribute("handled-as-static-file", true)
+                    if(httpResponse is JavalinResponseWrapper ) {
+                        httpResponse.outputStream.finalizeWrite()
+                    }
                     return true
                 }
             } catch (e: Exception) { // it's fine


### PR DESCRIPTION
Tested fix with the same webjars that first caused it to surface (see #671). These are now all loading correctly.

The bug was first discovered when including (and responding with) large webjars (e.g. Buefy). It was caused at line 688 in ResourceService.java, where jetty writes content via a buffer method rather than the usual single-pass write on line 686.

This resulted in multiple calls to our overriden write method, and as a result, each chunk of data was being compressed separately.

To get around the problem, the OutputStreamWrapper class has been changed to write to a dummy object rather than the actual outputStream. This object (ByteArrayOutputStream) collects and aggregates everything that jetty and/or javalin try writing to output. 

Once all response handling by javalin/jetty is finished, we call the new finalizeWrite() method, which takes the data from the dummy object, processes it as required (compression), then copies it to the real output stream.