### PR TITLE
Fix pebble maven coordinates in dependency suggestion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.mitchellbosecke</groupId>
+            <groupId>io.pebbletemplates</groupId>
             <artifactId>pebble</artifactId>
-            <version>2.4.0</version>
+            <version>3.1.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -14,7 +14,7 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
     THYMELEAF("Thymeleaf", "org.thymeleaf.TemplateEngine", "org.thymeleaf", "thymeleaf", "3.0.9.RELEASE"),
     MUSTACHE("Mustache", "com.github.mustachejava.MustacheFactory", "com.github.spullara.mustache.java", "compiler", "0.9.5"),
     JTWIG("Jtwig", "org.jtwig.environment.EnvironmentConfiguration", "org.jtwig", "jtwig-core", "5.87.0.RELEASE"),
-    PEBBLE("Pebble", "com.mitchellbosecke.pebble.PebbleEngine", "com.mitchellbosecke", "pebble", "2.4.0"),
+    PEBBLE("Pebble", "com.mitchellbosecke.pebble.PebbleEngine", "io.pebbletemplates", "pebble", "3.1.0"),
     COMMONMARK("Commonmark", "org.commonmark.renderer.html.HtmlRenderer", "com.atlassian.commonmark", "commonmark", "0.11.0"),
     SLF4JSIMPLE("Slf4j simple", "org.slf4j.impl.StaticLoggerBinder", "org.slf4j", "slf4j-simple", "1.7.26"),
     MICROMETER("Micrometer", "io.micrometer.core.instrument.Metrics", "io.micrometer", "micrometer-core", "1.1.3"),


### PR DESCRIPTION
The `groupId` changed from `com.mitchellbosecke` to `io.pebbletemplates`. I also updated the version and ran a simple manual test to confirm that it still works.

I also thought about updating [missingDependencyMessage](https://github.com/tipsy/javalin/blob/0c3732ca127b1632b7ba47b662cf1bd807f8d865/src/main/java/io/javalin/core/util/Util.kt#L56) to something like this (making it a bit more future proof, recommending to run with old dependencies is not great security wise):

```kotlin
internal fun missingDependencyMessage(dependency: OptionalDependency) = """|
        |-------------------------------------------------------------------
        |Missing dependency '${dependency.displayName}'. Add the dependency.
        |
        |pom.xml:
        |<dependency>
        |    <groupId>${dependency.groupId}</groupId>
        |    <artifactId>${dependency.artifactId}</artifactId>
        |    <version>${dependency.version}</version>
        |</dependency>
        |
        |build.gradle:
        |compile "${dependency.groupId}:${dependency.artifactId}:${dependency.version}"
        |
        |Also check the latest version here:
        |https://search.maven.org/search?q=${URLEncoder.encode("g:" + dependency.groupId + " AND a:" + dependency.artifactId, "UTF-8")}
        |-------------------------------------------------------------------""".trimMargin()
```
The above will result in a URL like this: https://search.maven.org/search?q=g:io.pebbletemplates%20AND%20a:pebble

Should I add it to this PR?