### PR TITLE
Fixed security scheme to specification

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
+++ b/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
@@ -1,15 +1,31 @@
 package io.javalin.plugin.openapi.jackson
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.javalin.plugin.json.ToJsonMapper
+import io.swagger.v3.oas.models.security.SecurityScheme
 
 /**
  * Default jackson mapper for creating the object api schema json.
  * This enables some of the options that are required to work with the uis.
  */
 object JacksonToJsonMapper : ToJsonMapper {
-    val objectMapper by lazy { jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL) }
+    val objectMapper by lazy {
+        jacksonObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .registerModule(SimpleModule().addSerializer(SecurityScheme.Type::class.java, EnumToStringSerializer()))
+                .registerModule(SimpleModule().addSerializer(SecurityScheme.In::class.java, EnumToStringSerializer()))
+    }
 
     override fun map(obj: Any): String = objectMapper.writeValueAsString(obj)
+}
+
+class EnumToStringSerializer<E : Enum<E>> : StdSerializer<E>(null as Class<E>?) {
+    override fun serialize(value: E, jgen: JsonGenerator, provider: SerializerProvider) {
+        jgen.writeString(value.toString())
+    }
 }

--- a/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
+++ b/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
@@ -1,10 +1,8 @@
 package io.javalin.plugin.openapi.jackson
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.javalin.plugin.json.ToJsonMapper
 import io.swagger.v3.oas.models.security.SecurityScheme
@@ -18,15 +16,9 @@ object JacksonToJsonMapper : ToJsonMapper {
         jacksonObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .registerModule(SimpleModule()
-                        .addSerializer(SecurityScheme.Type::class.java, EnumToStringSerializer())
-                        .addSerializer(SecurityScheme.In::class.java, EnumToStringSerializer()))
+                        .addSerializer(SecurityScheme.Type::class.java, ToStringSerializer())
+                        .addSerializer(SecurityScheme.In::class.java, ToStringSerializer()))
     }
 
     override fun map(obj: Any): String = objectMapper.writeValueAsString(obj)
-}
-
-class EnumToStringSerializer<E : Enum<E>> : StdSerializer<E>(null as Class<E>?) {
-    override fun serialize(value: E, jgen: JsonGenerator, provider: SerializerProvider) {
-        jgen.writeString(value.toString())
-    }
 }

--- a/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
+++ b/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
@@ -17,8 +17,9 @@ object JacksonToJsonMapper : ToJsonMapper {
     val objectMapper by lazy {
         jacksonObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .registerModule(SimpleModule().addSerializer(SecurityScheme.Type::class.java, EnumToStringSerializer()))
-                .registerModule(SimpleModule().addSerializer(SecurityScheme.In::class.java, EnumToStringSerializer()))
+                .registerModule(SimpleModule()
+                        .addSerializer(SecurityScheme.Type::class.java, EnumToStringSerializer())
+                        .addSerializer(SecurityScheme.In::class.java, EnumToStringSerializer()))
     }
 
     override fun map(obj: Any): String = objectMapper.writeValueAsString(obj)

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -64,9 +64,15 @@ fun createComplexExampleBaseConfiguration() = openapiDsl {
             type = SecurityScheme.Type.HTTP
             scheme = "basic"
         }
+        securityScheme {
+            type = SecurityScheme.Type.APIKEY
+            `in` = SecurityScheme.In.COOKIE
+            name = "token"
+        }
     }
     security {
         addList("http")
+        addList("token")
     }
     tag {
         name = "user"
@@ -210,7 +216,6 @@ class TestOpenApi {
         val userCrudHandlerDocumentation = documentCrud()
                 .getOne(document().json<User>("200"))
                 .getAll(document().jsonArray<User>("200"))
-
 
         class UserCrudHandler : CrudHandler {
             override fun getAll(ctx: Context) {

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -146,7 +146,6 @@ val simpleExampleWithMultipleGets = """
   }
 """.formatJson()
 
-
 @Language("JSON")
 val simpleExampleWithMultipleHttpMethods = """
   {
@@ -221,11 +220,10 @@ val complexExampleJson = """
       "description": "My example app"
     }
   ],
-  "security": [
-    {
-      "http": []
-    }
-  ],
+  "security" : [ {
+    "http" : [ ],
+    "token" : [ ]
+  } ],
   "tags": [
     {
       "name": "user",
@@ -468,10 +466,15 @@ val complexExampleJson = """
       "Address": $addressOpenApiSchema,
       "User": $userOpenApiSchema
     },
-    "securitySchemes": {
-      "http": {
-        "type": "HTTP",
-        "scheme": "basic"
+    "securitySchemes" : {
+      "http" : {
+        "type" : "http",
+        "scheme" : "basic"
+      },
+      "apiKey" : {
+        "type" : "apiKey",
+        "name" : "token",
+        "in" : "cookie"
       }
     }
   }


### PR DESCRIPTION
Actual implementation of the OpenApi Security Scheme (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#securitySchemeObject) is incorrect. For example "apiKey" is incorrectly serialized in json (actual code produces "APIKEY"). Test also fixed.