### PR TITLE
[javalinvue] Use https instead of matching scheme for cdn resources

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/rendering/vue/JavalinVue.kt
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/vue/JavalinVue.kt
@@ -65,7 +65,7 @@ object JavalinVue {
     }
 
     private fun String.replaceWebjarsWithCdn() =
-            this.replace("@cdnWebjar/", if (useCdn) "//cdn.jsdelivr.net/webjars/org.webjars.npm/" else "/webjars/")
+            this.replace("@cdnWebjar/", if (useCdn) "https://cdn.jsdelivr.net/webjars/org.webjars.npm/" else "/webjars/")
 
 }
 


### PR DESCRIPTION
There doesn't appear to be any valid usecases for fetching insecure CDN
content.