### PR TITLE
Fix allow multiline tags in VueDependencyResolver

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/rendering/vue/VueDependencyResolver.java
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/vue/VueDependencyResolver.java
@@ -30,8 +30,8 @@ public class VueDependencyResolver {
 
     private final Map<String, String> componentIdToOwnContent; // {component-id: component-content}
     private final Map<String, String> componentIdToDependencyContent; // {component-id: required-dependencies}
-    private final Pattern tagRegex = Pattern.compile("<\\s*([a-z0-9|-]*)\\s*.*>");
-    private final Pattern componentRegex = Pattern.compile("Vue.component\\(\\s*[\"|'](.*)[\"|']\\s*,.*");
+    private final Pattern tagRegex = Pattern.compile("<\\s*([a-z0-9|-]*).*?>", Pattern.DOTALL);
+    private final Pattern componentRegex = Pattern.compile("Vue.component\\s*\\(\\s*[\"|'](.*)[\"|']\\s*,.*");
 
     public VueDependencyResolver(final Set<Path> paths) {
         componentIdToOwnContent = new HashMap<>();

--- a/javalin/src/test/java/io/javalin/TestJavalinVueResolution.java
+++ b/javalin/src/test/java/io/javalin/TestJavalinVueResolution.java
@@ -132,4 +132,18 @@ public class TestJavalinVueResolution {
         });
     }
 
+    @Test
+    public void componentWithMultilineComponentsUsageTest() {
+        TestUtil.test((server, httpUtil) -> {
+            server.get("/multiline-view-number", new VueComponent("<view-multiline-dependency></view-multiline-dependency>"));
+            String body = httpUtil.getBody("/multiline-view-number");
+            assertThat(body).contains("Vue.component(\"view-multiline-dependency\",{template:\"#view-multiline-dependency\"})");
+            assertThat(body).contains("Vue.component('dependency-1',{template:\"#dependency-1\"})");
+            assertThat(body).contains("Vue.component('dependency-1-foo',{template:\"#dependency-1-foo\"})");
+            assertThat(body).contains("Vue.component('dependency-one',{template:\"#dependency-one\"})");
+            assertThat(body).doesNotContain("Vue.component('dependency-123',{template:\"#dependency-123\"})");
+            assertThat(body).doesNotContain("<dependency-123");
+        });
+    }
+
 }

--- a/javalin/src/test/resources/vue/view-multiline-dependency.vue
+++ b/javalin/src/test/resources/vue/view-multiline-dependency.vue
@@ -1,0 +1,18 @@
+<template id="view-multiline-dependency">
+    <dependency-1
+    ></dependency-1>
+
+    <dependency-1-foo
+        :foo="baz"
+        prop
+    />
+
+    <dependency-one
+        :foo="baz"
+        prop>
+        <span>foo</span>
+    </dependency-one>
+</template>
+<script>
+    Vue.component("view-multiline-dependency",{template:"#view-multiline-dependency"})
+</script>


### PR DESCRIPTION
The components in `view-multiline-dependency.vue` would not have been picked up before this change.

Also allows for `Vue.component(` and `Vue.component (` (space before
parenthesis).