### PR TITLE
Support for multiple app attributes with the same class type.

### DIFF
--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -61,7 +61,7 @@ public class JavalinConfig {
     // is to provide a cleaner API with dedicated setters
     public class Inner {
         @NotNull public Map<Class<? extends Plugin>, Plugin> plugins = new HashMap<>();
-        @NotNull public Map<Class<?>, Object> appAttributes = new HashMap<>();
+        @NotNull public Map<Class<?>, Map<String, Object>> appAttributes = new HashMap<>();
         @Nullable public RequestLogger requestLogger = null;
         @Nullable public ResourceHandler resourceHandler = null;
         @NotNull public AccessManager accessManager = SecurityUtil::noopAccessManager;

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -31,7 +31,11 @@ import javax.servlet.http.HttpServletResponse
  * @see <a href="https://javalin.io/documentation#context">Context in docs</a>
  */
 @Suppress("UNCHECKED_CAST")
-open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: HttpServletResponse, private val appAttributes: Map<Class<*>, Any> = mapOf()) {
+open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: HttpServletResponse, private val appAttributes: Map<Class<*>, Map<String, Any>> = mapOf()) {
+
+    companion object {
+        const val APP_ATTRIBUTE_DEFAULT_IDENTIFIER = "default"
+    }
 
     // @formatter:off
     @get:JvmSynthetic @set:JvmSynthetic internal var inExceptionHandler = false
@@ -63,7 +67,10 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     fun <T> use(clazz: Class<T>): T = req.getAttribute("ctx-ext-${clazz.canonicalName}") as T
 
     /** Gets an attribute from the Javalin instance serving the request */
-    fun <T> appAttribute(clazz: Class<T>): T = appAttributes[clazz] as T
+    fun <T> appAttribute(clazz: Class<T>): T = appAttribute(clazz, APP_ATTRIBUTE_DEFAULT_IDENTIFIER)
+
+    /** Gets aan attribute from the Javalin instance serving the request */
+    fun <T> appAttribute(clazz: Class<T>, identifier: String): T = appAttributes[clazz]?.get(identifier) as T
 
     /**
      * Gets cookie store value for specified key.

--- a/javalin/src/main/java/io/javalin/http/util/ContextUtil.kt
+++ b/javalin/src/main/java/io/javalin/http/util/ContextUtil.kt
@@ -68,7 +68,7 @@ object ContextUtil {
             matchedPath: String = "*",
             pathParamMap: Map<String, String> = mapOf(),
             handlerType: HandlerType = HandlerType.INVALID,
-            appAttributes: Map<Class<*>, Any> = mapOf()
+            appAttributes: Map<Class<*>, Map<String, Any>> = mapOf()
     ) = Context(request, response, appAttributes).apply {
         this.matchedPath = matchedPath
         this.pathParamMap = pathParamMap


### PR DESCRIPTION
With the current implementation of the App Attribute feature, you can only register one value to a class type, for example if you have multiple `Database` object instances for different database connections you can only register one as an attribute. 

Some developers will get around this by creating a class that'll store all of their database instances and then just add getters for the code to use later on. The downside for this is you're causing duplicated code across the project. 

This feature allows you to register app attributes with an optional string identifier for the following usage example:
`app.attribute(Database.class, "authentication", ...);`
`app.attribute(Database.class, "accounts", ...);`

and then retrieving app attributes you can use:
`Database authenticationDatabase = context.appAttribute(Database.class, "authentication");`
`Database accountsDatabase = context.appAttribute(Database.class, "accounts");`

If you don't need to specify an identifier than the word "default" will be automatically filled in for you on the original method: `app.attribute(Database.class, ...)`.

**Note:** _I haven't touched Kotlin before so the implementation of the "static final" variable might be incorrect._