### PR TITLE
Improving support for composed scheme

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
@@ -63,8 +63,8 @@ annotation class OpenApiRequestBody(
 
 @Target()
 annotation class OpenApiComposedRequestBody(
-        val anyOf: Array<KClass<*>> = [],
-        val oneOf: Array<KClass<*>> = [],
+        val anyOf: Array<OpenApiContent> = [],
+        val oneOf: Array<OpenApiContent> = [],
         val required: Boolean = false,
         val description: String = NULL_STRING,
         val contentType: String = ContentType.AUTODETECT

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt
@@ -16,7 +16,19 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
-import kotlin.reflect.KClass
+
+@JvmOverloads
+fun documentedContent(
+        clazz: Class<*>,
+        isArray: Boolean = false,
+        contentType: String? = ContentType.AUTODETECT
+): DocumentedContent {
+    return DocumentedContent(
+            clazz,
+            contentType = contentType,
+            isArray = isArray
+    )
+}
 
 /** Kotlin factory for documented content */
 inline fun <reified T> documentedContent(
@@ -76,18 +88,15 @@ class DocumentedContent @JvmOverloads constructor(
     }
 }
 
-sealed class Composition(val type: ComposedType, val classes: Array<Class<*>>) {
+sealed class Composition(val type: ComposedType, val content: List<DocumentedContent>) {
 
-    class OneOf(classes: Array<Class<*>>) : Composition(ComposedType.ONE_OF, classes)
-    class AnyOf(classes: Array<Class<*>>) : Composition(ComposedType.ANY_OF, classes)
+    class OneOf(contents: List<DocumentedContent>) : Composition(ComposedType.ONE_OF, contents)
+    class AnyOf(contents: List<DocumentedContent>) : Composition(ComposedType.ANY_OF, contents)
 
 }
 
-fun oneOf(vararg classes: Class<*>) = Composition.OneOf(classes.toList().toTypedArray())
-fun oneOf(vararg classes: KClass<*>) = Composition.OneOf(classes.map { it.java }.toTypedArray())
-
-fun anyOf(vararg classes: Class<*>) = Composition.AnyOf(classes.toList().toTypedArray())
-fun anyOf(vararg classes: KClass<*>) = Composition.AnyOf(classes.map { it.java }.toTypedArray())
+fun oneOf(vararg content: DocumentedContent) = Composition.OneOf(content.toList())
+fun anyOf(vararg content: DocumentedContent) = Composition.AnyOf(content.toList())
 
 /**
  * Try to determine the content type based on the class

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedResponse.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedResponse.kt
@@ -1,6 +1,10 @@
 package io.javalin.plugin.openapi.dsl
 
+import io.javalin.plugin.openapi.external.findSchema
+import io.javalin.plugin.openapi.external.mediaTypeRef
 import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.responses.ApiResponse
 import org.eclipse.jetty.http.HttpStatus
 
@@ -13,11 +17,32 @@ fun DocumentedResponse.getStatusMessage() = status.toIntOrNull()?.let { HttpStat
 
 fun ApiResponse.applyDocumentedResponse(documentedResponse: DocumentedResponse) {
     description = description ?: documentedResponse.getStatusMessage()
-    if (documentedResponse.content.isNotEmpty()) {
-        updateContent {
-            documentedResponse.content.forEach { applyDocumentedContent(it) }
+
+    val contentToApply = arrayListOf<DocumentedContent>()
+    documentedResponse.content.groupBy { it.contentType }.forEach { (contentType, list) ->
+        if (list.size > 1) {
+            val composedList = list.map {
+                val schema = if (!it.isNonRefType()) mediaTypeRef(it.fromType).schema
+                else findSchema(it.fromType)?.main
+                if (it.isArray) ArraySchema().items(schema) else schema
+            }
+
+            val schema = ComposedSchema().apply {
+                oneOf(composedList)
+            }
+            val content = DocumentedContent(schema, contentType)
+            contentToApply.add(content)
+        } else {
+            contentToApply.addAll(list)
         }
     }
+
+    if (contentToApply.isNotEmpty()) {
+        updateContent {
+            contentToApply.forEach { applyDocumentedContent(it) }
+        }
+    }
+
 }
 
 fun Components.applyDocumentedResponse(documentedResponse: DocumentedResponse) {

--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
@@ -166,8 +166,7 @@ class OpenApiDocumentation {
 
     @JvmOverloads
     fun body(composition: Composition, contentType: String? = null, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
-        val documentedContent = composition.classes.map { DocumentedContent(it, false, contentType) }
-        body(documentedContent, openApiUpdater, contentType, composition.type)
+        body(composition.content, openApiUpdater, contentType, composition.type)
     }
 
     @JvmOverloads
@@ -269,6 +268,11 @@ class OpenApiDocumentation {
             listOf(DocumentedContent(returnType, false, contentType))
         }
         result(status, documentedContent, openApiUpdater)
+    }
+
+    @JvmOverloads
+    fun result(status: String, composition: Composition.OneOf, applyUpdates: ApplyUpdates<ApiResponse>? = null) = apply {
+        result(status, composition.content, createUpdaterIfNotNull(applyUpdates))
     }
 
     fun result(documentedResponse: DocumentedResponse, applyUpdates: ApplyUpdates<ApiResponse>? = null) = apply {

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -443,32 +443,39 @@ class TestOpenApi {
     }
 
     @Test
-    fun `createSchema() work with composed body`() {
+    fun `createSchema() work with composed body and response`() {
         val app = Javalin.create {
             it.registerPlugin(OpenApiPlugin(OpenApiOptions(
                     Info().title("Example").version("1.0.0")
             )))
         }
 
-        val anyOfDocumentation = document()
-                .body(anyOf(Address::class, User::class))
+        val anyOfBodyDocumentation = document()
+                .body(anyOf(documentedContent<Address>(), documentedContent<User>(isArray = true)))
                 .operation {
                     it.summary = "Get body with any of objects"
                     it.operationId = "composedBodyAnyOf"
                 }
-        app.get("/composed-body/any-of", documented(anyOfDocumentation) {})
+        app.get("/composed-body/any-of", documented(anyOfBodyDocumentation) {})
 
-        val oneOfDocumentation = document()
-                .body(oneOf(Address::class, User::class))
+        val oneOfBodyDocumentation = document()
+                .body(oneOf(documentedContent<Address>(), documentedContent<User>(isArray = true)))
                 .operation {
                     it.summary = "Get body with one of objects"
                     it.operationId = "composedBodyOneOf"
                 }
-        app.get("/composed-body/one-of", documented(oneOfDocumentation) {})
+        app.get("/composed-body/one-of", documented(oneOfBodyDocumentation) {})
+
+        val oneOfResponseDocumentation = document()
+                .result("200", oneOf(documentedContent<Address>(), documentedContent<User>(), documentedContent<User>(contentType = "application/xml")))
+                .operation {
+                    it.summary = "Get with one of responses"
+                    it.operationId = "composedResponseOneOf"
+                }
+        app.get("/composed-response/one-of", documented(oneOfResponseDocumentation) {})
 
         val actual = JavalinOpenApi.createSchema(app)
-        print(actual.asJsonString())
-        assertThat(actual.asJsonString()).isEqualTo(composedBodyExample.formatJson())
+        assertThat(actual.asJsonString()).isEqualTo(composedExample.formatJson())
     }
 
     @Test

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -211,12 +211,12 @@ class ExtendedKotlinFieldHandlers : KotlinFieldHandlers()
         operationId = "composedBodyAnyOf",
         composedRequestBody = OpenApiComposedRequestBody(
                 anyOf = [
-                    Address::class,
-                    User::class
+                    OpenApiContent(from = Address::class),
+                    OpenApiContent(from = User::class, isArray = true)
                 ]
         )
 )
-fun getAnyOfHandler(ctx: Context) {
+fun getBodyAnyOfHandler(ctx: Context) {
 }
 
 @OpenApi(
@@ -225,12 +225,29 @@ fun getAnyOfHandler(ctx: Context) {
         operationId = "composedBodyOneOf",
         composedRequestBody = OpenApiComposedRequestBody(
                 oneOf = [
-                    Address::class,
-                    User::class
+                    OpenApiContent(from = Address::class),
+                    OpenApiContent(from = User::class, isArray = true)
                 ]
         )
 )
-fun getOneOfHandler(ctx: Context) {
+fun getBodyOneOfHandler(ctx: Context) {
+}
+
+@OpenApi(
+        path = "/composed-response/one-of",
+        summary = "Get with one of responses",
+        operationId = "composedResponseOneOf",
+        responses = [
+            OpenApiResponse("200", content = [
+                OpenApiContent(from = Address::class),
+                OpenApiContent(from = User::class, type = "application/xml")
+            ]),
+            OpenApiResponse("200", content = [
+                OpenApiContent(from = User::class)
+            ])
+        ]
+)
+fun getResponseOneOfHandler(ctx: Context) {
 }
 
 // endregion composed body
@@ -333,10 +350,12 @@ class TestOpenApiAnnotations {
     }
 
     @Test
-    fun `createOpenApiSchema() work with composed body`() {
+    fun `createOpenApiSchema() work with composed body and response`() {
         extractSchemaForTest {
-            it.get("/composed-body/any-of", ::getAnyOfHandler)
-            it.get("/composed-body/one-of", ::getOneOfHandler)
-        }.assertEqualTo(composedBodyExample)
+            it.get("/composed-body/any-of", ::getBodyAnyOfHandler)
+            it.get("/composed-body/one-of", ::getBodyOneOfHandler)
+            it.get("/composed-response/one-of", ::getResponseOneOfHandler)
+
+        }.assertEqualTo(composedExample)
     }
 }

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -931,7 +931,7 @@ val userJsonExpected = """
 
 
 @Language("json")
-val composedBodyExample = """
+val composedExample = """
 {
   "openapi" : "3.0.1",
   "info" : {
@@ -950,7 +950,10 @@ val composedBodyExample = """
                 "anyOf" : [ {
                   "$ref" : "#/components/schemas/Address"
                 }, {
-                  "$ref" : "#/components/schemas/User"
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
                 } ]
               }
             }
@@ -974,7 +977,10 @@ val composedBodyExample = """
                 "oneOf" : [ {
                   "$ref" : "#/components/schemas/Address"
                 }, {
-                  "$ref" : "#/components/schemas/User"
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
                 } ]
               }
             }
@@ -983,6 +989,33 @@ val composedBodyExample = """
         "responses" : {
           "200" : {
             "description" : "Default response"
+          }
+        }
+      }
+    },
+    "/composed-response/one-of" : {
+      "get" : {
+        "summary" : "Get with one of responses",
+        "operationId" : "composedResponseOneOf",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/components/schemas/Address"
+                  }, {
+                    "$ref" : "#/components/schemas/User"
+                  } ]
+                }
+              },
+              "application/xml" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
**Describe the feature**
Imporves support of composed scheme for openapi.
There was limitation in #825 for creating composed scheme of arrayed-elements.
#659 was not actually solved by #825, this PR adds support for responses with same status and group them to "oneOf" scheme.