### PR TITLE
Use jte 0.8.0, default engine uses ContentType.Html.

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/rendering/template/JavalinJte.kt
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/template/JavalinJte.kt
@@ -10,6 +10,7 @@ import io.javalin.core.util.OptionalDependency
 import io.javalin.core.util.Util
 import io.javalin.http.Context
 import io.javalin.plugin.rendering.FileRenderer
+import org.jusecase.jte.ContentType
 import org.jusecase.jte.TemplateEngine
 import org.jusecase.jte.output.StringOutput
 import org.jusecase.jte.resolve.DirectoryCodeResolver
@@ -33,6 +34,6 @@ object JavalinJte : FileRenderer {
         return stringOutput.toString()
     }
 
-    private fun defaultJteEngine() = TemplateEngine.create(DirectoryCodeResolver(File("src/main/jte").toPath()))
+    private fun defaultJteEngine() = TemplateEngine.create(DirectoryCodeResolver(File("src/main/jte").toPath()), ContentType.Html)
 
 }

--- a/javalin/src/test/java/io/javalin/TestTemplates.kt
+++ b/javalin/src/test/java/io/javalin/TestTemplates.kt
@@ -24,6 +24,7 @@ import org.jtwig.functions.FunctionRequest
 import org.jtwig.functions.SimpleJtwigFunction
 import org.jtwig.util.FunctionValueUtils
 import org.junit.Test
+import org.jusecase.jte.ContentType
 import org.jusecase.jte.TemplateEngine
 import org.jusecase.jte.resolve.ResourceCodeResolver
 import java.io.File
@@ -144,7 +145,7 @@ class TestTemplates {
     @Test
     fun `jte works`() = TestUtil.test { app, http ->
         try {
-            JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath()))
+            JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath(), ContentType.Html))
             app.get("/hello") { ctx -> ctx.render("test.jte", model("page", JteTestPage("hello", "world"))) }
             assertThat(http.getBody("/hello")).isEqualToIgnoringNewLines("<h1>hello world!</h1>")
         } catch (e:UnsupportedClassVersionError) {
@@ -155,7 +156,7 @@ class TestTemplates {
     @Test
     fun `jte multiple params work`() = TestUtil.test { app, http ->
         try {
-            JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath()))
+            JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath(), ContentType.Html))
             app.get("/hello") { ctx -> ctx.render("multiple-params.jte", model("one", "hello", "two", "world")) }
             assertThat(http.getBody("/hello")).isEqualToIgnoringNewLines("<h1>hello world!</h1>")
         } catch (e:UnsupportedClassVersionError) {

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <swagger.ui.version>3.25.2</swagger.ui.version>
         <thymeleaf.version>3.0.11.RELEASE</thymeleaf.version>
         <velocity.version>2.2</velocity.version>
-        <jte.version>0.6.0</jte.version>
+        <jte.version>0.8.0</jte.version>
 
         <!-- TEST DEPENDENCIES -->
         <assertj.version>3.15.0</assertj.version>


### PR DESCRIPTION
Hey @tipsy, I finished HMTL support for jte sooner than expected. The context-sensitive output escaping works really good and is very fast too. I'm running my website in production with 0.8.0 and `ContentType.Html` for a week or so, that I'd consider the 0.8.0 version stable!

In this PR I updated the jte version to 0.8.0 and set `ContentType.Html` as default in `JavalinJte.kt`. I think it is a sane default and prevents users from nasty footguns (XSS attacks and the like).

Let me know what you think 😊