### PR TITLE
Remove OS specific line ending solution in TestMultipart

### DIFF
--- a/javalin/src/test/java/io/javalin/testing/UploadInfo.kt
+++ b/javalin/src/test/java/io/javalin/testing/UploadInfo.kt
@@ -6,4 +6,4 @@
 
 package io.javalin.testing
 
-class UploadInfo(val filename: String = "", val contentLength: Int = 0, val contentType: String = "", val extension: String = "")
+class UploadInfo(val filename: String = "", val size: Long = 0L, val contentType: String = "", val extension: String = "")


### PR DESCRIPTION
The new way enables the test file to have a different line ending compared to the OS.
Also remove the deprecated use of UploadedFile.contentLength, using size instead.

The two modified tests caused me some trouble locally as the test file has Linux style line (LF) endings on my Windows system causing the tests to fail. The new solution checks the resulting string for Windows style line endings (CRLF) and uses a different expected string compared to Linux/macOS.

This also fixes the scenario of a test file with Windows style line endings on a non Windows system.