### PR TITLE
Add GitHub Actions based ci. Fixes #730

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,12 @@ jobs:
         java_version: [1.8, 11]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up JDK ${{ matrix.java_version }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java_version }}
-    - name: Build with Maven
-      run: mvn package --file pom.xml
+      - uses: actions/checkout@v1
+      - name: Set up JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java_version }}
+      - name: Make Maven wrapper executable
+        run: chmod +x ./mvnw
+      - name: Build with Maven
+        run: ./mvnw package --file pom.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java_version: [1.8, 11]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK ${{ matrix.java_version }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java_version }}
+    - name: Build with Maven
+      run: mvn package --file pom.xml

--- a/src/main/java/io/javalin/plugin/rendering/vue/JavalinVue.kt
+++ b/src/main/java/io/javalin/plugin/rendering/vue/JavalinVue.kt
@@ -75,7 +75,7 @@ class VueComponent(private val component: String) : Handler {
 object PathMaster {
     private val fileSystem by lazy { FileSystems.newFileSystem(PathMaster::class.java.getResource("").toURI(), emptyMap<String, Any>()) }
     fun classpathPath(path: String): Path = when {
-        PathMaster::class.java.getResource("").toURI().scheme == "jar" -> fileSystem.getPath(path)
+        PathMaster::class.java.getResource(path).toURI().scheme == "jar" -> fileSystem.getPath(path)
         else -> Paths.get(PathMaster::class.java.getResource(path).toURI())
     }
 }


### PR DESCRIPTION
I found some time to test out GitHub Actions and I think they are a worthy replacement for Travis.
The code will be tested on the latest Ubuntu with Java 8 and Java 11.
I tested the changes on my Javalin Rocker example repository as well.
The current run time for the Javalin repository is close to 4 minutes (3m 54s).
 
Open points:
- Do we need to test other operating systems like Windows and MacOS?
- Do we need to test a wider selection of java versions?

One disadvantage I found is the missing dependency cache. GitHub aims to fix this by November. Source: https://github.community/t5/GitHub-Actions/Caching-files-between-GitHub-Action-executions/td-p/29445

@tipsy Do you want me to remove TravisCI with this pull request as well?
