### PR TITLE
Recommend latest version in missing dependency message

### DIFF
--- a/src/main/java/io/javalin/core/util/Util.kt
+++ b/src/main/java/io/javalin/core/util/Util.kt
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
 import java.net.URL
+import java.net.URLEncoder
 import java.util.*
 import java.util.zip.Adler32
 import java.util.zip.CheckedInputStream
@@ -66,6 +67,9 @@ object Util {
             |
             |build.gradle:
             |compile "${dependency.groupId}:${dependency.artifactId}:${dependency.version}"
+            |
+            |Find the latest version here:
+            |https://search.maven.org/search?q=${URLEncoder.encode("g:" + dependency.groupId + " AND a:" + dependency.artifactId, "UTF-8")}
             |-------------------------------------------------------------------""".trimMargin()
 
     fun pathToList(pathString: String): List<String> = pathString.split("/").filter { it.isNotEmpty() }


### PR DESCRIPTION
As mentioned in https://github.com/tipsy/javalin/pull/767, this adds a hyperlink to the missing dependency message to allow developers to easily find the latest version (not every IDE has hints for this).

Example output:

```
-------------------------------------------------------------------
Missing dependency 'Jtwig'. Add the dependency.

pom.xml:
<dependency>
    <groupId>org.jtwig</groupId>
    <artifactId>jtwig-core</artifactId>
    <version>5.87.0.RELEASE</version>
</dependency>

build.gradle:
compile "org.jtwig:jtwig-core:5.87.0.RELEASE"

Find the latest version here:
https://search.maven.org/search?q=g%3Aorg.jtwig+AND+a%3Ajtwig-core
-------------------------------------------------------------------
```