### PR TITLE
remove check for localhost,  fixes #1024

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/rendering/vue/JavalinVue.kt
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/vue/JavalinVue.kt
@@ -61,7 +61,7 @@ object JavalinVue {
         |    }""".trimMargin() + "\n</script>\n"
 
     internal fun setRootDirPathIfUnset(ctx: Context) {
-        vueDirPath = vueDirPath ?: if (ctx.isLocalhost()) Paths.get("src/main/resources/vue") else PathMaster.classpathPath("/vue")
+        vueDirPath = vueDirPath ?: PathMaster.classpathPath("/vue")
     }
 
     private fun String.replaceWebjarsWithCdn() =


### PR DESCRIPTION
Removing the localhost check should fix the issue, since `/vue` is already resolved differently by `PathMaster#classpathPath` when the server is running as a standalone jar. 