### PR TITLE
[VueDependencyResolver] Allow components with digits in name

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/rendering/vue/VueDependencyResolver.java
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/vue/VueDependencyResolver.java
@@ -30,7 +30,7 @@ public class VueDependencyResolver {
 
     private final Map<String, String> componentIdToOwnContent; // {component-id: component-content}
     private final Map<String, String> componentIdToDependencyContent; // {component-id: required-dependencies}
-    private final Pattern tagRegex = Pattern.compile("<\\s*([a-z|-]*)\\s*.*>");
+    private final Pattern tagRegex = Pattern.compile("<\\s*([a-z0-9|-]*)\\s*.*>");
     private final Pattern componentRegex = Pattern.compile("Vue.component\\(\\s*[\"|'](.*)[\"|']\\s*,.*");
 
     public VueDependencyResolver(final Set<Path> paths) {

--- a/javalin/src/test/java/io/javalin/TestJavalinVueResolution.java
+++ b/javalin/src/test/java/io/javalin/TestJavalinVueResolution.java
@@ -117,4 +117,19 @@ public class TestJavalinVueResolution {
         });
     }
 
+    @Test
+    public void componentWithNumberTest() {
+        TestUtil.test((server, httpUtil) -> {
+            server.get("/multi-view-number", new VueComponent("<view-number-dependency></view-number-dependency>"));
+            String body = httpUtil.getBody("/multi-view-number");
+            assertThat(body).contains("<dependency-1></dependency-1>");
+            assertThat(body).contains("<dependency-1-foo></dependency-1-foo>");
+            assertThat(body).contains("Vue.component(\"view-number-dependency\",{template:\"#view-number-dependency\"})");
+            assertThat(body).contains("Vue.component('dependency-1',{template:\"#dependency-1\"})");
+            assertThat(body).contains("Vue.component('dependency-1-foo',{template:\"#dependency-1-foo\"})");
+            assertThat(body).doesNotContain("Vue.component('dependency-123',{template:\"#dependency-123\"})");
+            assertThat(body).doesNotContain("<dependency-123");
+        });
+    }
+
 }

--- a/javalin/src/test/resources/vue/dependency-1-foo.vue
+++ b/javalin/src/test/resources/vue/dependency-1-foo.vue
@@ -1,0 +1,6 @@
+<template id="dependency-1-foo">
+    <div>Dependency 1 foo</div>
+</template>
+<script>
+    Vue.component('dependency-1-foo',{template:"#dependency-1-foo"});
+</script>

--- a/javalin/src/test/resources/vue/dependency-1.vue
+++ b/javalin/src/test/resources/vue/dependency-1.vue
@@ -1,0 +1,6 @@
+<template id="dependency-1">
+    <div>Dependency 1</div>
+</template>
+<script>
+    Vue.component('dependency-1',{template:"#dependency-1"});
+</script>

--- a/javalin/src/test/resources/vue/dependency-123.vue
+++ b/javalin/src/test/resources/vue/dependency-123.vue
@@ -1,0 +1,6 @@
+<template id="dependency-123">
+    <div>Dependency 123</div>
+</template>
+<script>
+    Vue.component('dependency-123',{template:"#dependency-123"});
+</script>

--- a/javalin/src/test/resources/vue/view-number-dependency.vue
+++ b/javalin/src/test/resources/vue/view-number-dependency.vue
@@ -1,0 +1,7 @@
+<template id="view-number-dependency">
+    <dependency-1></dependency-1>
+    <dependency-1-foo></dependency-1-foo>
+</template>
+<script>
+    Vue.component("view-number-dependency",{template:"#view-number-dependency"})
+</script>


### PR DESCRIPTION
Currently there is a bug where components such as `<id-secure-wg2-login>` are resolved as `id-secure-wg`. This commit fixes this by updating the regex. Corresponding tests added.
