### PR TITLE
Serving static aliased files (resolves #1086)

### DIFF
--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -27,13 +27,17 @@ import io.javalin.http.staticfiles.Location;
 import io.javalin.http.staticfiles.ResourceHandler;
 import io.javalin.http.staticfiles.StaticFileConfig;
 import io.javalin.websocket.WsHandler;
+
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
@@ -116,11 +120,19 @@ public class JavalinConfig {
         return addStaticFiles("/", path, location);
     }
 
+    public JavalinConfig addStaticFiles(@NotNull String path, @NotNull Location location, @NotNull List<ContextHandler.AliasCheck> aliasChecks) {
+        return addStaticFiles("/", path, location, aliasChecks);
+    }
+
     public JavalinConfig addStaticFiles(@NotNull String urlPathPrefix, @NotNull String path, @NotNull Location location) {
+        return addStaticFiles(urlPathPrefix, path, location, Collections.emptyList());
+    }
+
+    public JavalinConfig addStaticFiles(@NotNull String urlPathPrefix, @NotNull String path, @NotNull Location location, @NotNull List<ContextHandler.AliasCheck> aliasChecks) {
         JettyUtil.disableJettyLogger();
         if (inner.resourceHandler == null)
             inner.resourceHandler = new JettyResourceHandler(precompressStaticFiles);
-        inner.resourceHandler.addStaticFileConfig(new StaticFileConfig(urlPathPrefix, path, location));
+        inner.resourceHandler.addStaticFileConfig(new StaticFileConfig(urlPathPrefix, path, location, aliasChecks));
         return this;
     }
 

--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -53,6 +53,7 @@ public class JavalinConfig {
     public boolean prefer405over404 = false;
     public boolean enforceSsl = false;
     public boolean precompressStaticFiles = false;
+    public ContextHandler.AliasCheck aliasCheckForStaticFiles = null;
     public boolean showJavalinBanner = true;
     public boolean logIfServerNotStarted = true;
     public boolean ignoreTrailingSlashes = true;
@@ -120,19 +121,11 @@ public class JavalinConfig {
         return addStaticFiles("/", path, location);
     }
 
-    public JavalinConfig addStaticFiles(@NotNull String path, @NotNull Location location, @NotNull List<ContextHandler.AliasCheck> aliasChecks) {
-        return addStaticFiles("/", path, location, aliasChecks);
-    }
-
     public JavalinConfig addStaticFiles(@NotNull String urlPathPrefix, @NotNull String path, @NotNull Location location) {
-        return addStaticFiles(urlPathPrefix, path, location, Collections.emptyList());
-    }
-
-    public JavalinConfig addStaticFiles(@NotNull String urlPathPrefix, @NotNull String path, @NotNull Location location, @NotNull List<ContextHandler.AliasCheck> aliasChecks) {
         JettyUtil.disableJettyLogger();
         if (inner.resourceHandler == null)
-            inner.resourceHandler = new JettyResourceHandler(precompressStaticFiles);
-        inner.resourceHandler.addStaticFileConfig(new StaticFileConfig(urlPathPrefix, path, location, aliasChecks));
+            inner.resourceHandler = new JettyResourceHandler(precompressStaticFiles, aliasCheckForStaticFiles);
+        inner.resourceHandler.addStaticFileConfig(new StaticFileConfig(urlPathPrefix, path, location));
         return this;
     }
 

--- a/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -59,7 +59,7 @@ class JettyResourceHandler(val precompressStaticFiles: Boolean = false, val alia
         }
     }
 
-    inner class AliasResourceHandler(private val urlPathPrefix: String, private val aliasCheck: AliasCheck?) : ResourceHandler() {
+    inner class AliasResourceHandler(private val urlPathPrefix: String, private val aliasCheck: AliasCheck) : ResourceHandler() {
         override fun getResource(path: String): Resource {
             val targetResource by lazy { path.removePrefix(urlPathPrefix) }
             return when {
@@ -92,7 +92,7 @@ class JettyResourceHandler(val precompressStaticFiles: Boolean = false, val alia
 
         private fun checkAlias(path: String?, resource: Resource): Boolean {
             if (resource.isAlias) {
-                if (aliasCheck != null && aliasCheck.check(path, resource)) {
+                if (aliasCheck.check(path, resource)) {
                     return true
                 }
                 return false

--- a/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -59,7 +59,7 @@ class JettyResourceHandler(val precompressStaticFiles: Boolean = false) : io.jav
                 if (baseResource != null) {
                     val caconicalPath = URIUtil.canonicalPath(path)
                     r = baseResource.addPath(caconicalPath)
-                    if (r != null && r.isAlias && (!checkAlias(path, r))) {
+                    if (r != null && r.isAlias && !checkAlias(path, r)) {
                         return null
                     }
                 }
@@ -106,7 +106,7 @@ class JettyResourceHandler(val precompressStaticFiles: Boolean = false) : io.jav
         for (handler in handlers) {
             try {
                 val resource = handler.getResource(target)
-                if (resource.isFile() || resource.isDirectoryWithWelcomeFile(handler as ResourceHandler, target)) {
+                if (resource.isFile() || resource.isDirectoryWithWelcomeFile(handler, target)) {
                     val maxAge = if (target.startsWith("/immutable/") || handler is WebjarHandler) 31622400 else 0
                     httpResponse.setHeader(Header.CACHE_CONTROL, "max-age=$maxAge")
                     // Remove the default content type because Jetty will not set the correct one

--- a/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/JettyResourceHandler.kt
@@ -11,7 +11,9 @@ import io.javalin.core.util.Header
 import io.javalin.core.util.Util
 import io.javalin.http.JavalinResponseWrapper
 import org.eclipse.jetty.server.Request
+import org.eclipse.jetty.server.handler.ContextHandler.AliasCheck
 import org.eclipse.jetty.server.handler.ResourceHandler
+import org.eclipse.jetty.util.URIUtil
 import org.eclipse.jetty.util.resource.EmptyResource
 import org.eclipse.jetty.util.resource.Resource
 import java.io.File
@@ -23,7 +25,7 @@ class JettyResourceHandler(val precompressStaticFiles: Boolean = false) : io.jav
     val handlers = mutableListOf<ResourceHandler>()
 
     override fun addStaticFileConfig(config: StaticFileConfig) {
-        val handler = if (config.path == "/webjars") WebjarHandler() else PrefixableHandler(config.urlPathPrefix).apply {
+        val handler = if (config.path == "/webjars") WebjarHandler() else PrefixableHandler(config.urlPathPrefix, config.aliasChecks).apply {
             resourceBase = getResourcePath(config)
             isDirAllowed = false
             isEtags = true
@@ -39,17 +41,48 @@ class JettyResourceHandler(val precompressStaticFiles: Boolean = false) : io.jav
         override fun getResource(path: String) = Resource.newClassPathResource("META-INF/resources$path") ?: super.getResource(path)
     }
 
-    inner class PrefixableHandler(private var urlPathPrefix: String) : ResourceHandler() {
+    inner class PrefixableHandler(private var urlPathPrefix: String, private val aliasChecks: List<AliasCheck>) : ResourceHandler() {
         override fun getResource(path: String): Resource {
             val targetResource by lazy { path.removePrefix(urlPathPrefix) }
             return when {
-                urlPathPrefix == "/" -> super.getResource(path) // same as regular ResourceHandler
-                targetResource == "" -> super.getResource("/") // directory without trailing '/'
+                urlPathPrefix == "/" -> getResourceWithAliasChecks(path)!! // same as regular ResourceHandler but with alias checks
+                targetResource == "" -> getResourceWithAliasChecks("/")!! // directory without trailing '/'
                 !path.startsWith(urlPathPrefix) -> EmptyResource.INSTANCE
                 !targetResource.startsWith("/") -> EmptyResource.INSTANCE
-                else -> super.getResource(targetResource)
+                else -> getResourceWithAliasChecks(targetResource)!!
             }
         }
+
+        private fun getResourceWithAliasChecks(path: String) : Resource? {
+            try {
+                var r: Resource? = null
+                if (baseResource != null) {
+                    val caconicalPath = URIUtil.canonicalPath(path)
+                    r = baseResource.addPath(caconicalPath)
+                    if (r != null && r.isAlias && (!checkAlias(path, r))) {
+                        return null
+                    }
+                }
+                if ((r == null || !r.exists()) && path.endsWith("/jetty-dir.css")) r = stylesheet
+                return r!!
+            } catch (e: java.lang.Exception) {
+
+            }
+            return null;
+        }
+
+        private fun checkAlias(path: String?, resource: Resource): Boolean {
+            if (resource.isAlias) {
+                aliasChecks.forEach {
+                    if (it.check(path, resource)) {
+                        return true
+                    }
+                }
+                return false
+            }
+            return true
+        }
+
     }
 
     private fun getResourcePath(staticFileConfig: StaticFileConfig): String {
@@ -73,7 +106,7 @@ class JettyResourceHandler(val precompressStaticFiles: Boolean = false) : io.jav
         for (handler in handlers) {
             try {
                 val resource = handler.getResource(target)
-                if (resource.isFile() || resource.isDirectoryWithWelcomeFile(handler, target)) {
+                if (resource.isFile() || resource.isDirectoryWithWelcomeFile(handler as ResourceHandler, target)) {
                     val maxAge = if (target.startsWith("/immutable/") || handler is WebjarHandler) 31622400 else 0
                     httpResponse.setHeader(Header.CACHE_CONTROL, "max-age=$maxAge")
                     // Remove the default content type because Jetty will not set the correct one

--- a/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.kt
@@ -1,10 +1,11 @@
 package io.javalin.http.staticfiles
 
+import org.eclipse.jetty.server.handler.ContextHandler
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 enum class Location { CLASSPATH, EXTERNAL; }
-data class StaticFileConfig(val urlPathPrefix: String, val path: String, val location: Location)
+data class StaticFileConfig(val urlPathPrefix: String, val path: String, val location: Location, val aliasChecks: List<ContextHandler.AliasCheck>)
 
 interface ResourceHandler {
     fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean

--- a/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/staticfiles/ResourceHandler.kt
@@ -1,11 +1,10 @@
 package io.javalin.http.staticfiles
 
-import org.eclipse.jetty.server.handler.ContextHandler
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 enum class Location { CLASSPATH, EXTERNAL; }
-data class StaticFileConfig(val urlPathPrefix: String, val path: String, val location: Location, val aliasChecks: List<ContextHandler.AliasCheck>)
+data class StaticFileConfig(val urlPathPrefix: String, val path: String, val location: Location)
 
 interface ResourceHandler {
     fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean

--- a/javalin/src/test/external/txt.txt
+++ b/javalin/src/test/external/txt.txt
@@ -1,0 +1,1 @@
+Sample text

--- a/javalin/src/test/java/io/javalin/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/TestStaticFiles.kt
@@ -77,7 +77,7 @@ class TestStaticFiles {
         }
     }
 
-    private fun createSimLink(targetPath: String, linkPath: String): File? {
+    private fun createSymLink(targetPath: String, linkPath: String): File? {
         val target = Paths.get(targetPath).toAbsolutePath()
         val link = Paths.get(linkPath).toAbsolutePath()
         // delete before creating new link
@@ -93,9 +93,9 @@ class TestStaticFiles {
 
     @Test
     fun `alias checks for static files should work`() {
-        val createdHtml = createSimLink("src/test/external/html.html", "src/test/external/linked_html.html")
+        val createdHtml = createSymLink("src/test/external/html.html", "src/test/external/linked_html.html")
         if (createdHtml != null) {
-            val createdTxt = createSimLink("src/test/external/txt.txt", "src/test/external/linked_txt.txt")
+            val createdTxt = createSymLink("src/test/external/txt.txt", "src/test/external/linked_txt.txt")
             if (createdTxt != null) {
                 TestUtil.test(staticWithAliasResourceApp) { _, http ->
                     assertThat(http.get("/linked_html.html").status).isEqualTo(200)
@@ -109,7 +109,7 @@ class TestStaticFiles {
 
     @Test
     fun `if aliases are not specified returns 404 for linked static file`() {
-        val created = createSimLink("src/test/external/html.html", "src/test/external/linked_html.html")
+        val created = createSymLink("src/test/external/html.html", "src/test/external/linked_html.html")
         if (created != null) {
             TestUtil.test(staticNoAliasCheckResourceApp) { _, http ->
                 assertThat(http.get("/linked_html.html").status).isEqualTo(404)

--- a/javalin/src/test/java/io/javalin/TestStaticFiles.kt
+++ b/javalin/src/test/java/io/javalin/TestStaticFiles.kt
@@ -14,15 +14,15 @@ import io.javalin.http.staticfiles.Location
 import io.javalin.testing.TestUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jetty.server.ServletResponseHttpWrapper
+import org.eclipse.jetty.server.handler.ContextHandler.ApproveAliases
 import org.eclipse.jetty.servlet.FilterHolder
 import org.junit.Test
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.*
-import javax.servlet.DispatcherType
-import javax.servlet.Filter
-import javax.servlet.FilterChain
-import javax.servlet.FilterConfig
-import javax.servlet.ServletRequest
-import javax.servlet.ServletResponse
+import javax.servlet.*
 
 class TestStaticFiles {
 
@@ -60,6 +60,54 @@ class TestStaticFiles {
             it.configureServletContextHandler { handler ->
                 handler.addFilter(FilterHolder(filter), "/*", EnumSet.allOf(DispatcherType::class.java))
             }
+        }
+    }
+
+    private val staticAllowedAliasResourceApp: Javalin by lazy {
+        Javalin.create { servlet ->
+            servlet.addStaticFiles("src/test/external/", Location.EXTERNAL, listOf(ApproveAliases()))
+        }
+    }
+
+    private val staticBlockedAliasResourceApp: Javalin by lazy {
+        Javalin.create { servlet ->
+            servlet.addStaticFiles("src/test/external/", Location.EXTERNAL)
+        }
+    }
+
+    private fun createSimLink(targetPath: String, linkPath: String): File? {
+        val target = Paths.get(targetPath).toAbsolutePath()
+        val link = Paths.get(linkPath).toAbsolutePath()
+        // delete before creating new link
+        link.toFile().delete()
+        try {
+            Files.createSymbolicLink(link, target)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            return null
+        }
+        return link.toFile()
+    }
+
+    @Test
+    fun `if aliases are allowed returns 200 for linked static file`() {
+        val created = createSimLink("src/test/external/html.html", "src/test/external/linked_html.html")
+        if (created != null) {
+            TestUtil.test(staticAllowedAliasResourceApp) { _, http ->
+                assertThat(http.get("/linked_html.html").status).isEqualTo(200)
+            }
+            created.delete()
+        }
+    }
+
+    @Test
+    fun `if aliases are not allowed returns 404 for linked static file`() {
+        val created = createSimLink("src/test/external/html.html", "src/test/external/linked_html.html")
+        if (created != null) {
+            TestUtil.test(staticBlockedAliasResourceApp) { _, http ->
+                assertThat(http.get("/linked_html.html").status).isEqualTo(404)
+            }
+            created.delete()
         }
     }
 

--- a/javalin/src/test/java/io/javalin/examples/HelloWorldStaticFiles_linked.java
+++ b/javalin/src/test/java/io/javalin/examples/HelloWorldStaticFiles_linked.java
@@ -1,0 +1,40 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin.examples;
+
+import io.javalin.Javalin;
+import io.javalin.http.staticfiles.Location;
+import org.eclipse.jetty.server.handler.ContextHandler;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class HelloWorldStaticFiles_linked {
+
+    public static void main(String[] args) {
+        createSimLink("src/test/external/html.html", "src/test/external/linked_html.html");
+
+        Javalin.create(config -> {
+            config.addStaticFiles("src/test/external/", Location.EXTERNAL, Collections.singletonList(new ContextHandler.ApproveAliases()));
+        }).start(7070);
+    }
+
+    private static void createSimLink(String targetPath, String linkPath) {
+        Path target = Paths.get(targetPath).toAbsolutePath();
+        Path link = Paths.get(linkPath).toAbsolutePath();
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/javalin/src/test/java/io/javalin/examples/HelloWorldStaticFiles_linked.java
+++ b/javalin/src/test/java/io/javalin/examples/HelloWorldStaticFiles_linked.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
 
 public class HelloWorldStaticFiles_linked {
 
@@ -23,7 +21,8 @@ public class HelloWorldStaticFiles_linked {
         createSimLink("src/test/external/html.html", "src/test/external/linked_html.html");
 
         Javalin.create(config -> {
-            config.addStaticFiles("src/test/external/", Location.EXTERNAL, Collections.singletonList(new ContextHandler.ApproveAliases()));
+            config.aliasCheckForStaticFiles = new ContextHandler.ApproveAliases();
+            config.addStaticFiles("src/test/external/", Location.EXTERNAL);
         }).start(7070);
     }
 

--- a/javalin/src/test/java/io/javalin/examples/HelloWorldStaticFiles_linked.java
+++ b/javalin/src/test/java/io/javalin/examples/HelloWorldStaticFiles_linked.java
@@ -18,7 +18,7 @@ import java.nio.file.Paths;
 public class HelloWorldStaticFiles_linked {
 
     public static void main(String[] args) {
-        createSimLink("src/test/external/html.html", "src/test/external/linked_html.html");
+        createSymLink("src/test/external/html.html", "src/test/external/linked_html.html");
 
         Javalin.create(config -> {
             config.aliasCheckForStaticFiles = new ContextHandler.ApproveAliases();
@@ -26,7 +26,7 @@ public class HelloWorldStaticFiles_linked {
         }).start(7070);
     }
 
-    private static void createSimLink(String targetPath, String linkPath) {
+    private static void createSymLink(String targetPath, String linkPath) {
         Path target = Paths.get(targetPath).toAbsolutePath();
         Path link = Paths.get(linkPath).toAbsolutePath();
         try {


### PR DESCRIPTION
Resolves #1086
Added possibility to set alias checks to serve static files. Because `ResourceHandler` was called manually it was impossible to attach context to enable jetty's alias checks. So I re-implemented `ResourceHandler.getResource()` to check aliases set by user in `StaticFileConfig` during configuring Javalin config.

**Example:**
```
Javalin.create(config -> {
    // will serve successfully all aliased/linked files
    config.addStaticFiles("src/test/external/", Location.EXTERNAL, Collections.singletonList(new ContextHandler.ApproveAliases()));
    
   // will server only checked by custom rules aliased/linked files
   config.addStaticFiles("src/test/external/", Location.EXTERNAL, Collections.singletonList(new MyAliasCheck()));

   // won't server aliased/linked files
   config.addStaticFiles("src/test/external/", Location.EXTERNAL);
}).start(7070);
```