### PR TITLE
added OpenApiExample annotation

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
@@ -93,6 +93,11 @@ annotation class OpenApiSecurity(
         val scopes: Array<String> = []
 )
 
+@Target(AnnotationTarget.FUNCTION)
+annotation class OpenApiExample(
+        val name: String
+)
+
 /** Null string because annotations do not support null values */
 const val NULL_STRING = "-- This string represents a null value and shouldn't be used --"
 

--- a/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedContent.kt
@@ -171,8 +171,8 @@ fun Content.applyDocumentedContent(documentedContent: DocumentedContent) {
             else -> mediaTypeRef(documentedContent.fromType, documentedContent.contentType)
         }
     }
-
-    get(documentedContent.contentType)?.examples = documentedContent.examples
+    if (documentedContent.examples.isNotEmpty())
+        get(documentedContent.contentType)?.examples = documentedContent.examples
 }
 
 fun Components.applyDocumentedContent(documentedResponse: DocumentedContent) {


### PR DESCRIPTION
PR to resolve #820, as I mentioned in issue, this solution does not feel like correct one. I am not sure if the code I wrote should be in `DocumentedContent.kt`. And is it okay to use directly kotlin.reflect API and java.lang.reflect API? I see usage of io.github.classgraph to scan annotations. Tips are welcome.

Java:
```
public class User {
    public String name;
    public String email;
    ...
    @OpenApiExample(name = "example with some name")
    private static User example() {
        return new User("some name", "some email");
    }
}
```
Kotlin:
```
class User(val name: String, val email: String) {
    companion object {
        @OpenApiExample(name = "example with some name")
        fun example() = User("some name", "some email")
    }
}
```