### PR TITLE
[Compression] Remove jBrotli and Implement Jvm-Brotli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,6 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>bintray-nitram509-jbrotli</id>
-            <name>bintray</name>
-            <url>http://dl.bintray.com/nitram509/jbrotli</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -96,9 +88,9 @@
 
         <!-- BEGIN Optional dependencies -->
         <dependency>
-            <groupId>org.meteogroup.jbrotli</groupId>
-            <artifactId>jbrotli</artifactId>
-            <version>0.5.0</version>
+            <groupId>com.nixxcode.jvmbrotli</groupId>
+            <artifactId>jvmbrotli</artifactId>
+            <version>0.2.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/io/javalin/core/compression/Brotli.kt
+++ b/src/main/java/io/javalin/core/compression/Brotli.kt
@@ -1,52 +1,11 @@
 package io.javalin.core.compression
 
-import io.javalin.core.util.Header
-import io.javalin.core.util.OptionalDependency
-import io.javalin.core.util.Util
-import org.meteogroup.jbrotli.Brotli
-import org.meteogroup.jbrotli.BrotliCompressor
-import java.io.ByteArrayOutputStream
-
-import javax.servlet.http.HttpServletResponse
-
 /**
- * Kotlin wrapper for jbrotli library.
- *
  * @param level Compression level. Higher yields better (but slower) compression. Range 0..11, default = 4
  */
 @Deprecated("WARNING: Brotli compression is an experimental feature!")
 class Brotli(val level: Int = 4) {
-
-    private val brotliCompressor: BrotliCompressor
-    private val brotliParameter: Brotli.Parameter
-
     init {
         require(level in 0..11) { "Valid range for parameter level is 0 to 11" }
-        Util.ensureDependencyPresent(OptionalDependency.JBROTLI)
-        brotliCompressor = BrotliCompressor()
-        brotliParameter = Brotli.Parameter(Brotli.DEFAULT_MODE, level, Brotli.DEFAULT_LGWIN, Brotli.DEFAULT_LGBLOCK)
-    }
-
-    /**
-     * @param out The target output stream
-     * @param data data to compress
-     */
-    fun write(res: HttpServletResponse, data: ByteArray, off: Int, len: Int) {
-        //We need a padded buffer, because compression sometimes yields a bigger output than the original
-        val paddedBufferSize = if (len >= 1024) len*2 else 2048
-        val output = ByteArray(paddedBufferSize)
-        val compressedLength = brotliCompressor.compress(brotliParameter, data, off, len, output, 0, paddedBufferSize)
-
-        if(compressedLength >= len) { //If compressed length is same or bigger, there's no point, let's just write the original
-            res.setHeader(Header.CONTENT_ENCODING, "null")
-            res.outputStream.write(data, off, len)
-        } else {
-            res.setHeader(Header.CONTENT_ENCODING, "br")
-            res.outputStream.write(output.copyOfRange(0, compressedLength))
-        }
-    }
-
-    fun write(res: HttpServletResponse, data: ByteArrayOutputStream) {
-        write(res, data.toByteArray(), 0, data.size())
     }
 }

--- a/src/main/java/io/javalin/core/compression/CompressionStrategy.kt
+++ b/src/main/java/io/javalin/core/compression/CompressionStrategy.kt
@@ -1,7 +1,9 @@
 package io.javalin.core.compression
 
+import com.nixxcode.jvmbrotli.common.BrotliLoader
 import io.javalin.Javalin
-import org.meteogroup.jbrotli.libloader.BrotliLibraryLoader
+import io.javalin.core.util.OptionalDependency
+import io.javalin.core.util.Util
 
 /**
  * This class is a settings container for Javalin's content compression.
@@ -26,29 +28,32 @@ class CompressionStrategy(brotli: Brotli? = null, gzip: Gzip? = null) {
     }
 
     init {
-        //Enabling brotli requires special handling since jbrotli libs are platform dependent
+        //Enabling brotli requires special handling since jvm-brotli is platform dependent
         this.brotli = if (brotli != null) tryLoadBrotli(brotli) else null
         this.gzip = gzip
     }
 
     /**
-     * When enabling Brotli, we try loading the jbrotli native library first.
+     * When enabling Brotli, we try loading the jvm-brotli native library first.
      * If this fails, we keep Brotli disabled and warn the user.
      */
-    private fun tryLoadBrotli(brotli: Brotli) = try {
-        BrotliLibraryLoader.loadBrotli()
-        brotli
-    } catch (t: Throwable) {
-        Javalin.log?.warn("""${"\n"}
-            Failed to enable Brotli compression, because the JBrotli native library couldn't be loaded.
-            Brotli is currently only supported on Windows, Linux and Mac OSX.
-            If you are running Javalin on a supported system, but are still getting this error,
-            try re-importing your Maven and/or Gradle dependencies. If that doesn't resolve it,
-            please create an issue at https://github.com/tipsy/javalin/
-            ---------------------------------------------------------------
-            If you still want compression, please ensure GZIP is enabled!
-            ---------------------------------------------------------------
-        """.trimIndent())
-        null
+    private fun tryLoadBrotli(brotli: Brotli) : Brotli? {
+        Util.ensureDependencyPresent(OptionalDependency.JVMBROTLI)
+        val brotliAvailable = BrotliLoader.isBrotliAvailable()
+        if (brotliAvailable) {
+            return brotli
+        } else {
+            Javalin.log?.warn("""${"\n"}
+                Failed to enable Brotli compression, because the jvm-brotli native library couldn't be loaded.
+                jvm-brotli is currently only supported on Windows, Linux and Mac OSX.
+                If you are running Javalin on a supported system, but are still getting this error,
+                try re-importing your Maven and/or Gradle dependencies. If that doesn't resolve it,
+                please create an issue at https://github.com/tipsy/javalin/
+                ---------------------------------------------------------------
+                If you still want compression, please ensure GZIP is enabled!
+                ---------------------------------------------------------------
+            """.trimIndent())
+            return null
+        }
     }
 }

--- a/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -23,6 +23,6 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
     SWAGGER_CORE("Swagger Core", "io.swagger.v3.oas.models.OpenAPI", "io.swagger.core.v3", "swagger-models", "2.0.8"),
     OPENAPI_KOTLIN_DSL("OpenAPI Kotlin DSL", "cc.vileda.openapi.dsl.OpenApiDslKt", "cc.vileda", "kotlin-openapi3-dsl", "0.20.1"),
     CLASS_GRAPH("ClassGraph", "io.github.classgraph.ClassGraph", "io.github.classgraph", "classgraph", "4.8.34"),
-    JBROTLI("JBrotli", "org.meteogroup.jbrotli.Brotli", "org.meteogroup", "jbrotli", "0.5.0"),
+    JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),
 }
 

--- a/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -25,4 +25,3 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
     CLASS_GRAPH("ClassGraph", "io.github.classgraph.ClassGraph", "io.github.classgraph", "classgraph", "4.8.34"),
     JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),
 }
-

--- a/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
+++ b/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
@@ -1,11 +1,14 @@
 package io.javalin.http
 
+import com.nixxcode.jvmbrotli.enc.BrotliOutputStream
+import com.nixxcode.jvmbrotli.enc.Encoder
 import io.javalin.core.JavalinConfig
 import io.javalin.core.util.Header
 import io.javalin.core.util.Util
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.logging.Level
 import java.util.zip.GZIPOutputStream
 import javax.servlet.ServletOutputStream
 import javax.servlet.WriteListener
@@ -44,7 +47,6 @@ class JavalinResponseWrapper(val res: HttpServletResponse, val rwc: ResponseWrap
 
 class OutputStreamWrapper(val res: HttpServletResponse, val rwc: ResponseWrapperContext) : ServletOutputStream() {
 
-    private val buffer = ByteArrayOutputStream()
     private lateinit var compressorOutputStream: OutputStream
 
     private var isFirstWrite = true
@@ -54,8 +56,6 @@ class OutputStreamWrapper(val res: HttpServletResponse, val rwc: ResponseWrapper
     companion object {
         @JvmStatic
         var minSizeForCompression = 1500 // 1500 is the size of a packet, compressing responses smaller than this serves no purpose
-        @JvmStatic
-        var maxBufferSize = 1000000 // Size limit in bytes, after which the stream buffer is flushed and any further writing is streamed
         @JvmStatic
         val excludedMimeTypes = setOf(
                 "image/",
@@ -70,38 +70,24 @@ class OutputStreamWrapper(val res: HttpServletResponse, val rwc: ResponseWrapper
                 "application/x-rar-compressed")
     }
 
-    /**
-     * Buffering is a temporary workaround for brotli, because jbrotli stream compression is currently broken.
-     * The idea is we buffer the response (up to 1 MB max by default), then compress it and send it to output.
-     * If the total content size exceeds this limit, we switch to streaming and fail over to gzip (if enabled).
-     *
-     * This should allow brotli to work for most responses, as not many will exceed 1 MB in size.
-     * Code will be refactored to full streaming once the brotli issue is fixed.
-     *
-     * Buffering only happens if brotli is enabled in compression strategy. Gzip (or uncompressed) go directly to streaming.
-     */
     override fun write(b: ByteArray, off: Int, len: Int) {
         if (isFirstWrite) { // first write
             setAvailableCompressors(len)
             isFirstWrite = false
         }
-        if (buffer.size() <= maxBufferSize && brotliEnabled) { // size limit not exceeded, so we write all output to the stream buffer
-            buffer.write(b, off, len)
-            if (buffer.size() > maxBufferSize) {
-                // Size limit has just been exceeded, flush the buffer and switch to streaming
-                streamToOutput(buffer.toByteArray(), 0, buffer.size())
-            }
-        } else {
-            streamToOutput(b, off, len)
-        }
-    }
 
-    private fun streamToOutput(b: ByteArray, off: Int, len: Int) {
         when {
-            gzipEnabled -> { // Gzip only for now while streaming, as Brotli stream compression currently doesn't work
+            brotliEnabled -> {
+                if (res.getHeader(Header.CONTENT_ENCODING) != "br") {
+                    res.setHeader(Header.CONTENT_ENCODING, "br")
+                    compressorOutputStream = LeveledBrotliStream(res.outputStream, rwc.compressionStrategy.brotli!!.level)
+                }
+                (compressorOutputStream as LeveledBrotliStream).write(b, off, len)
+            }
+            gzipEnabled -> {
                 if (res.getHeader(Header.CONTENT_ENCODING) != "gzip") {
                     res.setHeader(Header.CONTENT_ENCODING, "gzip")
-                    compressorOutputStream = LeveledGzipStream(res.outputStream, rwc.compressionStrategy.gzip?.level ?: -1)
+                    compressorOutputStream = LeveledGzipStream(res.outputStream, rwc.compressionStrategy.gzip!!.level)
                 }
                 (compressorOutputStream as LeveledGzipStream).write(b, off, len)
             }
@@ -109,26 +95,21 @@ class OutputStreamWrapper(val res: HttpServletResponse, val rwc: ResponseWrapper
         }
     }
 
+    // If we used compression, finalize the stream
     fun finalize() {
-        if (buffer.size() < maxBufferSize && brotliEnabled) { // compress and output the buffer
-            writeBrotliToOutput()
-            return
+        if (res.getHeader(Header.CONTENT_ENCODING) == "br" && brotliEnabled) {
+            (compressorOutputStream as BrotliOutputStream).close()
         }
-
-        // did we gzip? If so, finalize the gzip stream
         if (res.getHeader(Header.CONTENT_ENCODING) == "gzip" && gzipEnabled) {
             (compressorOutputStream as LeveledGzipStream).finish()
         }
-    }
-
-    private fun writeBrotliToOutput() {
-        rwc.config.inner.compressionStrategy.brotli?.write(res, buffer)
     }
 
     private fun setAvailableCompressors(len: Int) {
         // enable compression based on length of first write and mime type
         if (len >= minSizeForCompression && !excludedMimeType(res.contentType ?: "") && res.getHeader(Header.CONTENT_ENCODING).isNullOrEmpty()) {
             brotliEnabled = rwc.accepts.contains("br", ignoreCase = true) && rwc.compressionStrategy.brotli != null
+            if (brotliEnabled) return
             gzipEnabled = rwc.accepts.contains("gzip", ignoreCase = true) && rwc.compressionStrategy.gzip != null
         }
     }
@@ -152,3 +133,5 @@ class LeveledGzipStream(out: OutputStream, level: Int) : GZIPOutputStream(out) {
         this.def.setLevel(level)
     }
 }
+
+class LeveledBrotliStream(out: OutputStream, level: Int) : BrotliOutputStream(out, Encoder.Parameters().setQuality(level))

--- a/src/test/java/io/javalin/TestCompression.kt
+++ b/src/test/java/io/javalin/TestCompression.kt
@@ -7,6 +7,8 @@
 package io.javalin
 
 import com.mashape.unirest.http.Unirest
+import com.nixxcode.jvmbrotli.common.BrotliLoader
+import com.nixxcode.jvmbrotli.dec.BrotliInputStream
 import io.javalin.core.compression.Brotli
 import io.javalin.core.compression.Gzip
 import io.javalin.core.util.FileUtil
@@ -21,8 +23,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
-import org.meteogroup.jbrotli.io.BrotliInputStream
-import org.meteogroup.jbrotli.libloader.BrotliLibraryLoader
 import java.util.zip.GZIPInputStream
 
 class TestCompression {
@@ -36,7 +36,6 @@ class TestCompression {
     @Before
     fun reset() {
         OutputStreamWrapper.minSizeForCompression = testDocument.length
-        OutputStreamWrapper.maxBufferSize = 1000000
     }
 
     val fullCompressionApp by lazy {
@@ -221,6 +220,7 @@ class TestCompression {
 
     @Test
     fun `brotli works for large static files`() {
+        assumeTrue(tryLoadBrotli())
         val path = "/webjars/swagger-ui/${OptionalDependency.SWAGGERUI.version}/swagger-ui-bundle.js"
         val compressedWebjars = Javalin.create {
             it.compressionStrategy(Brotli(4), Gzip(6))
@@ -232,21 +232,8 @@ class TestCompression {
     }
 
     @Test
-    fun `compression fails over to gzip for large static files`() {
-        assumeTrue(tryLoadBrotli())
-        val path = "/webjars/swagger-ui/${OptionalDependency.SWAGGERUI.version}/swagger-ui-bundle.js"
-        val compressedWebJars = Javalin.create {
-            it.compressionStrategy(Brotli(4), Gzip(6)) // brotli must be enabled to test failover
-            it.enableWebjars()
-        }
-        TestUtil.test(compressedWebJars) { _, http ->
-            OutputStreamWrapper.maxBufferSize = 50000 // Set buffer size limit lower than the file we're getting, to test failover to gzip
-            assertValidGzipResponse(http.origin, path)
-        }
-    }
-
-    @Test
     fun `brotli works for dynamic responses of different sizes`() {
+        assumeTrue(tryLoadBrotli())
         val repeats = listOf(10, 100, 1000, 10_000)
         val brotliApp = Javalin.create { it.compressionStrategy(Brotli(4), Gzip(6)) }
         repeats.forEach { n -> brotliApp.get("/$n") { it.result(testDocument.repeat(n)) } }
@@ -341,10 +328,6 @@ class TestCompression {
                 .execute()
     }
 
-    private fun tryLoadBrotli() = try {
-        BrotliLibraryLoader.loadBrotli()
-        true
-    } catch (t: Throwable) {
-        false
-    }
+    private fun tryLoadBrotli() = BrotliLoader.isBrotliAvailable()
+
 }

--- a/src/test/java/io/javalin/TestCompression.kt
+++ b/src/test/java/io/javalin/TestCompression.kt
@@ -99,7 +99,7 @@ class TestCompression {
 
     @Test
     fun `does brotli when size is big and Accept header is set`() = TestUtil.test(fullCompressionApp) { _, http ->
-        assumeTrue(tryLoadBrotli())
+        assumeTrue(BrotliLoader.isBrotliAvailable())
         assertThat(Unirest.get(http.origin + "/huge").asString().body.length).isEqualTo(hugeLength)
         assertThat(getResponse(http.origin, "/huge", "br").headers().get(Header.CONTENT_ENCODING)).isEqualTo("br")
         assertThat(getResponse(http.origin, "/huge", "br").body()!!.contentLength()).isEqualTo(2235L) // hardcoded because lazy
@@ -132,7 +132,7 @@ class TestCompression {
 
     @Test
     fun `does brotli when both enabled and supported`() = TestUtil.test(fullCompressionApp) { _, http ->
-        assumeTrue(tryLoadBrotli())
+        assumeTrue(BrotliLoader.isBrotliAvailable())
         val res = getResponse(http.origin, "/huge", "br, gzip")
         assertThat(res.headers().get(Header.CONTENT_ENCODING)).isEqualTo("br")
 
@@ -220,7 +220,7 @@ class TestCompression {
 
     @Test
     fun `brotli works for large static files`() {
-        assumeTrue(tryLoadBrotli())
+        assumeTrue(BrotliLoader.isBrotliAvailable())
         val path = "/webjars/swagger-ui/${OptionalDependency.SWAGGERUI.version}/swagger-ui-bundle.js"
         val compressedWebjars = Javalin.create {
             it.compressionStrategy(Brotli(4), Gzip(6))
@@ -233,7 +233,7 @@ class TestCompression {
 
     @Test
     fun `brotli works for dynamic responses of different sizes`() {
-        assumeTrue(tryLoadBrotli())
+        assumeTrue(BrotliLoader.isBrotliAvailable())
         val repeats = listOf(10, 100, 1000, 10_000)
         val brotliApp = Javalin.create { it.compressionStrategy(Brotli(4), Gzip(6)) }
         repeats.forEach { n -> brotliApp.get("/$n") { it.result(testDocument.repeat(n)) } }
@@ -327,7 +327,5 @@ class TestCompression {
                 .build())
                 .execute()
     }
-
-    private fun tryLoadBrotli() = BrotliLoader.isBrotliAvailable()
 
 }


### PR DESCRIPTION
pom.xml:
- jBrotli repository and dependency removed.
- Jvm-Brotli optional dependency added

Brotli.kt:
- Has been changed in line with the corresponding Gzip.kt class. A lot of unnecessary code has been removed.

CompressionStrategy.kt:
- Minor structural changes to tryLoadBrotli() method, to accommodate the fact jvm-brotli returns true/false when querying Brotli availability.
- Added optional dependency check to tryLoadBrotli()

OptionalDependency.kt
- Replaced jBrotli with Jvm-Brotli

JavalinResponseWrapper.kt:
- The buffer workaround and all corresponding variables have been removed. The Brotli code has been brought in line with that of Gzip.
- When initializing the compressor on first write, only one is initialized now. We no longer need both Gzip and Brotli initialized, since Brotli streaming works and no failover is needed.

TestCompression.kt:
- tryLoadBrotli() method has been removed. Brotli-dependent test code now simply calls BrotliLoader.isBrotliAvailable()
- Removed Brotli to Gzip failover test, since it was part of the workaround and is no longer required