### PR TITLE
TestExceptionMapper: Do proper JSON escaping on title

### DIFF
--- a/javalin/src/main/java/io/javalin/http/HttpResponseExceptionMapper.kt
+++ b/javalin/src/main/java/io/javalin/http/HttpResponseExceptionMapper.kt
@@ -7,6 +7,7 @@
 package io.javalin.http
 
 import io.javalin.core.util.Header
+import io.javalin.http.util.JsonEscapeUtil
 import java.util.concurrent.CompletionException
 
 object HttpResponseExceptionMapper {
@@ -58,6 +59,6 @@ object HttpResponseExceptionMapper {
         else -> docsUrl + "error-responses"
     }
 
-    private fun String.jsonEscape() = this.replace("\"", "\\\"")
+    private fun String.jsonEscape() = JsonEscapeUtil.escape(this)
 
 }

--- a/javalin/src/main/java/io/javalin/http/util/JsonEscapeUtil.kt
+++ b/javalin/src/main/java/io/javalin/http/util/JsonEscapeUtil.kt
@@ -1,0 +1,25 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin.http.util
+
+object JsonEscapeUtil {
+    fun escape(str: String): String {
+        val builder = StringBuilder(str.length)
+        for (ch in str) {
+            builder.append(when (ch) {
+                '\"' -> "\\\""
+                '\n' -> "\\n"
+                '\r' -> "\\r"
+                '\\' -> "\\\\"
+                '\t' -> "\\t"
+                '\b' -> "\\b"
+                else -> ch
+            })
+        }
+        return builder.toString()
+    }
+}

--- a/javalin/src/test/java/io/javalin/TestExceptionMapper.kt
+++ b/javalin/src/test/java/io/javalin/TestExceptionMapper.kt
@@ -92,4 +92,10 @@ class TestExceptionMapper {
         assertThat(http.jsonGet("/").body).contains("""MY MESSAGE WITH \"QUOTES\"""")
     }
 
+    @Test
+    fun `exception title can contain newlines`() = TestUtil.test { app, http ->
+        app.get("/") { throw BadRequestResponse("MY MESSAGE WITH \nNEWLINES\n") }
+        assertThat(http.jsonGet("/").body).contains("""MY MESSAGE WITH \nNEWLINES\n""")
+    }
+
 }


### PR DESCRIPTION
The jsonEscape function in TestExceptionMapper didn't
really do anything other than replace `"` with `\"`, which
doesn't handle things like newlines, backslashes or
any other characters that need to be escaped in JSON.

This patch uses the Jackson library function
JsonStringEncoder.quoteAsString to do the escaping.