### PR TITLE
[openapi] support different content types in `formDataBody`

### DIFF
--- a/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
+++ b/src/main/java/io/javalin/plugin/openapi/dsl/OpenApiDocumentation.kt
@@ -111,9 +111,17 @@ class OpenApiDocumentation {
         formParamBody(T::class.java, createUpdaterIfNotNull(applyUpdates))
     }
 
+    inline fun <reified T> formParamBody(contentType: String? = null, noinline applyUpdates: ApplyUpdates<RequestBody>? = null) = apply {
+        formParamBody(T::class.java, contentType, createUpdaterIfNotNull(applyUpdates))
+    }
+
     @JvmOverloads
     fun formParamBody(clazz: Class<*>, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
-        body(clazz, ContentType.FORM_DATA_URL_ENCODED, openApiUpdater)
+        formParamBody(clazz, null, openApiUpdater)
+    }
+
+    fun formParamBody(clazz: Class<*>, contentType: String? = null, openApiUpdater: OpenApiUpdater<RequestBody>? = null) = apply {
+        body(clazz, contentType ?: ContentType.FORM_DATA_URL_ENCODED, openApiUpdater)
     }
 
     // --- UPLOADED FILE ---

--- a/src/test/java/io/javalin/openapi/TestOpenApi.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApi.kt
@@ -16,6 +16,7 @@ import io.javalin.http.Context
 import io.javalin.plugin.openapi.JavalinOpenApi
 import io.javalin.plugin.openapi.OpenApiOptions
 import io.javalin.plugin.openapi.OpenApiPlugin
+import io.javalin.plugin.openapi.annotations.ContentType
 import io.javalin.plugin.openapi.annotations.HttpMethod
 import io.javalin.plugin.openapi.dsl.*
 import io.javalin.plugin.openapi.jackson.JacksonToJsonMapper
@@ -167,6 +168,11 @@ fun buildComplexExample(options: OpenApiOptions): Javalin {
             .result<Unit>("200")
     app.put("/form-data-schema", documented(getFormDataSchemaDocumentation) {})
 
+    val getFormDataSchemaMultipartDocumentation = document()
+            .formParamBody<Address>(contentType = ContentType.FORM_DATA_MULTIPART)
+            .result<Unit>("200")
+    app.put("/form-data-schema-multipart", documented(getFormDataSchemaMultipartDocumentation) {})
+
     val putUserDocumentation = document()
             .operation {
                 it.addTagsItem("user")
@@ -224,7 +230,7 @@ fun buildComplexExample(options: OpenApiOptions): Javalin {
             it.required = true
         }
         .formParam<String>("title")
-    app.get("/uploadWithFormData", documented(getUploadWithFormDataDocumentation) {
+    app.get("/upload-with-form-data", documented(getUploadWithFormDataDocumentation) {
         it.uploadedFile("file")
         it.formParam("title")
     })

--- a/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
+++ b/src/test/java/io/javalin/openapi/TestOpenApiAnnotations.kt
@@ -125,6 +125,15 @@ fun putFormDataSchemaHandler(ctx: Context) {
 }
 
 @OpenApi(
+        requestBody = OpenApiRequestBody(content = [OpenApiContent(Address::class, type = ContentType.FORM_DATA_MULTIPART)]),
+        responses = [
+            OpenApiResponse(status = "200")
+        ]
+)
+fun putFormDataSchemaMultipartHandler(ctx: Context) {
+}
+
+@OpenApi(
         tags = ["user"],
         requestBody = OpenApiRequestBody(
                 required = true,
@@ -280,12 +289,13 @@ class TestOpenApiAnnotations {
         app.get("/users2", ::getUsers2Handler)
         app.put("/form-data", ::putFormDataHandler)
         app.put("/form-data-schema", ::putFormDataSchemaHandler)
+        app.put("/form-data-schema-multipart", ::putFormDataSchemaMultipartHandler)
         app.put("/user", ::putUserHandler)
         app.get("/string", ::getStringHandler)
         app.get("/homepage", ::getHomepageHandler)
         app.get("/upload", ::getUploadHandler)
         app.get("/uploads", ::getUploadsHandler)
-        app.get("/uploadWithFormData", ::getUploadWithFormDataHandler)
+        app.get("/upload-with-form-data", ::getUploadWithFormDataHandler)
         app.get("/resources/*", ::getResources)
         app.get("/ignore", ::getIgnore)
 

--- a/src/test/java/io/javalin/openapi/json.kt
+++ b/src/test/java/io/javalin/openapi/json.kt
@@ -464,6 +464,26 @@ val complexExampleJson = """
         }
       }
     },
+    "/form-data-schema-multipart": {
+      "put": {
+        "summary": "Put formDataSchemaMultipart",
+        "operationId": "putFormDataSchemaMultipart",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Address"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/string": {
       "get": {
         "summary": "Get string",
@@ -559,10 +579,10 @@ val complexExampleJson = """
         }
       }
     },
-     "/uploadWithFormData": {
+    "/upload-with-form-data": {
       "get": {
-        "summary": "Get uploadwithformdata",
-        "operationId": "getUploadwithformdata",
+        "summary": "Get uploadWithFormData",
+        "operationId": "getUploadWithFormData",
         "requestBody": {
           "description": "MyFile",
           "content": {


### PR DESCRIPTION
Follow up PR to #860 . 

`formParamBody` behaves a little bit different then `formParam`, as you provide a java class as a schema. The indented use case is to easily type more complex forms, that are not send as JSON.
It doesn't make sense to use the `uploadedFile` method in combination with `formParamBody`, as `formParamBody` contains the complete schema. If you want to add an file upload to this request, you would add a binary field to the class for the schema.

That's why I only added support to manually set the content type of the `formParamBody`, so you can use 'multipart/form-data' instead of 'application/x-www-form-urlencoded`.