### PR TITLE
Fixed Swagger doc for endpoints with file upload and from params

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
+++ b/src/main/java/io/javalin/plugin/openapi/annotations/AnnotationApi.kt
@@ -102,7 +102,8 @@ class NULL_CLASS
 object ContentType {
     const val JSON = "application/json"
     const val HTML = "text/html"
-    const val FORM_DATA = "application/x-www-form-urlencoded"
+    const val FORM_DATA_URL_ENCODED = "application/x-www-form-urlencoded"
+    const val FORM_DATA_MULTIPART = "multipart/form-data"
     const val AUTODETECT = "AUTODETECT - Will be replaced later"
 }
 

--- a/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
@@ -10,6 +10,7 @@ import io.javalin.core.event.HandlerMetaInfo
 import io.javalin.http.HandlerType
 import io.javalin.plugin.openapi.CreateSchemaOptions
 import io.javalin.plugin.openapi.JavalinOpenApi
+import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.annotations.HttpMethod
 import io.javalin.plugin.openapi.annotations.PathInfo
 import io.javalin.plugin.openapi.external.schema
@@ -110,9 +111,12 @@ fun Operation.applyMetaInfo(options: CreateSchemaOptions, path: PathParser, meta
         }
     }
 
-    if (documentation.hasFormParameter()) {
+    if (documentation.hasFormParameter() || documentation.hasFileUploads()) {
         updateRequestBody {
-            applyDocumentedFormParameters(documentation.formParameterList)
+            // Requests with file uploads need to be a multipart content
+            // Regular forms alone will be url encoded by default
+            val contentType = if (documentation.hasFileUploads()) ContentType.FORM_DATA_MULTIPART else ContentType.FORM_DATA_URL_ENCODED
+            applyDocumentedFormParameters(documentation.formParameterList, documentation.fileUploadList, contentType)
         }
     }
 

--- a/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/openApiBuilderDsl.kt
@@ -113,10 +113,7 @@ fun Operation.applyMetaInfo(options: CreateSchemaOptions, path: PathParser, meta
 
     if (documentation.hasFormParameter() || documentation.hasFileUploads()) {
         updateRequestBody {
-            // Requests with file uploads need to be a multipart content
-            // Regular forms alone will be url encoded by default
-            val contentType = if (documentation.hasFileUploads()) ContentType.FORM_DATA_MULTIPART else ContentType.FORM_DATA_URL_ENCODED
-            applyDocumentedFormParameters(documentation.formParameterList, documentation.fileUploadList, contentType)
+            applyDocumentedFormParameters(documentation.formParameterList, documentation.fileUploadList)
         }
     }
 

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -5,18 +5,7 @@
  */
 package io.javalin.openapi
 
-import cc.vileda.openapi.dsl.asJson
-import cc.vileda.openapi.dsl.components
-import cc.vileda.openapi.dsl.externalDocs
-import cc.vileda.openapi.dsl.get
-import cc.vileda.openapi.dsl.info
-import cc.vileda.openapi.dsl.openapiDsl
-import cc.vileda.openapi.dsl.path
-import cc.vileda.openapi.dsl.paths
-import cc.vileda.openapi.dsl.security
-import cc.vileda.openapi.dsl.securityScheme
-import cc.vileda.openapi.dsl.server
-import cc.vileda.openapi.dsl.tag
+import cc.vileda.openapi.dsl.*
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.mashape.unirest.http.Unirest
 import io.javalin.Javalin
@@ -28,13 +17,7 @@ import io.javalin.plugin.openapi.JavalinOpenApi
 import io.javalin.plugin.openapi.OpenApiOptions
 import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.annotations.HttpMethod
-import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
-import io.javalin.plugin.openapi.dsl.anyOf
-import io.javalin.plugin.openapi.dsl.document
-import io.javalin.plugin.openapi.dsl.documentCrud
-import io.javalin.plugin.openapi.dsl.documented
-import io.javalin.plugin.openapi.dsl.documentedContent
-import io.javalin.plugin.openapi.dsl.oneOf
+import io.javalin.plugin.openapi.dsl.*
 import io.javalin.plugin.openapi.jackson.JacksonToJsonMapper
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
@@ -233,6 +216,17 @@ fun buildComplexExample(options: OpenApiOptions): Javalin {
             }
     app.get("/uploads", documented(getUploadsDocumentation) {
         it.uploadedFiles("files")
+    })
+
+    val getUploadWithFormDataDocumentation = OpenApiDocumentation()
+        .uploadedFile("file") {
+            it.description = "MyFile"
+            it.required = true
+        }
+        .formParam<String>("title")
+    app.get("/uploadWithFormData", documented(getUploadWithFormDataDocumentation) {
+        it.uploadedFile("file")
+        it.formParam("title")
     })
 
     val getResourcesDocumentation = OpenApiDocumentation()

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -116,7 +116,7 @@ fun putFormDataHandler(ctx: Context) {
 }
 
 @OpenApi(
-        requestBody = OpenApiRequestBody(content = [OpenApiContent(Address::class, type = ContentType.FORM_DATA)]),
+        requestBody = OpenApiRequestBody(content = [OpenApiContent(Address::class, type = ContentType.FORM_DATA_URL_ENCODED)]),
         responses = [
             OpenApiResponse(status = "200")
         ]
@@ -171,6 +171,17 @@ fun getUploadHandler(ctx: Context) {
         ]
 )
 fun getUploadsHandler(ctx: Context) {
+}
+
+@OpenApi(
+        fileUploads = [
+            OpenApiFileUpload(name = "file", description = "MyFile", required = true)
+        ],
+        formParams = [
+            OpenApiFormParam("title")
+        ]
+)
+fun getUploadWithFormDataHandler(ctx: Context) {
 }
 
 @OpenApi(
@@ -274,6 +285,7 @@ class TestOpenApiAnnotations {
         app.get("/homepage", ::getHomepageHandler)
         app.get("/upload", ::getUploadHandler)
         app.get("/uploads", ::getUploadsHandler)
+        app.get("/uploadWithFormData", ::getUploadWithFormDataHandler)
         app.get("/resources/*", ::getResources)
         app.get("/ignore", ::getIgnore)
 

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -559,6 +559,37 @@ val complexExampleJson = """
         }
       }
     },
+     "/uploadWithFormData": {
+      "get": {
+        "summary": "Get uploadwithformdata",
+        "operationId": "getUploadwithformdata",
+        "requestBody": {
+          "description": "MyFile",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Default response"
+          }
+        }
+      }
+    },
     "/resources/*": {
       "get": {
         "summary": "Get resources with wildcard",


### PR DESCRIPTION
**Description:**
Fix for #859
`fileUploads` (like `formParam`) are now collected in a list and when we generate the docs both are taken into account to pick the correct content type and create a single entry in the `requestBody`.

**Test plan:**
Added new unit test case

**Outstanding issues:**
The `formParamBody` function is unchanged and will continue to use URL encoding even if there are also file uploads.
My current understanding of the code:
`formParamBody` applies changes as soon as it's called - this would cause issues if afterwords a `fileUpload` is added. We could defer this to later so that we know if there are file uploads as well.
But there is also the issue that both `fileUpload`and `formParamBody` offer the API to change the `requestBody`. Example:
```
OpenApiDocumentation()
        .uploadedFile("file") {
            it.description = "MyFile"
            it.required = true
        }
        .formParamBody<Address> {
            it.description = "These changes would override the stuff above"
            it.required = false
        }
```
Would generate
```
 "requestBody" : {
          "description" : "These changes would override the stuff above",
          "content" : {
            "multipart/form-data" : {
              "schema" : {
                "type" : "object",
                "properties" : {
                  "file" : {
                    "type" : "string",
                    "format" : "binary"
                  },
                  "title" : {
                    "type" : "string"
                  }
                }
              }
            }
          },
          "required" : false
        },
```
Silently overriding `description = "MyFile"` and `required = true` doesn't seem like the best solution but I also didn't want to change the public API with this pull requests so I left it as is for now.
If anyone has a suggestion I'd be happy to hear it.
