### PR TITLE
openapi composed body feature (anyOf, oneOf)

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
@@ -21,6 +21,7 @@ annotation class OpenApi(
         val queryParams: Array<OpenApiParam> = [],
         val formParams: Array<OpenApiFormParam> = [],
         val requestBody: OpenApiRequestBody = OpenApiRequestBody([]),
+        val composedRequestBody: OpenApiComposedRequestBody = OpenApiComposedRequestBody([]),
         val fileUploads: Array<OpenApiFileUpload> = [],
         val responses: Array<OpenApiResponse> = [],
         /** The path of the endpoint. This will if the annotation * couldn't be found via reflection. */
@@ -61,6 +62,15 @@ annotation class OpenApiRequestBody(
 )
 
 @Target()
+annotation class OpenApiComposedRequestBody(
+        val anyOf: Array<KClass<*>> = [],
+        val oneOf: Array<KClass<*>> = [],
+        val required: Boolean = false,
+        val description: String = NULL_STRING,
+        val contentType: String = ContentType.AUTODETECT
+)
+
+@Target()
 annotation class OpenApiFileUpload(
         val name: String,
         val isArray: Boolean = false,
@@ -87,6 +97,12 @@ object ContentType {
     const val HTML = "text/html"
     const val FORM_DATA = "application/x-www-form-urlencoded"
     const val AUTODETECT = "AUTODETECT - Will be replaced later"
+}
+
+enum class ComposedType {
+    NULL,
+    ANY_OF,
+    ONE_OF;
 }
 
 enum class HttpMethod {

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt
@@ -1,5 +1,6 @@
 package io.javalin.plugin.openapi.dsl
 
+import io.javalin.plugin.openapi.annotations.ComposedType
 import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.external.mediaType
 import io.javalin.plugin.openapi.external.mediaTypeArrayOf
@@ -15,6 +16,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
+import kotlin.reflect.KClass
 
 /** Kotlin factory for documented content */
 inline fun <reified T> documentedContent(
@@ -74,6 +76,19 @@ class DocumentedContent @JvmOverloads constructor(
     }
 }
 
+sealed class Composition(val type: ComposedType, val classes: Array<Class<*>>) {
+
+    class OneOf(classes: Array<Class<*>>) : Composition(ComposedType.ONE_OF, classes)
+    class AnyOf(classes: Array<Class<*>>) : Composition(ComposedType.ANY_OF, classes)
+
+}
+
+fun oneOf(vararg classes: Class<*>) = Composition.OneOf(classes.toList().toTypedArray())
+fun oneOf(vararg classes: KClass<*>) = Composition.OneOf(classes.map { it.java }.toTypedArray())
+
+fun anyOf(vararg classes: Class<*>) = Composition.AnyOf(classes.toList().toTypedArray())
+fun anyOf(vararg classes: KClass<*>) = Composition.AnyOf(classes.map { it.java }.toTypedArray())
+
 /**
  * Try to determine the content type based on the class
  */
@@ -90,8 +105,11 @@ fun Class<*>.guessContentType(): String =
 val nonRefTypes = setOf(
         String::class.java,
         Boolean::class.java,
+        java.lang.Boolean::class.java,
         Int::class.java,
         Integer::class.java,
+        Double::class.java,
+        java.lang.Double::class.java,
         List::class.java,
         Long::class.java,
         BigDecimal::class.java,

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedRequestBody.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedRequestBody.kt
@@ -1,16 +1,44 @@
 package io.javalin.plugin.openapi.dsl
 
+import io.javalin.plugin.openapi.annotations.ComposedType
+import io.javalin.plugin.openapi.annotations.ContentType
+import io.javalin.plugin.openapi.external.findSchema
+import io.javalin.plugin.openapi.external.mediaTypeRef
 import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.parameters.RequestBody
 
 class DocumentedRequestBody(
-        val content: List<DocumentedContent>
+        val content: List<DocumentedContent>,
+        val contentType: String? = null,
+        val composedType: ComposedType = ComposedType.NULL
 )
 
 fun RequestBody.applyDocumentedRequestBody(documentedRequestBody: DocumentedRequestBody) {
     if (documentedRequestBody.content.isNotEmpty()) {
-        updateContent {
-            documentedRequestBody.content.forEach { applyDocumentedContent(it) }
+        if (documentedRequestBody.composedType != ComposedType.NULL) {
+            val composedList = documentedRequestBody.content.map {
+                val schema = if (!it.isNonRefType()) mediaTypeRef(it.fromType).schema
+                else findSchema(it.fromType)?.main
+                if (it.isArray) ArraySchema().items(schema) else schema
+            }
+
+            val schema = ComposedSchema().apply {
+                when (documentedRequestBody.composedType) {
+                    ComposedType.ANY_OF -> anyOf(composedList)
+                    ComposedType.ONE_OF -> oneOf(composedList)
+                }
+            }
+            val content = DocumentedContent(schema, documentedRequestBody.contentType ?: ContentType.AUTODETECT)
+
+            updateContent {
+                applyDocumentedContent(content)
+            }
+        } else {
+            updateContent {
+                documentedRequestBody.content.forEach { applyDocumentedContent(it) }
+            }
         }
     }
 }

--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
@@ -1,5 +1,6 @@
 package io.javalin.plugin.openapi.dsl
 
+import io.javalin.plugin.openapi.annotations.ComposedType
 import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.external.findSchema
 import io.swagger.v3.oas.models.Components
@@ -164,6 +165,12 @@ class OpenApiDocumentation {
     }
 
     @JvmOverloads
+    fun body(composition: Composition, contentType: String? = null, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
+        val documentedContent = composition.classes.map { DocumentedContent(it, false, contentType) }
+        body(documentedContent, openApiUpdater, contentType, composition.type)
+    }
+
+    @JvmOverloads
     fun body(returnType: Class<*>, contentType: String? = null, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
         val documentedContent = listOf(DocumentedContent(returnType, false, contentType))
         body(documentedContent, openApiUpdater)
@@ -176,8 +183,8 @@ class OpenApiDocumentation {
     }
 
     @JvmOverloads
-    fun body(content: List<DocumentedContent>, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
-        val documentedBody = DocumentedRequestBody(content)
+    fun body(content: List<DocumentedContent>, openApiUpdater: OpenApiUpdater<RequestBody>? = null, contentType: String? = null, composedType: ComposedType = ComposedType.NULL) = apply {
+        val documentedBody = DocumentedRequestBody(content, contentType, composedType)
         body(documentedBody, openApiUpdater)
     }
 

--- a/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.models.media.MapSchema
 import io.swagger.v3.oas.models.media.MediaType
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.media.StringSchema
+import io.swagger.v3.oas.models.media.NumberSchema
 import io.swagger.v3.oas.models.parameters.Parameter
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -119,6 +120,9 @@ internal fun <T> findSchema(clazz: Class<T>): FindSchemaResponse? {
         Date::class.java -> FindSchemaResponse(DateSchema())
         LocalDate::class.java -> FindSchemaResponse(DateSchema())
         LocalDateTime::class.java -> FindSchemaResponse(DateTimeSchema())
+        java.lang.Double::class.java -> FindSchemaResponse(NumberSchema())
+        Double::class.java -> FindSchemaResponse(NumberSchema())
+        Float::class.java -> FindSchemaResponse(NumberSchema())
         /* BEGIN Custom classes */
         ByteArray::class.java -> FindSchemaResponse(StringSchema().format("binary"))
         /* END Custom classes */

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -20,6 +20,7 @@ import io.javalin.plugin.openapi.annotations.OpenApiFileUpload
 import io.javalin.plugin.openapi.annotations.OpenApiFormParam
 import io.javalin.plugin.openapi.annotations.OpenApiParam
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody
+import io.javalin.plugin.openapi.annotations.OpenApiComposedRequestBody
 import io.javalin.plugin.openapi.annotations.OpenApiResponse
 import org.junit.Test
 
@@ -203,6 +204,37 @@ class ExtendedKotlinFieldHandlers : KotlinFieldHandlers()
 
 // endregion handler types
 
+// region composed body
+@OpenApi(
+        path = "/composed-body/any-of",
+        summary = "Get body with any of objects",
+        operationId = "composedBodyAnyOf",
+        composedRequestBody = OpenApiComposedRequestBody(
+                anyOf = [
+                    Address::class,
+                    User::class
+                ]
+        )
+)
+fun getAnyOfHandler(ctx: Context) {
+}
+
+@OpenApi(
+        path = "/composed-body/one-of",
+        summary = "Get body with one of objects",
+        operationId = "composedBodyOneOf",
+        composedRequestBody = OpenApiComposedRequestBody(
+                oneOf = [
+                    Address::class,
+                    User::class
+                ]
+        )
+)
+fun getOneOfHandler(ctx: Context) {
+}
+
+// endregion composed body
+
 class TestOpenApiAnnotations {
     @Test
     fun `createOpenApiSchema() work with complexExample and annotations`() {
@@ -298,5 +330,13 @@ class TestOpenApiAnnotations {
         extractSchemaForTest {
             it.get("/test", ExtendedKotlinFieldHandlers().kotlinFieldHandler)
         }.assertEqualTo(simpleExample)
+    }
+
+    @Test
+    fun `createOpenApiSchema() work with composed body`() {
+        extractSchemaForTest {
+            it.get("/composed-body/any-of", ::getAnyOfHandler)
+            it.get("/composed-body/one-of", ::getOneOfHandler)
+        }.assertEqualTo(composedBodyExample)
     }
 }

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -928,3 +928,94 @@ val userJsonExpected = """
 	"description": "Some additional information for the /user endpoint"
 }
 """.trimIndent()
+
+
+@Language("json")
+val composedBodyExample = """
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Example",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/composed-body/any-of" : {
+      "get" : {
+        "summary" : "Get body with any of objects",
+        "operationId" : "composedBodyAnyOf",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "anyOf" : [ {
+                  "$ref" : "#/components/schemas/Address"
+                }, {
+                  "$ref" : "#/components/schemas/User"
+                } ]
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Default response"
+          }
+        }
+      }
+    },
+    "/composed-body/one-of" : {
+      "get" : {
+        "summary" : "Get body with one of objects",
+        "operationId" : "composedBodyOneOf",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "oneOf" : [ {
+                  "$ref" : "#/components/schemas/Address"
+                }, {
+                  "$ref" : "#/components/schemas/User"
+                } ]
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Default response"
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "Address" : {
+        "required" : [ "number", "street" ],
+        "type" : "object",
+        "properties" : {
+          "street" : {
+            "type" : "string"
+          },
+          "number" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "User" : {
+        "required" : [ "name" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "address" : {
+            "$ref" : "#/components/schemas/Address"
+          }
+        }
+      }
+    }
+  }
+}
+""".trimIndent()


### PR DESCRIPTION
**Describe the feature**
PR to add support for https://github.com/tipsy/javalin/issues/817
```
@OpenApi(composedRequestBody = @OpenApiComposedRequestBody(
            anyOf = {
                Address.class,
                User.class,
            }
        )
)
```
should compile to json:
```
"requestBody" : {
  "content" : {
    "application/json" : {
      "schema" : {
        "anyOf" : [ {
          "$ref" : "#/components/schemas/Address"
        }, {
          "$ref" : "#/components/schemas/User"
        } ]
      }
    }
  }
}
```

**Another minor changes**
Added more primitive wrappers (Double, Float, Boolean) to nonRefTypes and to findScheme

https://github.com/sealedtx/javalin/blob/b616f31c7ae9e97cdff329ff5a60644e894a4e5a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt#L111-L112
```
val nonRefTypes = setOf(
        ...
        Double::class.java,
        java.lang.Double::class.java,
        ...
)
```

https://github.com/sealedtx/javalin/blob/b616f31c7ae9e97cdff329ff5a60644e894a4e5a/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt#L123-L124
```
internal fun <T> findSchema(clazz: Class<T>): FindSchemaResponse? {
    ...
    return when (clazz) {
        ...
        java.lang.Double::class.java -> FindSchemaResponse(NumberSchema())
        Double::class.java -> FindSchemaResponse(NumberSchema())
        ...
        }
    }
}
```


