### PR TITLE
[javalin] Expose factory method JavalinJackson.defaultObjectMapper

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/json/JavalinJackson.kt
+++ b/javalin/src/main/java/io/javalin/plugin/json/JavalinJackson.kt
@@ -26,6 +26,14 @@ object JavalinJackson {
         return (objectMapper ?: defaultObjectMapper)
     }
 
+    @JvmStatic
+    fun defaultObjectMapper(): ObjectMapper = try {
+        val className = OptionalDependency.JACKSON_KT.testClass
+        ObjectMapper().registerModule(Class.forName(className).getConstructor().newInstance() as Module)
+    } catch (e: ClassNotFoundException) {
+        ObjectMapper()
+    }
+
     fun toJson(`object`: Any): String {
         Util.ensureDependencyPresent(OptionalDependency.JACKSON)
         return (objectMapper ?: defaultObjectMapper).writeValueAsString(`object`)
@@ -37,13 +45,6 @@ object JavalinJackson {
             Util.ensureDependencyPresent(OptionalDependency.JACKSON_KT)
         }
         return (objectMapper ?: defaultObjectMapper).readValue(json, clazz)
-    }
-
-    private fun defaultObjectMapper(): ObjectMapper = try {
-        val className = OptionalDependency.JACKSON_KT.testClass
-        ObjectMapper().registerModule(Class.forName(className).getConstructor().newInstance() as Module)
-    } catch (e: ClassNotFoundException) {
-        ObjectMapper()
     }
 
 }

--- a/javalin/src/test/java/io/javalin/TestJson.kt
+++ b/javalin/src/test/java/io/javalin/TestJson.kt
@@ -131,4 +131,16 @@ class TestJson {
         assertThat(SerializeableObject().value2).isEqualTo(mappedBack.value2)
     }
 
+    data class SerializeableDataClass(val value1: String, val value2: String)
+
+    @Test
+    fun `can use JavalinJson with a custom object-mapper on a kotlin data class`() {
+        val jacksonKtEnabledObjectMapper = JavalinJackson.defaultObjectMapper()
+        JavalinJackson.configure(jacksonKtEnabledObjectMapper) // override mapper
+        val mapped = JavalinJson.toJson(SerializeableDataClass("First value", "Second value"))
+        val mappedBack = JavalinJson.fromJson(mapped, SerializeableDataClass::class.java)
+        assertThat("First value").isEqualTo(mappedBack.value1)
+        assertThat("Second value").isEqualTo(mappedBack.value2)
+    }
+
 }


### PR DESCRIPTION
When a mapper is provided via JavalinJackson.configure(), we lack the ability to retain the settings of the default mapper
(namely, having the jackson-module-kotlin module registered by default, which can be surprising)