### PR TITLE
692 fix

### DIFF
--- a/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
+++ b/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
@@ -116,7 +116,7 @@ class OutputStreamWrapper(val res: HttpServletResponse, val rwc: ResponseWrapper
         }
 
         // did we gzip? If so, finalize the gzip stream
-        if (res.getHeader(Header.CONTENT_ENCODING) == "gzip" && ::compressorOutputStream.isInitialized) {
+        if (res.getHeader(Header.CONTENT_ENCODING) == "gzip" && gzipEnabled) {
             (compressorOutputStream as LeveledGzipStream).finish()
         }
     }
@@ -127,7 +127,7 @@ class OutputStreamWrapper(val res: HttpServletResponse, val rwc: ResponseWrapper
 
     private fun setAvailableCompressors(len: Int) {
         // enable compression based on length of first write and mime type
-        if (len >= minSizeForCompression && !excludedMimeType(res.contentType ?: "")) {
+        if (len >= minSizeForCompression && !excludedMimeType(res.contentType ?: "") && res.getHeader(Header.CONTENT_ENCODING).isNullOrEmpty()) {
             brotliEnabled = rwc.accepts.contains("br", ignoreCase = true) && rwc.compressionStrategy.brotli != null
             gzipEnabled = rwc.accepts.contains("gzip", ignoreCase = true) && rwc.compressionStrategy.gzip != null
         }

--- a/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
+++ b/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
@@ -116,7 +116,7 @@ class OutputStreamWrapper(val res: HttpServletResponse, val rwc: ResponseWrapper
         }
 
         // did we gzip? If so, finalize the gzip stream
-        if (res.getHeader(Header.CONTENT_ENCODING) == "gzip") {
+        if (res.getHeader(Header.CONTENT_ENCODING) == "gzip" && ::compressorOutputStream.isInitialized) {
             (compressorOutputStream as LeveledGzipStream).finish()
         }
     }


### PR DESCRIPTION
Fix for #692 

We check if a content_encoding header already exists on first write. If it does, we never enable the compressors at all.

This way, we can rely on compression enable vars (gzipEnabled and brotliEnabled) to tell us whether or not we actually did any compression work.

If not, we just skip the steps in the finalize() code.