### PR TITLE
Add jaeger tracing plugin

### DIFF
--- a/javalin/pom.xml
+++ b/javalin/pom.xml
@@ -91,6 +91,12 @@
             <artifactId>micrometer-core</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-client</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+
         <!-- END Optional dependencies -->
 
         <!-- BEGIN Test dependencies -->
@@ -132,7 +138,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/javalin/src/main/java/io/javalin/plugin/tracing/JaegerPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/tracing/JaegerPlugin.kt
@@ -1,0 +1,37 @@
+package io.javalin.plugin.tracing
+
+import io.jaegertracing.Configuration
+import io.jaegertracing.internal.JaegerTracer
+import io.jaegertracing.internal.samplers.ProbabilisticSampler
+import io.javalin.Javalin
+import io.javalin.core.plugin.Plugin
+import io.opentracing.util.GlobalTracer
+
+class JaegerPlugin @JvmOverloads constructor(
+        private val tracer: JaegerTracer = Configuration("javalin-app")
+                .tracerBuilder
+                .withSampler(ProbabilisticSampler(0.8))
+                .build()
+) : Plugin {
+    override fun apply(app: Javalin) {
+        // register tracer as global tracer
+        GlobalTracer.registerIfAbsent(tracer)
+        app.before {
+            // start root span
+            val span = tracer.buildSpan("root-span")
+                    .withTag("method", it.method())
+                    .withTag("path", it.path())
+                    .start()
+            // set as active span in scope manager
+            tracer.scopeManager().activate(span)
+        }
+        // finish root span
+        app.after { tracer.scopeManager().activeSpan().finish() }
+
+        // in case of exception mark active span as error - and log the exception message
+        // note this won't get triggered if the application also defines an exception handler
+        app.exception(Exception::class.java) { e, _ ->
+            tracer.scopeManager().activeSpan().setTag("error", true).log(e.message).finish()
+        }
+    }
+}

--- a/javalin/src/test/java/io/javalin/TestJaegerPlugin.kt
+++ b/javalin/src/test/java/io/javalin/TestJaegerPlugin.kt
@@ -1,0 +1,46 @@
+package io.javalin
+
+import io.jaegertracing.Configuration
+import io.jaegertracing.internal.reporters.InMemoryReporter
+import io.jaegertracing.internal.samplers.ConstSampler
+import io.javalin.plugin.tracing.JaegerPlugin
+import io.javalin.testing.HttpUtil
+import org.assertj.core.api.Assertions
+import org.junit.After
+import org.junit.Test
+
+class TestJaegerPlugin {
+    private val inMemoryReporter: InMemoryReporter = InMemoryReporter()
+    val app: Javalin = Javalin.create { config ->
+        config.registerPlugin(JaegerPlugin(Configuration("jaeger-plugin-test")
+                .tracerBuilder
+                .withSampler(ConstSampler(true))
+                .withReporter(inMemoryReporter)
+                .build())
+        )
+    }.start(0)
+    val http = HttpUtil(app.port())
+
+    @After
+    fun after() {
+        app.stop()
+    }
+
+    @Test
+    fun `root span created with tags`() {
+        app.get("/hello/:name") { it.result("Hello: ${it.pathParam("name")}") }
+        http.get("/hello/jon")
+
+        val spans = inMemoryReporter.spans
+        Assertions.assertThat(spans.size).isEqualTo(1)
+
+        val rootSpan = spans.first()
+        Assertions.assertThat(rootSpan.tags.containsKey("method"))
+        Assertions.assertThat(rootSpan.tags.containsKey("path"))
+
+        Assertions.assertThat(rootSpan.tags.getOrDefault("method", "")).isEqualTo("GET")
+        Assertions.assertThat(rootSpan.tags.getOrDefault("path", "")).isEqualTo("/hello/jon")
+
+        Assertions.assertThat(rootSpan.isFinished)
+    }
+}


### PR DESCRIPTION
Adds a plugin that sets up the jaeger tracer, starts the root span, and marks it as active in the scope manager

```
// used this to actually play around
import io.javalin.Javalin
import io.javalin.plugin.tracing.JaegerPlugin
import io.opentracing.util.GlobalTracer

fun main() {
    val app = Javalin.create {
        it.registerPlugin (JaegerPlugin())
    }

    val tracer = GlobalTracer.get()
    app.get("/") {
        val scope = tracer.scopeManager()
        val span = tracer.buildSpan("get-user")
                .asChildOf(scope.activeSpan())
                .start()
        scope.activate(span).use { _ ->
            it.result("finished")
            span.finish()
        }
    }
    app.get("/foo/:id") {
        val scope = tracer.scopeManager()
        val span = tracer.buildSpan("set-user")
                .asChildOf(scope.activeSpan())
                .withTag("id", it.pathParam("id"))
                .start()
        scope.activate(span).use { _ ->
            span.finish()
            it.result("set user")
        }
    }

    app.start()
}

```
example image of the span from the jaeger UI
![Screen Shot 2020-06-22 at 11 16 57 PM](https://user-images.githubusercontent.com/6923282/85357445-5382a900-b4df-11ea-8897-f65a6bd5053e.png)


the jaeger all in one binary I used https://github.com/jaegertracing/jaeger/releases/tag/v1.18.0
