### PR TITLE
Add host to start

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -130,7 +130,7 @@ public class Javalin {
     /**
      * Synchronously starts the application instance on the specified host and port.
      *
-     * @param host to run on, overriding the default "localhost"
+     * @param host to run on, overriding the default "0.0.0.0"
      * @param port to run on
      * @return running application instance.
      * @see Javalin#create()

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -128,6 +128,21 @@ public class Javalin {
     }
 
     /**
+     * Synchronously starts the application instance on the specified host and port.
+     *
+     * @param host to run on, overriding the default "localhost"
+     * @param port to run on
+     * @return running application instance.
+     * @see Javalin#create()
+     * @see Javalin#start()
+     */
+    public Javalin start(String host, int port) {
+        server.setServerHost(host);
+        server.setServerPort(port);
+        return start();
+    }
+
+    /**
      * Synchronously starts the application instance.
      *
      * @return running application instance.
@@ -194,6 +209,13 @@ public class Javalin {
      */
     public int port() {
         return server.getServerPort();
+    }
+
+    /**
+     * Get which host instance is running on
+     */
+    public String host() {
+        return server.getServerHost();
     }
 
     /**

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse
 class JavalinServer(val config: JavalinConfig) {
 
     var serverPort = 7000
-    var serverHost = null
+    var serverHost: String? = null
 
     fun server(): Server {
         config.inner.server = config.inner.server ?: JettyUtil.getOrDefault(config.inner.server)

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse
 class JavalinServer(val config: JavalinConfig) {
 
     var serverPort = 7000
-    var serverHost = localhost
+    var serverHost = "localhost"
 
     fun server(): Server {
         config.inner.server = config.inner.server ?: JettyUtil.getOrDefault(config.inner.server)

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse
 class JavalinServer(val config: JavalinConfig) {
 
     var serverPort = 7000
-    var serverHost = "localhost"
+    var serverHost = null
 
     fun server(): Server {
         config.inner.server = config.inner.server ?: JettyUtil.getOrDefault(config.inner.server)
@@ -77,7 +77,7 @@ class JavalinServer(val config: JavalinConfig) {
 
         JettyUtil.reEnableJettyLogger()
         serverPort = (server().connectors[0] as? ServerConnector)?.localPort ?: -1
-        serverHost = (server().connectors[0] as? ServerConnector)?.host ?: ""
+        serverHost = (server().connectors[0] as? ServerConnector)?.host ?: null
     }
 
     private fun defaultSessionHandler() = SessionHandler().apply { httpOnly = true }

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletResponse
 class JavalinServer(val config: JavalinConfig) {
 
     var serverPort = 7000
+    var serverHost = localhost
 
     fun server(): Server {
         config.inner.server = config.inner.server ?: JettyUtil.getOrDefault(config.inner.server)
@@ -62,6 +63,7 @@ class JavalinServer(val config: JavalinConfig) {
             handler = attachJavalinHandlers(server.handler, HandlerList(httpHandler, webSocketHandler))
             connectors = connectors.takeIf { it.isNotEmpty() } ?: arrayOf(ServerConnector(server).apply {
                 this.port = serverPort
+                this.host = serverHost
             })
         }.start()
 
@@ -75,6 +77,7 @@ class JavalinServer(val config: JavalinConfig) {
 
         JettyUtil.reEnableJettyLogger()
         serverPort = (server().connectors[0] as? ServerConnector)?.localPort ?: -1
+        serverHost = (server().connectors[0] as? ServerConnector)?.host ?: ""
     }
 
     private fun defaultSessionHandler() = SessionHandler().apply { httpOnly = true }

--- a/src/test/java/io/javalin/TestCustomJetty.kt
+++ b/src/test/java/io/javalin/TestCustomJetty.kt
@@ -39,8 +39,8 @@ class TestCustomJetty {
 
     @Test
     fun `setting host works`() {
-        Javalin.create().start("http://localhost", 1234).get("/") { it.result("HOST WORKS") }
-        assertThat(Unirest.get("http://localhost:1234/").asString().body).isEqualTo("HOST WORKS")
+        Javalin.create().start("127.1.2.3", 1234).get("/") { it.result("HOST WORKS") }
+        assertThat(Unirest.get("http://127.1.2.3:1234/").asString().body).isEqualTo("HOST WORKS")
     }
 
     @Test

--- a/src/test/java/io/javalin/TestCustomJetty.kt
+++ b/src/test/java/io/javalin/TestCustomJetty.kt
@@ -38,6 +38,12 @@ class TestCustomJetty {
     }
 
     @Test
+    fun `setting host works`() {
+        Javalin.create().start("http://localhost", 1234).get("/") { it.result("HOST WORKS") }
+        assertThat(Unirest.get("http://localhost:1234/").asString().body).isEqualTo("HOST WORKS")
+    }
+
+    @Test
     fun `embedded server can have custom jetty Handler`() {
         val statisticsHandler = StatisticsHandler()
         val newServer = Server().apply { handler = statisticsHandler }


### PR DESCRIPTION
Adding a host override for the Javalin start method, for times when the server has multiple IP addresses and Javalin is only running on one.