### PR TITLE
Add content length header config for static files

### DIFF
--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -112,7 +112,7 @@ public class JavalinConfig {
         return this;
     }
 
-    public JavalinConfig addStaticFiles(@NotNull String classpathPath,@NotNull boolean enforceContentLengthHeader) {
+    public JavalinConfig addStaticFiles(@NotNull String classpathPath, boolean enforceContentLengthHeader) {
         addStaticFiles(classpathPath, Location.CLASSPATH, enforceContentLengthHeader);
         return this;
     }
@@ -122,7 +122,7 @@ public class JavalinConfig {
         return this;
     }
 
-    public JavalinConfig addStaticFiles(@NotNull String path, @NotNull Location location,@NotNull boolean enforceContentLengthHeader) {
+    public JavalinConfig addStaticFiles(@NotNull String path, @NotNull Location location, boolean enforceContentLengthHeader) {
         JettyUtil.disableJettyLogger();
         if (inner.resourceHandler == null) inner.resourceHandler = new JettyResourceHandler();
         inner.resourceHandler.addStaticFileConfig(new StaticFileConfig(path, location, enforceContentLengthHeader));

--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -108,14 +108,24 @@ public class JavalinConfig {
     }
 
     public JavalinConfig addStaticFiles(@NotNull String classpathPath) {
-        addStaticFiles(classpathPath, Location.CLASSPATH);
+        addStaticFiles(classpathPath, false);
+        return this;
+    }
+
+    public JavalinConfig addStaticFiles(@NotNull String classpathPath,@NotNull boolean enforceContentLengthHeader) {
+        addStaticFiles(classpathPath, Location.CLASSPATH, enforceContentLengthHeader);
         return this;
     }
 
     public JavalinConfig addStaticFiles(@NotNull String path, @NotNull Location location) {
+        addStaticFiles(path, location, false);
+        return this;
+    }
+
+    public JavalinConfig addStaticFiles(@NotNull String path, @NotNull Location location,@NotNull boolean enforceContentLengthHeader) {
         JettyUtil.disableJettyLogger();
         if (inner.resourceHandler == null) inner.resourceHandler = new JettyResourceHandler();
-        inner.resourceHandler.addStaticFileConfig(new StaticFileConfig(path, location));
+        inner.resourceHandler.addStaticFileConfig(new StaticFileConfig(path, location, enforceContentLengthHeader));
         return this;
     }
 

--- a/javalin/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
+++ b/javalin/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
@@ -28,7 +28,7 @@ class ResponseWrapperContext(request: HttpServletRequest, val config: JavalinCon
     val compStrat = config.inner.compressionStrategy
 }
 
-class JavalinResponseWrapper(val res: HttpServletResponse, private val rwc: ResponseWrapperContext) : HttpServletResponseWrapper(res) {
+class JavalinResponseWrapper(val res: HttpServletResponse, val rwc: ResponseWrapperContext) : HttpServletResponseWrapper(res) {
 
     private val outputStreamWrapper by lazy { OutputStreamWrapper(res, rwc) }
     override fun getOutputStream() = outputStreamWrapper

--- a/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -130,7 +130,13 @@ class JettyResourceHandler : io.javalin.http.staticfiles.ResourceHandler {
     }
 
     private fun getCompressedFile(originResource: Resource, target: String, type: CompressType, level: Int): Resource {
-        val tmp = File(tempDir.path, target + type.extension).apply { this.deleteOnExit() }
+        val tmp = File(tempDir.path, target + type.extension).apply {
+            this.parentFile.also {
+                it.mkdirs()
+                it.deleteOnExit()
+            }
+            this.deleteOnExit()
+        }
         if (!tmp.exists()) {
             val fileInput = originResource.inputStream
             val outputStream: OutputStream = when (type) {

--- a/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -75,6 +75,7 @@ class JettyResourceHandler : io.javalin.http.staticfiles.ResourceHandler {
 
         fun handleFile(target: String, baseRequest: Request, request: HttpServletRequest, response: HttpServletResponse) {
             var resource = getResource(target)
+            if(resource.isDirectoryWithWelcomeFile(this, target)) return
             val rwc = (response as JavalinResponseWrapper).rwc
                     when {
                         rwc.acceptsBrotli && rwc.compStrat.brotli != null -> {

--- a/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -73,15 +73,15 @@ class JettyResourceHandler : io.javalin.http.staticfiles.ResourceHandler {
     val tempDir = createTempDir("javalin-compress").also { it.deleteOnExit() }
 
     private fun getCompressedFile(originResource: Resource, target: String, type: CompressType, level: Int): Resource {
-        val my = File(tempDir.path, target + "." + type.fileType).apply { this.deleteOnExit() }
-        if (!my.exists()) {
+        val tmp = File(tempDir.path, target + type.extension).apply { this.deleteOnExit() }
+        if (!tmp.exists()) {
             val fileInput = originResource.inputStream
             val outputStream: OutputStream = when (type) {
                 CompressType.GZIP -> {
-                    LeveledGzipStream(my.outputStream(), level)
+                    LeveledGzipStream(tmp.outputStream(), level)
                 }
                 CompressType.BR -> {
-                    LeveledBrotliStream(my.outputStream(), level)
+                    LeveledBrotliStream(tmp.outputStream(), level)
                 }
             }
             val buffer = ByteArray(2048)
@@ -92,7 +92,7 @@ class JettyResourceHandler : io.javalin.http.staticfiles.ResourceHandler {
             fileInput.close()
             outputStream.close()
         }
-        return Resource.newResource(my)
+        return Resource.newResource(tmp)
     }
 
     override fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean {

--- a/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -72,7 +72,7 @@ class JettyResourceHandler : io.javalin.http.staticfiles.ResourceHandler {
 
     inner class StaticFileHandler : ResourceHandler() {
         var enforceContentLengthHeader = false
-
+        val CUSTOM_COMPRESS_PREFIX = "javalin-pecompressed-files/"
         fun handleFile(target: String, baseRequest: Request, request: HttpServletRequest, response: HttpServletResponse) {
             var resource = getResource(target)
             if(resource.isDirectoryWithWelcomeFile(this, target)) return
@@ -111,6 +111,13 @@ class JettyResourceHandler : io.javalin.http.staticfiles.ResourceHandler {
             }
             response.contentType = null
             super.handle(target, baseRequest, request, response)
+        }
+
+        override fun getResource(path: String): Resource {// return custom resource
+            if (path.startsWith(CUSTOM_COMPRESS_PREFIX)) {
+                return Resource.newResource(path.substringAfter(CUSTOM_COMPRESS_PREFIX))
+            }
+            return super.getResource(path)
         }
     }
 

--- a/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.kt
@@ -4,7 +4,8 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 enum class Location { CLASSPATH, EXTERNAL; }
-data class StaticFileConfig(val path: String, val location: Location, var enforceContentLengthHeader: Boolean)
+data class StaticFileConfig(val path: String, val location: Location
+                            , var enforceContentLengthHeader: Boolean = false)
 
 interface ResourceHandler {
     fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean

--- a/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.kt
@@ -4,7 +4,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 enum class Location { CLASSPATH, EXTERNAL; }
-data class StaticFileConfig(val path: String, val location: Location)
+data class StaticFileConfig(val path: String, val location: Location, var enforceContentLengthHeader: Boolean)
 
 interface ResourceHandler {
     fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean


### PR DESCRIPTION
For issue #892.
Now static file can enforce to use content-length response header instead of transfer-encoding.
That's helpful for resume large file download.
I just tested resume large file download successfully on Chrome 81 and Firefox 75.

```kotlin

val app = Javalin.create {config->
    // enforce to use content-length
    config.addStaticFiles("/public/page",true) 
    // follow jetty default setting
    config.addStaticFiles("/public/assets")
    config.addStaticFiles("/public/js",false)
}.start()
```
