### PR TITLE
OpenApiDocumentation: security scheme

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
@@ -24,10 +24,18 @@ annotation class OpenApi(
         val composedRequestBody: OpenApiComposedRequestBody = OpenApiComposedRequestBody([]),
         val fileUploads: Array<OpenApiFileUpload> = [],
         val responses: Array<OpenApiResponse> = [],
+        val security: Array<OpenApiSecurity> = [],
         /** The path of the endpoint. This will if the annotation * couldn't be found via reflection. */
         val path: String = NULL_STRING,
         /** The method of the endpoint. This will if the annotation * couldn't be found via reflection. */
         val method: HttpMethod = HttpMethod.GET
+)
+
+@Target()
+annotation class OpenApiSecurity(
+        val scheme: AuthScheme,
+        val name: String = NULL_STRING,
+        val format: String = NULL_STRING
 )
 
 @Target()
@@ -115,6 +123,15 @@ enum class HttpMethod {
     OPTIONS,
     TRACE;
 }
+
+enum class AuthScheme {
+    BASIC,
+    BEARER,
+    APIKEY_COOKIE,
+    APIKEY_HEADER,
+    APIKEY_QUERY
+}
+
 
 data class PathInfo(val path: String, val method: HttpMethod)
 

--- a/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
@@ -127,6 +127,14 @@ fun Operation.applyMetaInfo(options: CreateSchemaOptions, path: PathParser, meta
         }
     }
 
+    if (documentation.hasSecuritySchemes()) {
+        documentation.securitySchemeList.forEach {
+            updateSecurityRequirement {
+                addList(it.key)
+            }
+        }
+    }
+
     documentation.operationUpdaterList.applyAllUpdates(this)
 }
 

--- a/src/main/java/io/javalin/plugin/openapi/dsl/openApiUpdaterDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/openApiUpdaterDsl.kt
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.parameters.RequestBody
 import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.responses.ApiResponses
+import io.swagger.v3.oas.models.security.SecurityRequirement
 
 internal fun OpenAPI.updateComponents(apply: Components.() -> Unit) {
     components = components ?: Components()
@@ -75,4 +76,11 @@ internal fun ApiResponses.updateResponse(name: String, apply: ApiResponse.() -> 
     } else {
         response.apply(apply)
     }
+}
+
+fun Operation.updateSecurityRequirement(apply: SecurityRequirement.() -> Unit) {
+    if (security == null) {
+        security = mutableListOf()
+    }
+    security.add(SecurityRequirement().apply(apply))
 }

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -658,4 +658,27 @@ class TestOpenApi {
         assertThat(userJson.formatJson()).isEqualTo(userJsonExpected.formatJson())
         assertThat(userWithIdJson.formatJson()).isEqualTo(userWithIdJsonExpected.formatJson())
     }
+
+    @Test
+    fun `createSchema() work with security requirements`() {
+        val app = Javalin.create {
+            it.registerPlugin(OpenApiPlugin(OpenApiOptions(
+                    Info().title("Example").version("1.0.0")
+            )))
+        }
+
+        val secureDocument = document()
+                .basicAuth()
+                .bearerAuth("JWT")
+                .apiKeyAuth("API-KEY", SecurityScheme.In.COOKIE)
+
+        app.get("/very-secure-request", documented(secureDocument) {})
+
+        val insecureDocument = document()
+
+        app.get("/insecure-request", documented(insecureDocument) {})
+
+        val actual = JavalinOpenApi.createSchema(app)
+        assertThat(actual.asJsonString()).isEqualTo(secureExample.formatJson())
+    }
 }

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -14,6 +14,7 @@ import io.javalin.plugin.openapi.JavalinOpenApi
 import io.javalin.plugin.openapi.OpenApiOptions
 import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.annotations.ContentType
+import io.javalin.plugin.openapi.annotations.AuthScheme
 import io.javalin.plugin.openapi.annotations.OpenApi
 import io.javalin.plugin.openapi.annotations.OpenApiContent
 import io.javalin.plugin.openapi.annotations.OpenApiFileUpload
@@ -22,6 +23,7 @@ import io.javalin.plugin.openapi.annotations.OpenApiParam
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody
 import io.javalin.plugin.openapi.annotations.OpenApiComposedRequestBody
 import io.javalin.plugin.openapi.annotations.OpenApiResponse
+import io.javalin.plugin.openapi.annotations.OpenApiSecurity
 import org.junit.Test
 
 // region complexExampleWithAnnotationsHandler
@@ -252,6 +254,28 @@ fun getResponseOneOfHandler(ctx: Context) {
 
 // endregion composed body
 
+//region secure handlers
+@OpenApi(
+        path = "/very-secure-request",
+        security = [
+            OpenApiSecurity(scheme = AuthScheme.BASIC),
+            OpenApiSecurity(scheme = AuthScheme.BEARER, format = "JWT"),
+            OpenApiSecurity(scheme = AuthScheme.APIKEY_COOKIE, name = "API-KEY")
+        ]
+)
+fun getSecureRequestHandler(ctx: Context) {
+
+}
+
+@OpenApi(
+        path = "/insecure-request"
+)
+fun getInSecureRequestHandler(ctx: Context) {
+
+}
+// endregion secure handlers
+
+
 class TestOpenApiAnnotations {
     @Test
     fun `createOpenApiSchema() work with complexExample and annotations`() {
@@ -357,5 +381,14 @@ class TestOpenApiAnnotations {
             it.get("/composed-response/one-of", ::getResponseOneOfHandler)
 
         }.assertEqualTo(composedExample)
+    }
+
+    @Test
+    fun `createOpenApiSchema() work with security requirements`() {
+        extractSchemaForTest {
+            it.get("/very-secure-request", ::getSecureRequestHandler)
+            it.get("/insecure-request", ::getInSecureRequestHandler)
+
+        }.assertEqualTo(secureExample)
     }
 }

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -1052,3 +1052,64 @@ val composedExample = """
   }
 }
 """.trimIndent()
+
+
+@Language("json")
+val secureExample = """
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Example",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/very-secure-request" : {
+      "get" : {
+        "summary" : "Get verySecureRequest",
+        "operationId" : "getVerySecureRequest",
+        "responses" : {
+          "200" : {
+            "description" : "Default response"
+          }
+        },
+        "security" : [ {
+          "basicAuth" : [ ]
+        }, {
+          "bearerAuth" : [ ]
+        }, {
+          "apiKeyAuth" : [ ]
+        } ]
+      }
+    },
+    "/insecure-request" : {
+      "get" : {
+        "summary" : "Get insecureRequest",
+        "operationId" : "getInsecureRequest",
+        "responses" : {
+          "200" : {
+            "description" : "Default response"
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "securitySchemes" : {
+      "basicAuth" : {
+        "type" : "http",
+        "scheme" : "basic"
+      },
+      "bearerAuth" : {
+        "type" : "http",
+        "scheme" : "bearer",
+        "bearerFormat" : "JWT"
+      },
+      "apiKeyAuth" : {
+        "type" : "apiKey",
+        "name" : "API-KEY",
+        "in" : "cookie"
+      }
+    }
+  }
+}
+""".trimIndent()


### PR DESCRIPTION
Hi @tipsy, Here is how I implemented security scheme feature for OpenApiDocumentation (#805). Take a look, it could be not the best solution, but the most evident for me.

| Auth method  | DSL | Annotations |
| ------------- | ------------- | ------------- |
| basicAuth | implemented  | implemented |
| bearerAuth  | implemented  | implemented |
| apiKeyAuth | implemented  | implemented |
| oauth2  | not implemented (could be done manually)  | not implemented |
| openID  | not supported in Swagger UI  | not supported in Swagger UI 

DSL:

```
OpenApiDocumentation document = OpenApiBuilder.document()
            .basicAuth()
            .bearerAuth("JWT")
            .apiKeyAuth("API-KEY", SecurityScheme.In.QUERY);

        app.get("/test-dsl-auth", documented(document, this::dslMethod));
```

Annotations:
```
    @OpenApi(
        path = "/test-annotation",
        method = HttpMethod.GET,
        security = {
            @OpenApiSecurity(scheme = AuthScheme.BASIC),
            @OpenApiSecurity(scheme = AuthScheme.BEARER, format = "JWT"),
            @OpenApiSecurity(scheme = AuthScheme.APIKEY_COOKIE, name = "API-KEY")
        }
    )
    public void annotationMethod(Context ctx) {
    }
```

