### PR TITLE
Add the ability to set the bind host IP (like "0.0.0.0")

### DIFF
--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -123,13 +123,18 @@ public class Javalin {
     }
 
     /**
-     * Set the host IP to bind to. This defaults to "0.0.0.0" meaning any local IP.
+     * Synchronously starts the application instance on the specified port
+     * with the given host IP to bind to.
      *
      * @param host The host IP to bind to
+     * @param port to run on
+     * @return running application instance.
+     * @see Javalin#create()
+     * @see Javalin#start()
      */
-    public Javalin host(String host) {
+    public Javalin start(String host, int port) {
         server.setServerHost(host);
-        return this;
+        return start(port);
     }
 
     /**

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -123,8 +123,7 @@ public class Javalin {
     }
 
     /**
-     * Set the host to bind to. Often we want to set the host
-     * to "0.0.0.0" when running as docker container.
+     * Set the host IP to bind to. This defaults to "0.0.0.0" meaning any local IP.
      *
      * @param host The host IP to bind to
      */

--- a/src/main/java/io/javalin/Javalin.java
+++ b/src/main/java/io/javalin/Javalin.java
@@ -123,6 +123,17 @@ public class Javalin {
     }
 
     /**
+     * Set the host to bind to. Often we want to set the host
+     * to "0.0.0.0" when running as docker container.
+     *
+     * @param host The host IP to bind to
+     */
+    public Javalin host(String host) {
+        server.setServerHost(host);
+        return this;
+    }
+
+    /**
      * Synchronously starts the application instance on the specified port.
      *
      * @param port to run on

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletResponse
 
 class JavalinServer(val config: JavalinConfig) {
 
-    var serverHost: String? = null
+    var serverHost: String = "0.0.0.0"
     var serverPort = 7000
 
     fun server(): Server {
@@ -67,9 +67,7 @@ class JavalinServer(val config: JavalinConfig) {
             handler = attachJavalinHandlers(server.handler, HandlerList(httpHandler, webSocketHandler))
             connectors = connectors.takeIf { it.isNotEmpty() } ?: arrayOf(ServerConnector(server).apply {
                 this.port = serverPort
-                serverHost?.let {
-                    this.host = serverHost
-                }
+                this.host = serverHost
             })
         }.start()
 

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -32,11 +32,7 @@ import javax.servlet.http.HttpServletResponse
 class JavalinServer(val config: JavalinConfig) {
 
     var serverPort = 7000
-    var serverHost: String = defaultHost()
-
-    private fun defaultHost(): String {
-        return InetSocketAddress(serverPort).hostName
-    }
+    var serverHost: String = InetSocketAddress(serverPort).hostName
 
     fun server(): Server {
         config.inner.server = config.inner.server ?: JettyUtil.getOrDefault(config.inner.server)

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -25,13 +25,18 @@ import org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS
 import org.eclipse.jetty.servlet.ServletHolder
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 import java.net.BindException
+import java.net.InetSocketAddress
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 class JavalinServer(val config: JavalinConfig) {
 
-    var serverHost: String = "0.0.0.0"
     var serverPort = 7000
+    var serverHost: String = defaultHost()
+
+    private fun defaultHost(): String {
+        return InetSocketAddress(serverPort).hostName
+    }
 
     fun server(): Server {
         config.inner.server = config.inner.server ?: JettyUtil.getOrDefault(config.inner.server)

--- a/src/main/java/io/javalin/core/JavalinServer.kt
+++ b/src/main/java/io/javalin/core/JavalinServer.kt
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletResponse
 
 class JavalinServer(val config: JavalinConfig) {
 
+    var serverHost: String? = null
     var serverPort = 7000
 
     fun server(): Server {
@@ -66,6 +67,9 @@ class JavalinServer(val config: JavalinConfig) {
             handler = attachJavalinHandlers(server.handler, HandlerList(httpHandler, webSocketHandler))
             connectors = connectors.takeIf { it.isNotEmpty() } ?: arrayOf(ServerConnector(server).apply {
                 this.port = serverPort
+                serverHost?.let {
+                    this.host = serverHost
+                }
             })
         }.start()
 

--- a/src/test/java/io/javalin/TestCustomJetty.kt
+++ b/src/test/java/io/javalin/TestCustomJetty.kt
@@ -38,14 +38,16 @@ class TestCustomJetty {
 
     @Test
     fun `setting port works`() {
-        Javalin.create().start(1234).get("/") { it.result("PORT WORKS") }
+        val app = Javalin.create().start(1234).get("/") { it.result("PORT WORKS") }
         assertThat(Unirest.get("http://localhost:1234/").asString().body).isEqualTo("PORT WORKS")
+        app.stop()
     }
 
     @Test
     fun `setting host works`() {
-        Javalin.create().host("127.1.2.3").start(1235).get("/") { it.result("HOST WORKS") }
+        val app = Javalin.create().host("127.1.2.3").start(1235).get("/") { it.result("HOST WORKS") }
         assertThat(Unirest.get("http://127.1.2.3:1235/").asString().body).isEqualTo("HOST WORKS")
+        app.stop()
     }
 
     @Test

--- a/src/test/java/io/javalin/TestCustomJetty.kt
+++ b/src/test/java/io/javalin/TestCustomJetty.kt
@@ -45,7 +45,7 @@ class TestCustomJetty {
 
     @Test
     fun `setting host works`() {
-        val app = Javalin.create().host("127.0.0.1").start(1235).get("/") { it.result("HOST WORKS") }
+        val app = Javalin.create().start("127.0.0.1", 1235).get("/") { it.result("HOST WORKS") }
         assertThat(Unirest.get("http://127.0.0.1:1235/").asString().body).isEqualTo("HOST WORKS")
         app.stop()
     }

--- a/src/test/java/io/javalin/TestCustomJetty.kt
+++ b/src/test/java/io/javalin/TestCustomJetty.kt
@@ -43,6 +43,12 @@ class TestCustomJetty {
     }
 
     @Test
+    fun `setting host works`() {
+        Javalin.create().host("127.1.2.3").start(1234).get("/") { it.result("HOST WORKS") }
+        assertThat(Unirest.get("http://127.1.2.3:1234/").asString().body).isEqualTo("HOST WORKS")
+    }
+
+    @Test
     fun `embedded server can have custom jetty Handler`() {
         val statisticsHandler = StatisticsHandler()
         val newServer = Server().apply { handler = statisticsHandler }

--- a/src/test/java/io/javalin/TestCustomJetty.kt
+++ b/src/test/java/io/javalin/TestCustomJetty.kt
@@ -45,8 +45,8 @@ class TestCustomJetty {
 
     @Test
     fun `setting host works`() {
-        val app = Javalin.create().host("127.1.2.3").start(1235).get("/") { it.result("HOST WORKS") }
-        assertThat(Unirest.get("http://127.1.2.3:1235/").asString().body).isEqualTo("HOST WORKS")
+        val app = Javalin.create().host("127.0.0.1").start(1235).get("/") { it.result("HOST WORKS") }
+        assertThat(Unirest.get("http://127.0.0.1:1235/").asString().body).isEqualTo("HOST WORKS")
         app.stop()
     }
 

--- a/src/test/java/io/javalin/TestCustomJetty.kt
+++ b/src/test/java/io/javalin/TestCustomJetty.kt
@@ -44,8 +44,8 @@ class TestCustomJetty {
 
     @Test
     fun `setting host works`() {
-        Javalin.create().host("127.1.2.3").start(1234).get("/") { it.result("HOST WORKS") }
-        assertThat(Unirest.get("http://127.1.2.3:1234/").asString().body).isEqualTo("HOST WORKS")
+        Javalin.create().host("127.1.2.3").start(1235).get("/") { it.result("HOST WORKS") }
+        assertThat(Unirest.get("http://127.1.2.3:1235/").asString().body).isEqualTo("HOST WORKS")
     }
 
     @Test


### PR DESCRIPTION
We often want to do this when running in docker and this makes this easier to do than what we need to do currently.

This means to set the bind host we can do `host("0.0.0.0")` like below:

```java
final Javalin app = Javalin.create(config -> {
      ...
      }
    );
app.host("0.0.0.0").start(8090);
```

---------------------
Rather than (what we currently do in java):

```java
    int port = Integer.parseInt(System.getProperty("PORT", "8090"));
    org.eclipse.jetty.server.Server server = new org.eclipse.jetty.server.Server();
    ServerConnector connector = new ServerConnector(server);
    connector.setHost("0.0.0.0");
    connector.setPort(port);
    server.setConnectors(new ServerConnector[]{connector});

    final Javalin app = Javalin.create(config -> {
        ...
        config.server(()-> server);
      }
    );
```