### PR TITLE
Use jte 1.0.0.

### DIFF
--- a/javalin/pom.xml
+++ b/javalin/pom.xml
@@ -82,7 +82,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jusecase</groupId>
+            <groupId>gg.jte</groupId>
             <artifactId>jte</artifactId>
             <optional>true</optional>
         </dependency>

--- a/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -26,5 +26,5 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
     SWAGGER_CORE("Swagger Core", "io.swagger.v3.oas.models.OpenAPI", "io.swagger.core.v3", "swagger-models", "2.1.2"),
     CLASS_GRAPH("ClassGraph", "io.github.classgraph.ClassGraph", "io.github.classgraph", "classgraph", "4.8.66"),
     JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),
-    JTE("jte", "org.jusecase.jte.TemplateEngine", "org.jusecase", "jte", "0.6.0"),
+    JTE("jte", "gg.jte.TemplateEngine", "gg.jte", "jte", "1.0.0"),
 }

--- a/javalin/src/main/java/io/javalin/plugin/rendering/template/JavalinJte.kt
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/template/JavalinJte.kt
@@ -10,10 +10,10 @@ import io.javalin.core.util.OptionalDependency
 import io.javalin.core.util.Util
 import io.javalin.http.Context
 import io.javalin.plugin.rendering.FileRenderer
-import org.jusecase.jte.ContentType
-import org.jusecase.jte.TemplateEngine
-import org.jusecase.jte.output.StringOutput
-import org.jusecase.jte.resolve.DirectoryCodeResolver
+import gg.jte.ContentType
+import gg.jte.TemplateEngine
+import gg.jte.output.StringOutput
+import gg.jte.resolve.DirectoryCodeResolver
 import java.io.File
 
 object JavalinJte : FileRenderer {

--- a/javalin/src/test/java/io/javalin/TestTemplates.kt
+++ b/javalin/src/test/java/io/javalin/TestTemplates.kt
@@ -24,9 +24,9 @@ import org.jtwig.functions.FunctionRequest
 import org.jtwig.functions.SimpleJtwigFunction
 import org.jtwig.util.FunctionValueUtils
 import org.junit.Test
-import org.jusecase.jte.ContentType
-import org.jusecase.jte.TemplateEngine
-import org.jusecase.jte.resolve.ResourceCodeResolver
+import gg.jte.ContentType
+import gg.jte.TemplateEngine
+import gg.jte.resolve.ResourceCodeResolver
 import java.io.File
 
 class TestTemplates {

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <swagger.ui.version>3.25.2</swagger.ui.version>
         <thymeleaf.version>3.0.11.RELEASE</thymeleaf.version>
         <velocity.version>2.2</velocity.version>
-        <jte.version>0.8.0</jte.version>
+        <jte.version>1.0.0</jte.version>
 
         <!-- TEST DEPENDENCIES -->
         <assertj.version>3.15.0</assertj.version>
@@ -200,7 +200,7 @@
                 <version>${pebble.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jusecase</groupId>
+                <groupId>gg.jte</groupId>
                 <artifactId>jte</artifactId>
                 <version>${jte.version}</version>
             </dependency>


### PR DESCRIPTION
Hey @tipsy!

I finally considered jte stable enough to release a 1.0 version! I also built a small landing page for it with Javalin (https://jte.gg/).

Sorry about the jte tutorial delay, gonna sit down and write it the next days. It probably makes sense to publish it after the next Javalin version is out, right? Otherwise people won't have the extension and might be confused.