### PR TITLE
[bundle] add javalin-bundle module

### DIFF
--- a/javalin-bundle/pom.xml
+++ b/javalin-bundle/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>javalin-parent</artifactId>
+        <groupId>io.javalin</groupId>
+        <version>3.8.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>javalin-bundle</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin-openapi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/javalin-bundle/src/main/resources/logback.xml
+++ b/javalin-bundle/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     <modules>
         <module>javalin</module>
         <module>javalin-openapi</module>
+      <module>javalin-bundle</module>
     </modules>
 
     <parent>
@@ -67,6 +68,7 @@
         <jetty.version>9.4.28.v20200408</jetty.version>
         <jtwig.version>5.87.0.RELEASE</jtwig.version>
         <jvmbrotli.version>0.2.0</jvmbrotli.version>
+        <logback.version>1.2.3</logback.version>
         <micrometer.version>1.3.6</micrometer.version>
         <mustache.version>0.9.6</mustache.version>
         <pebble.version>3.1.2</pebble.version>
@@ -119,6 +121,11 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
             </dependency>
 
             <!-- Jetty -->


### PR DESCRIPTION
This add javalin-bundle module

a ready-to-go javalin dependency with Javalin, Logback and OpenAPI Plugin
a default logback config with console appender and info level is provided

original issue #933 