### PR TITLE
Add missing JvmSynthetic annotations to reified methods. Fixes #979

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -116,6 +116,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
      * JavalinJson can be configured to use any mapping library.
      * @return The mapped object
      */
+    @JvmSynthetic
     inline fun <reified T : Any> body(): T = bodyAsClass(T::class.java)
 
     /** Gets the request body as a [ByteArray].
@@ -172,6 +173,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     fun <T> formParam(key: String, clazz: Class<T>, default: String? = null) = Validator.create(clazz, formParam(key, default), "Form parameter '$key' with value '${formParam(key, default)}'")
 
     /** Reified version of [formParam] (Kotlin only) */
+    @JvmSynthetic
     inline fun <reified T : Any> formParam(key: String, default: String? = null) = formParam(key, T::class.java, default)
 
     /** Gets a list of form params for the specified key, or empty list. */
@@ -198,6 +200,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     fun <T> pathParam(key: String, clazz: Class<T>) = Validator.create(clazz, pathParam(key), "Path parameter '$key' with value '${pathParam(key)}'")
 
     /** Reified version of [pathParam] (Kotlin only) */
+    @JvmSynthetic
     inline fun <reified T : Any> pathParam(key: String) = pathParam(key, T::class.java)
 
     /** Gets a map of all the [pathParam] keys and values. */
@@ -247,6 +250,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     fun <T> header(header: String, clazz: Class<T>): Validator<T> = Validator.create(clazz, header(header), "Request header '$header' with value '${header(header)}'")
 
     /** Reified version of [header] (Kotlin only) */
+    @JvmSynthetic
     inline fun <reified T : Any> header(header: String) = header(header, T::class.java)
 
     /** Gets a map with all the header keys and values on the request. */
@@ -292,6 +296,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     fun <T> queryParam(key: String, clazz: Class<T>, default: String? = null) = Validator.create(clazz, queryParam(key, default), "Query parameter '$key' with value '${queryParam(key, default)}'")
 
     /** Reified version of [queryParam] (Kotlin only) */
+    @JvmSynthetic
     inline fun <reified T : Any> queryParam(key: String, default: String? = null) = queryParam(key, T::class.java, default)
 
     /** Gets a list of query params for the specified key, or empty list. */

--- a/javalin/src/main/java/io/javalin/websocket/WsContext.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsContext.kt
@@ -36,11 +36,13 @@ abstract class WsContext(val sessionId: String, @JvmField val session: Session) 
     fun queryParam(key: String): String? = upgradeCtx.queryParam(key)
     fun queryParam(key: String, default: String? = null): String? = upgradeCtx.queryParam(key, default)
     fun <T> queryParam(key: String, clazz: Class<T>, default: String? = null) = upgradeCtx.queryParam(key, clazz, default)
+    @JvmSynthetic
     inline fun <reified T : Any> queryParam(key: String, default: String? = null) = queryParam(key, T::class.java, default)
 
     fun pathParamMap(): Map<String, String> = upgradeCtx.pathParamMap()
     fun pathParam(key: String): String = upgradeCtx.pathParam(key)
     fun <T> pathParam(key: String, clazz: Class<T>) = upgradeCtx.pathParam(key, clazz)
+    @JvmSynthetic
     inline fun <reified T : Any> pathParam(key: String) = pathParam(key, T::class.java)
 
     fun host() = upgradeReq.host // why can't we get this from upgradeCtx?


### PR DESCRIPTION
Fixes issue #979 by annotating all reified methods which have a corresponding non-reified signature with `@JvmSynthetic`

The functions are already supposed to be for Kotlin users only, so I do not think it will cause problems.

Two cases of reified functions remain.
- `JavalinConfig.getPlugin()` in JavalinConfigExt.kt. This one is an extension function which will be available as `JavalinConfigExtKt.getPlugin(JavalinConfig)` which no one should be using. There is also no conflicting method here.
- `Context.bodyValidator()` in Context.kt. We do not have another method with the same name and signature that should be available. So we do not need to hide this reified method.
