### PR TITLE
Skipping exampleSetFlag on serialization

### DIFF
--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.javalin.plugin.json.ToJsonMapper
 import io.javalin.plugin.openapi.utils.LazyDefaultValue
+import io.swagger.v3.core.jackson.mixin.SchemaMixin
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.security.SecurityScheme
 
 /**
@@ -28,6 +30,7 @@ class JacksonToJsonMapper(
         fun createObjectMapperWithDefaults(): ObjectMapper {
             return jacksonObjectMapper()
                     .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                    .addMixIn(Schema::class.java, SchemaMixin::class.java)
                     .registerModule(
                             SimpleModule()
                                     .addSerializer(SecurityScheme.Type::class.java, ToStringSerializer())

--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/jackson/JavalinModelResolver.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/jackson/JavalinModelResolver.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.core.converter.AnnotatedType
 import io.swagger.v3.core.converter.ModelConverter
 import io.swagger.v3.core.converter.ModelConverterContext
 import io.swagger.v3.core.jackson.ModelResolver
+import io.swagger.v3.core.util.PrimitiveType
 import io.swagger.v3.oas.models.media.DateTimeSchema
 import io.swagger.v3.oas.models.media.Schema
 import java.time.Instant
@@ -18,8 +19,8 @@ class JavalinModelResolver(mapper: ObjectMapper) : ModelResolver(mapper) {
         }
         val type = extractJavaType(annotatedType)
 
-        if (type.isTypeOrSubTypeOf(Instant::class.java) && !_mapper.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)) {
-            return DateTimeSchema()
+        if (type.isTypeOrSubTypeOf(Instant::class.java) && _mapper.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)) {
+            return PrimitiveType.LONG.createProperty();
         }
 
         return super.resolve(annotatedType, context, next)

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <pebble.version>3.1.2</pebble.version>
         <redoc.version>2.0.0-rc.23</redoc.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <swagger.models.version>2.1.2</swagger.models.version>
+        <swagger.core.version>2.1.4</swagger.core.version>
         <swagger.parser.version>2.0.19</swagger.parser.version>
         <swagger.ui.version>3.25.2</swagger.ui.version>
         <thymeleaf.version>3.0.11.RELEASE</thymeleaf.version>
@@ -91,7 +91,7 @@
         <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
         <junit.benchmark.version>0.7.2</junit.benchmark.version>
         <junit.version>4.13.1</junit.version>
-        <kotlin.openapi.dsl.version>0.20.2</kotlin.openapi.dsl.version>
+        <kotlin.openapi.dsl.version>1.0.0</kotlin.openapi.dsl.version>
         <mockk.version>1.10.0</mockk.version>
         <bytebuddy.version>1.10.15</bytebuddy.version>
         <bytebuddyagent.version>1.10.15</bytebuddyagent.version>
@@ -218,8 +218,13 @@
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-core</artifactId>
+                <version>${swagger.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-models</artifactId>
-                <version>${swagger.models.version}</version>
+                <version>${swagger.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.parser.v3</groupId>


### PR DESCRIPTION
The flag is excluded in default swagger object mapper.
Fixes #1079 - issues after updating to swagger 2.1.4