### PR TITLE
Yamlmapper

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
+++ b/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
@@ -17,7 +17,7 @@ object JacksonToJsonMapper : ToJsonMapper {
 
 
 object JacksonToYamlMapper : ToJsonMapper {
-    val objectMapper by lazy { Yaml.pretty() }
+    val objectMapper by lazy { Yaml.mapper() }
 
-    override fun map(obj: Any): String = objectMapper.writeValueAsString(obj)
+    override fun map(obj: Any): String = Yaml.pretty(obj)
 }

--- a/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
+++ b/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
@@ -3,6 +3,7 @@ package io.javalin.plugin.openapi.jackson
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.javalin.plugin.json.ToJsonMapper
+import io.swagger.v3.core.util.Yaml
 
 /**
  * Default jackson mapper for creating the object api schema json.
@@ -10,6 +11,13 @@ import io.javalin.plugin.json.ToJsonMapper
  */
 object JacksonToJsonMapper : ToJsonMapper {
     val objectMapper by lazy { jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL) }
+
+    override fun map(obj: Any): String = objectMapper.writeValueAsString(obj)
+}
+
+
+object JacksonToYamlMapper : ToJsonMapper {
+    val objectMapper by lazy { Yaml.pretty() }
 
     override fun map(obj: Any): String = objectMapper.writeValueAsString(obj)
 }

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.SerializationFeature
 import io.javalin.plugin.json.JavalinJackson
 import io.javalin.plugin.openapi.jackson.JacksonToJsonMapper
+import io.javalin.plugin.openapi.jackson.JacksonToYamlMapper
 import io.swagger.v3.oas.models.OpenAPI
 import org.intellij.lang.annotations.Language
 
@@ -22,6 +23,13 @@ fun String.formatJson(): String {
 }
 
 fun OpenAPI.asJsonString(): String = JacksonToJsonMapper.map(this)
+
+fun String.createYamlFromJson(): String {
+    val node = JavalinJackson.fromJson(this, JsonNode::class.java)
+    return JacksonToYamlMapper.map(node)
+}
+
+fun OpenAPI.asYamlString(): String = JacksonToYamlMapper.map(this)
 
 // This variable is needed for the jsons. That's how I can avoid the ugly """${"$"}""".
 val ref = "\$ref"

--- a/src/test/java/io/javalin/openapi/utils.kt
+++ b/src/test/java/io/javalin/openapi/utils.kt
@@ -10,9 +10,11 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import org.assertj.core.api.Assertions.assertThat
 
+
+val OPENAPI_OPTION_BASIC = OpenApiOptions(Info().title("Example").version("1.0.0"))
+
 fun extractSchemaForTest(initSchema: (app: Javalin) -> Unit): OpenAPI {
-    val options = OpenApiOptions(Info().title("Example").version("1.0.0"))
-    return extractSchemaForTest(options, initSchema)
+    return extractSchemaForTest(OPENAPI_OPTION_BASIC, initSchema)
 }
 
 fun extractSchemaForTest(options: OpenApiOptions, initSchema: (app: Javalin) -> Unit): OpenAPI {


### PR DESCRIPTION
The other thing.... but I found a discrepancy, json-mapper maps enums to their name, shoudl they be mapped to their value? see the failing test { actual: type: http, expected: type: HTTP} when mapping enum  io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP