### PR TITLE
Improve welcome file handling

### DIFF
--- a/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -44,6 +44,7 @@ class JettyResourceHandler(val precompressStaticFiles: Boolean = false) : io.jav
             val targetResource by lazy { path.removePrefix(urlPathPrefix) }
             return when {
                 urlPathPrefix == "/" -> super.getResource(path) // same as regular ResourceHandler
+                targetResource == "" -> super.getResource("/") // directory without trailing '/'
                 !path.startsWith(urlPathPrefix) -> EmptyResource.INSTANCE
                 !targetResource.startsWith("/") -> EmptyResource.INSTANCE
                 else -> super.getResource(targetResource)

--- a/javalin/src/test/java/io/javalin/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/TestStaticFiles.kt
@@ -101,6 +101,8 @@ class TestStaticFiles {
     fun `directory root return welcome file if there is a welcome file`() = TestUtil.test(defaultStaticResourceApp) { _, http ->
         assertThat(http.get("/subdir/").status).isEqualTo(200)
         assertThat(http.getBody("/subdir/")).isEqualTo("<h1>Welcome file</h1>")
+        assertThat(http.get("/subdir").status).isEqualTo(200)
+        assertThat(http.getBody("/subdir")).isEqualTo("<h1>Welcome file</h1>")
     }
 
     @Test


### PR DESCRIPTION
Allow for paths to static files, such as `/subdir` to be handled as `/subdir/`, which in turn allows for `/subdir/index.html` to be accessed via `/subdir`, `/subdir/` and `/subdir/index.html`.

Fixes #1002.