### PR TITLE
[meta] Disable Maven dependency download messages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,5 @@ jobs:
         run: chmod +x ./mvnw
       - name: Build with Maven
         run: ./mvnw package --file pom.xml --batch-mode
+        env:
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn


### PR DESCRIPTION
As discussed in #833, this change disables the informational download messages by setting the causing loggers log level to `warn`.