### PR TITLE
[api] Add regex path parameter matching

### DIFF
--- a/src/main/java/io/javalin/core/PathParser.kt
+++ b/src/main/java/io/javalin/core/PathParser.kt
@@ -15,6 +15,10 @@ class PathParser(path: String) {
             .map {
                 when {
                     it.startsWith(":") -> PathSegment.Parameter(it.removePrefix(":"))
+                    it.startsWith("{") -> PathSegment.Parameter(
+                            it.removePrefix("{").split(":").first(),
+                            it.removeSuffix("}").split(":").drop(1).joinToString(":")
+                    )
                     it == "*" -> PathSegment.Wildcard
                     else -> PathSegment.Normal(it)
                 }
@@ -24,7 +28,7 @@ class PathParser(path: String) {
 
     private val matchRegex = "^/${segments.joinToString("/") { it.asRegexString() }}/?$".toRegex()
 
-    private val pathParamRegex = matchRegex.pattern.replace("[^/]+?", "([^/]+?)").toRegex()
+    private val pathParamRegex = "^/${segments.joinToString("/") { it.asRegexString(true) }}/?$".toRegex()
 
     fun matches(url: String): Boolean = url matches matchRegex
 
@@ -37,18 +41,30 @@ class PathParser(path: String) {
 }
 
 sealed class PathSegment {
+    /**
+     * @param extract surround the regex with brackets if it is a path parameter.
+     */
+    internal abstract fun asRegexString(extract: Boolean = false): String
 
-    internal abstract fun asRegexString(): String
-
+    /**
+     * @param content the content (literal between two dashes of an url) this segment represents
+     */
     class Normal(val content: String) : PathSegment() {
-        override fun asRegexString(): String = content
+        override fun asRegexString(extract: Boolean): String = content
     }
 
-    class Parameter(val name: String) : PathSegment() {
-        override fun asRegexString(): String = "[^/]+?" // Accepting everything except slash
+    /**
+     * @param name the name of the parameter this segment represents
+     * @param regex the regex to match for the path detection, the default is accept everything except slash
+     */
+    class Parameter(val name: String, val regex: String = "[^/]+?") : PathSegment() {
+        override fun asRegexString(extract: Boolean): String = if (extract) "($regex)" else regex
     }
 
+    /**
+     * A segment representing a wildcard, matching everything including dashes.
+     */
     object Wildcard : PathSegment() {
-        override fun asRegexString(): String = ".*?" // Accept everything
+        override fun asRegexString(extract: Boolean): String = ".*?" // Accept everything
     }
 }

--- a/src/test/java/io/javalin/TestApiBuilder.kt
+++ b/src/test/java/io/javalin/TestApiBuilder.kt
@@ -226,6 +226,25 @@ class TestApiBuilder {
         assertThat(Unirest.delete(http.origin + "/s/users/myUser").asString().status).isEqualTo(204)
     }
 
+    @Test
+    fun `Regex parameter works`() = TestUtil.test { app, http ->
+        app.routes {
+            get("/user") {
+                it.result("All my users")
+            }
+            get("/user/{id:[0-9]+}") {
+                it.result("My single user with id: ${it.pathParam<Long>("id").get()}")
+            }
+            get("/user/count") {
+                it.result("42")
+            }
+        }
+
+        assertThat(Unirest.get(http.origin + "/user").asString().body).isEqualTo("All my users")
+        assertThat(Unirest.get(http.origin + "/user/2").asString().body).isEqualTo("My single user with id: 2")
+        assertThat(Unirest.get(http.origin + "/user/count").asString().body).isEqualTo("42")
+    }
+
     class UserController : CrudHandler {
 
         override fun getAll(ctx: Context) {


### PR DESCRIPTION
Add custom path parameter regex. As seen in the test, this allows the user to only map specific requests to an endpoint.