### PR TITLE
OpenApi default response

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
@@ -92,7 +92,16 @@ fun Operation.applyMetaInfo(options: CreateSchemaOptions, path: PathParser, meta
         }
     }
 
-    if (documentation.hasResponses()) {
+    if (!documentation.hasResponses()) {
+        updateResponses {
+            updateResponse("200") {
+                this.description(
+                    "This endpoint currently has no documented responses, since OpenApi requires a response" +
+                            " which should be successful, this documentation was automatically generated"
+                )
+            }
+        }
+    } else {
         updateResponses {
             documentation.responseUpdaterListMapping
                     .forEach { name, updater ->
@@ -102,6 +111,7 @@ fun Operation.applyMetaInfo(options: CreateSchemaOptions, path: PathParser, meta
                     }
         }
     }
+
     documentation.operationUpdaterList.applyAllUpdates(this)
 }
 

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -194,7 +194,12 @@ val provideRouteExampleJson = """
       "/test": {
         "get": {
           "summary": "Get test",
-          "operationId": "getTest"
+          "operationId": "getTest",
+          "responses" : {
+            "200" : {
+              "description" : "This endpoint currently has no documented responses, since OpenApi requires a response which should be successful, this documentation was automatically generated"
+            }
+          }
         }
       }
     },
@@ -298,6 +303,11 @@ val complexExampleJson = """
             }
           },
           "required": true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "This endpoint currently has no documented responses, since OpenApi requires a response which should be successful, this documentation was automatically generated"
+          }
         }
       }
     },
@@ -420,6 +430,11 @@ val complexExampleJson = """
             }
           },
           "required": true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "This endpoint currently has no documented responses, since OpenApi requires a response which should be successful, this documentation was automatically generated"
+          }
         }
       }
     },
@@ -446,6 +461,11 @@ val complexExampleJson = """
             }
           },
           "required": true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "This endpoint currently has no documented responses, since OpenApi requires a response which should be successful, this documentation was automatically generated"
+          }
         }
       }
     },
@@ -529,7 +549,12 @@ val crudExampleJson = """
               "type": "string"
             }
           }
-        ]
+        ],
+        "responses" : {
+          "200" : {
+            "description" : "This endpoint currently has no documented responses, since OpenApi requires a response which should be successful, this documentation was automatically generated"
+          }
+        }
       },
       "patch": {
         "summary": "Patch users with userId",
@@ -543,7 +568,12 @@ val crudExampleJson = """
               "type": "string"
             }
           }
-        ]
+        ],
+        "responses" : {
+          "200" : {
+            "description" : "This endpoint currently has no documented responses, since OpenApi requires a response which should be successful, this documentation was automatically generated"
+          }
+        }
       }
     },
     "/users": {
@@ -568,7 +598,12 @@ val crudExampleJson = """
       },
       "post": {
         "summary": "Post users",
-        "operationId": "postUsers"
+        "operationId": "postUsers",
+        "responses" : {
+          "200" : {
+            "description" : "This endpoint currently has no documented responses, since OpenApi requires a response which should be successful, this documentation was automatically generated"
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
Currently this is not applied to Documentation created with `OpenApiOptions(createInitialConfiguration: () -> OpenAPI)` because default summary, description, etc... is also not applied.

@TobiasWalle 
Is this a bug or a feature?