### PR TITLE
Closes #1012 - Check if Accept header `contains` */* instead of being…

### DIFF
--- a/javalin/src/main/java/io/javalin/http/SinglePageHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/SinglePageHandler.kt
@@ -41,7 +41,7 @@ class SinglePageHandler {
 
     fun handle(ctx: Context): Boolean {
         val accepts = ctx.header(Header.ACCEPT) ?: ""
-        if (accepts.contains("text/html") || accepts == "*/*" || accepts == "") {
+        if (accepts.contains("text/html") || accepts.contains("*/*") || accepts == "") {
             for (path in pathPageMap.keys) {
                 if (ctx.path().startsWith(path)) {
                     ctx.html(when (ctx.isLocalhost()) {

--- a/javalin/src/test/java/io/javalin/TestSinglePageMode.kt
+++ b/javalin/src/test/java/io/javalin/TestSinglePageMode.kt
@@ -92,6 +92,13 @@ class TestSinglePageMode {
     }
 
     @Test
+    fun `SinglePageHandler works when accepts contains star-slash-star`() = TestUtil.test(rootSinglePageApp_classPath) { app, http ->
+        val ieAcceptHeader = "image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, application/x-shockwave-flash, application/msword, */*"
+        val starSlashStarAcceptsResponseBody = Unirest.get("http://localhost:${app.port()}/not-a-file").header(Header.ACCEPT, ieAcceptHeader).asString().body
+        assertThat(starSlashStarAcceptsResponseBody).contains("HTML works")
+    }
+
+    @Test
     fun `SinglePageHandler works for just subpaths - classpath`() = TestUtil.test(dualSinglePageApp_classPath) { _, http ->
         assertThat(http.htmlGet("/").body).contains("Not found")
         assertThat(http.htmlGet("/").status).isEqualTo(404)


### PR DESCRIPTION
… equal to make single page handler work with IE.