### PR TITLE
OpenAPI: fix adding Enums to components (resolves #1047)

### DIFF
--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt
@@ -104,9 +104,6 @@ internal data class FindSchemaResponse(
 )
 
 internal fun <T> findSchema(clazz: Class<T>): FindSchemaResponse? {
-    getEnumSchema(clazz)?.let {
-        return FindSchemaResponse(it)
-    }
     return when (clazz) {
         String::class.java -> FindSchemaResponse(StringSchema())
         Boolean::class.java -> FindSchemaResponse(BooleanSchema())
@@ -134,17 +131,6 @@ internal fun <T> findSchema(clazz: Class<T>): FindSchemaResponse? {
         }
     }
 }
-
-internal fun <T> getEnumSchema(clazz: Class<T>): Schema<*>? {
-    val values = clazz.enumConstants ?: return null
-
-    val schema = StringSchema()
-    for (enumVal in values) {
-        schema.addEnumItem(enumVal.toString())
-    }
-    return schema
-}
-
 
 internal fun <T> MediaType.example(clazz: Class<T>, value: T, init: Example.() -> Unit) {
     if (examples == null) {

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApi.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApi.kt
@@ -260,6 +260,10 @@ fun buildComplexExample(options: OpenApiOptions): Javalin {
 
     app.get("/ignored", documented(document().ignore()) {})
 
+    app.get("/enums/:my-enum-path-param", documented(document()
+            .pathParam<UserType>("my-enum-path-param")
+            .queryParam<UserType>("my-enum-query-param")) {})
+
     return app
 }
 

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApi.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApi.kt
@@ -45,9 +45,14 @@ import java.time.Instant
 
 class Address(val street: String, val number: Int)
 
-class User(val name: String, val address: Address? = null)
+class User(val name: String, val address: Address? = null, val userType: UserType? = null)
 
 class Log(val timestamp: Instant, val message: String)
+
+enum class UserType{
+    ONE, TWO
+}
+
 
 fun createComplexExampleBaseConfiguration() = openapiDsl {
     info {

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiAnnotations.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiAnnotations.kt
@@ -295,7 +295,6 @@ fun getQueryParamListHandler(ctx: Context) {
 // endregion composed body
 
 @OpenApi(
-        tags = ["user"],
         pathParams = [
             OpenApiParam(name = "my-enum-path-param", type = UserType::class)
         ],

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiAnnotations.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiAnnotations.kt
@@ -294,6 +294,18 @@ fun getQueryParamListHandler(ctx: Context) {
 
 // endregion composed body
 
+@OpenApi(
+        tags = ["user"],
+        pathParams = [
+            OpenApiParam(name = "my-enum-path-param", type = UserType::class)
+        ],
+        queryParams = [
+            OpenApiParam(name = "my-enum-query-param", type = UserType::class)
+        ]
+)
+fun getEnumParamsHandler(ctx: Context) {
+}
+
 class TestOpenApiAnnotations {
     @Test
     fun `createOpenApiSchema works with complexExample and annotations`() {
@@ -316,6 +328,7 @@ class TestOpenApiAnnotations {
         app.get("/upload-with-form-data", ::getUploadWithFormDataHandler)
         app.get("/resources/*", ::getResources)
         app.get("/ignore", ::getIgnore)
+        app.get("/enums/:my-enum-path-param", ::getEnumParamsHandler)
 
         val actual = JavalinOpenApi.createSchema(app)
 

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/json.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/json.kt
@@ -874,7 +874,6 @@ val complexExampleJson = """
     },
     "/enums/{my-enum-path-param}" : {
       "get" : {
-        "tags" : [ "user" ],
         "summary" : "Get enums with myEnumPathParam",
         "operationId" : "getEnumsWithMyEnumPathParam",
         "parameters" : [ {
@@ -1160,31 +1159,8 @@ val overrideJson = """
   },
   "components" : {
     "schemas" : {
-      "Address" : {
-        "required" : [ "number", "street" ],
-        "type" : "object",
-        "properties" : {
-          "street" : {
-            "type" : "string"
-          },
-          "number" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }
-      },
-      "User" : {
-        "required" : [ "name" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
-          },
-          "address" : {
-            "$ref" : "#/components/schemas/Address"
-          }
-        }
-      }
+      "Address" : $addressOpenApiSchema,
+      "User" : $userOpenApiSchema
     }
   }
 }

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/json.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/json.kt
@@ -39,6 +39,10 @@ val userOpenApiSchema = """
       },
       "address":{
           "$ref": "#/components/schemas/Address"
+      },
+      "userType" : {
+        "type" : "string",
+        "enum" : [ "ONE", "TWO" ]
       }
    }
 }
@@ -61,6 +65,14 @@ val addressOpenApiSchema = """
          "format": "int32"
       }
    }
+}
+""".formatJson()
+
+@Language("JSON")
+val userTypeOpenApiSchema = """
+{
+    "type" : "string",
+    "enum" : [ "ONE", "TWO" ]
 }
 """.formatJson()
 
@@ -120,31 +132,8 @@ val queryBeanExample = """
       },
       "components" : {
         "schemas" : {
-          "Address" : {
-            "required" : [ "number", "street" ],
-            "type" : "object",
-            "properties" : {
-              "street" : {
-                "type" : "string"
-              },
-              "number" : {
-                "type" : "integer",
-                "format" : "int32"
-              }
-            }
-          },
-          "User" : {
-            "required" : [ "name" ],
-            "type" : "object",
-            "properties" : {
-              "name" : {
-                "type" : "string"
-              },
-              "address" : {
-                "$ref" : "#/components/schemas/Address"
-              }
-            }
-          }
+          "Address" : $addressOpenApiSchema,
+          "User" : $userOpenApiSchema
         }
       }
     }
@@ -882,12 +871,39 @@ val complexExampleJson = """
           }
         }
       }
+    },
+    "/enums/{my-enum-path-param}" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "summary" : "Get enums with myEnumPathParam",
+        "operationId" : "getEnumsWithMyEnumPathParam",
+        "parameters" : [ {
+          "name" : "my-enum-path-param",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/UserType"
+          }
+        }, {
+          "name" : "my-enum-query-param",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/UserType"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Default response"
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
       "Address": $addressOpenApiSchema,
-      "User": $userOpenApiSchema
+      "User": $userOpenApiSchema,
+      "UserType": $userTypeOpenApiSchema
     },
     "securitySchemes" : {
       "http" : {
@@ -1339,32 +1355,9 @@ val composedExample = """
   },
   "components" : {
     "schemas" : {
-      "Address" : {
-        "required" : [ "number", "street" ],
-        "type" : "object",
-        "properties" : {
-          "street" : {
-            "type" : "string"
-          },
-          "number" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }
-      },
-      "User" : {
-        "required" : [ "name" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
-          },
-          "address" : {
-            "$ref" : "#/components/schemas/Address"
-          }
-        }
-      }
+      "Address" : $addressOpenApiSchema,
+      "User" : $userOpenApiSchema
     }
   }
 }
-""".trimIndent()
+""".formatJson()


### PR DESCRIPTION
Resolves #1047 

### Problem found:
Here the `Enum` type is being added to components because `isNonRefType()` returns `false` for `Enum`
https://github.com/tipsy/javalin/blob/1a32e62287292b14f8b62b411fc059ec27e5a867/javalin-openapi/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedParameter.kt#L36-L40

But here in `findSchema` there is different implementation for enums - `getEnumSchema` - which does not allow to create ref schema, it simply returns `StringSchema` with enum values. That is why ref schema is not added to components.
https://github.com/tipsy/javalin/blob/1a32e62287292b14f8b62b411fc059ec27e5a867/javalin-openapi/src/main/java/io/javalin/plugin/openapi/external/KotlinOpenApiDsl.kt#L106-L109

Here later, again because `isNonRefType()` returns `false` for `Enum`, the code creates ref schema (which does not exists in components):
https://github.com/tipsy/javalin/blob/1a32e62287292b14f8b62b411fc059ec27e5a867/javalin-openapi/src/main/java/io/javalin/plugin/openapi/dsl/DocumentedParameter.kt#L16-L24

It is not very clear for me why method `getEnumSchema` is present, because `ModelConverters.getInstance().readAllAsResolvedSchema(clazz)` can handle `Enum` correctly. Maybe there was a problem in previous versions of `io.swagger`?

### Another solution:
Modify `isNonRefType()` to make `Enum` non-ref type:
`fun Class<*>.isNonRefType(): Boolean = this in nonRefTypes || this.isEnum`

In sush case enums will not be added to components at all:

**Enum is non-ref type:**
```
"schema": {
    "type": "string",
    "enum": [
        "value1",
        "value2",
        "value3"
    ]
}
```
**Enum is ref type:**
```
"schema": {
    "$ref": "#/components/schemas/MyEnum"
}
...
"components": {
    "schemas": {
      "MyEnum": {
        "type": "string",
        "enum": [
          "value1",
          "value2",
          "value3"
        ]
      }
    }
  }
```