### PR TITLE
Add Redoc Options configuration

### DIFF
--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/ui/RedocOptionsObject.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/ui/RedocOptionsObject.kt
@@ -1,0 +1,99 @@
+package io.javalin.plugin.openapi.ui
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+
+data class RedocOptionsObject(
+    val disableSearch: Boolean = false,
+    val expandDefaultServerVariables: Boolean = false,
+    val expandResponses: String = "",
+    val maxDisplayedEnumValues: Int? = null,
+    val hideDownloadButton: Boolean = false,
+    val hideHostname: Boolean = false,
+    val hideLoading: Boolean = false,
+    val hideSingleRequestSampleTab: Boolean = false,
+    val expandSingleSchemaField: Boolean = false,
+    val jsonSampleExpandLevel: String = "2",
+    val hideSchemaTitles: Boolean = false,
+    val simpleOneOfTypeLabel: Boolean = false,
+    val menuToggle: Boolean = false,
+    val nativeScrollbars: Boolean = false,
+    val noAutoAuth: Boolean = false,
+    val onlyRequiredInSamples: Boolean = false,
+    val pathInMiddlePanel: Boolean = false,
+    val requiredPropsFirst: Boolean = false,
+    val scrollYOffset: String = "0",
+    val showExtensions: Boolean = false,
+    val sortPropsAlphabetically: Boolean = false,
+    val suppressWarning: Boolean = false,
+    val payloadSampleIdx: Int = 0,
+    val untrustedSpec: Boolean = false,
+    val theme: RedocOptionsTheme = RedocOptionsTheme(),
+    @JsonIgnore val extras: Map<String, Any?> = emptyMap()
+) {
+    internal fun json(): ObjectNode {
+        val mapper = ObjectMapper()
+        return mapper.valueToTree<ObjectNode>(this).apply {
+            extras.forEach { (key, value) -> this.replace(key, mapper.valueToTree(value)) }
+        }
+    }
+    
+    class Builder {
+        private var disableSearch: Boolean = false
+        private var expandDefaultServerVariables: Boolean = false
+        private var expandResponses: String = ""
+        private var maxDisplayedEnumValues: Int? = null
+        private var hideDownloadButton: Boolean = false
+        private var hideHostname: Boolean = false
+        private var hideLoading: Boolean = false
+        private var hideSingleRequestSampleTab: Boolean = false
+        private var expandSingleSchemaField: Boolean = false
+        private var jsonSampleExpandLevel: String = "2"
+        private var hideSchemaTitles: Boolean = false
+        private var simpleOneOfTypeLabel: Boolean = false
+        private var menuToggle: Boolean = false
+        private var nativeScrollbars: Boolean = false
+        private var noAutoAuth: Boolean = false
+        private var onlyRequiredInSamples: Boolean = false
+        private var pathInMiddlePanel: Boolean = false
+        private var requiredPropsFirst: Boolean = false
+        private var scrollYOffset: String = "0"
+        private var showExtensions: Boolean = false
+        private var sortPropsAlphabetically: Boolean = false
+        private var suppressWarning: Boolean = false
+        private var payloadSampleIdx: Int = 0
+        private var untrustedSpec: Boolean = false
+        private var theme: RedocOptionsTheme = RedocOptionsTheme()
+        private var extras: Map<String, Any?> = emptyMap()
+        
+        fun setDisableSearch(boolean: Boolean) = apply { disableSearch = boolean }
+        fun setExpandDefaultServerVariables(boolean: Boolean) = apply { expandDefaultServerVariables = boolean }
+        fun setExpandResponse(string: String) = apply { expandResponses = string }
+        fun setMaxDisplayedEnumValues(int: Int?) = apply { maxDisplayedEnumValues = int }
+        fun setHideDownloadButton(boolean: Boolean) = apply { hideDownloadButton = boolean }
+        fun setHideHostname(boolean: Boolean) = apply { hideHostname = boolean }
+        fun setHideLoading(boolean: Boolean) = apply { hideLoading = boolean }
+        fun setHideSingleRequestSampleTab(boolean: Boolean) = apply { hideSingleRequestSampleTab = boolean }
+        fun setExpandSingleSchemaField(boolean: Boolean) = apply { expandSingleSchemaField = boolean }
+        fun setJsonSampleExpandLevel(string: String) = apply { jsonSampleExpandLevel = string }
+        fun setHideSchemaTitles(boolean: Boolean) = apply { hideSchemaTitles = boolean }
+        fun setSimpleOneOfTypeLabel(boolean: Boolean) = apply { simpleOneOfTypeLabel = boolean }
+        fun setMenuToggle(boolean: Boolean) = apply { menuToggle = boolean }
+        fun setNativeScrollbars(boolean: Boolean) = apply { nativeScrollbars = boolean }
+        fun setNoAutoAuth(boolean: Boolean) = apply { noAutoAuth = boolean }
+        fun setOnlyRequiredInSamples(boolean: Boolean) = apply { onlyRequiredInSamples = boolean}
+        fun setPathInMiddlePanel(boolean: Boolean) = apply { pathInMiddlePanel = boolean }
+        fun setRequiredPropsFirst(boolean: Boolean) = apply { requiredPropsFirst = boolean }
+        fun setScrollYOffset(string: String) = apply { scrollYOffset = string }
+        fun setShowExtensions(boolean: Boolean) = apply { showExtensions = boolean }
+        fun setSortPropsAlphabetically(boolean: Boolean) = apply { sortPropsAlphabetically = boolean }
+        fun setSuppressWarning(boolean: Boolean) = apply { suppressWarning = boolean }
+        fun setPayloadSampleIdx(int: Int) = apply { payloadSampleIdx = int }
+        fun setUntrustedSpec(boolean: Boolean) = apply { untrustedSpec = boolean }
+        fun setTheme(redocOptionsTheme: RedocOptionsTheme) = apply { theme = redocOptionsTheme }
+        fun setExtras(map: Map<String, Any?>) = apply { extras = map }
+        
+        fun build() = RedocOptionsObject(disableSearch, expandDefaultServerVariables, expandResponses, maxDisplayedEnumValues, hideDownloadButton, hideHostname, hideLoading, hideSingleRequestSampleTab, expandSingleSchemaField, jsonSampleExpandLevel, hideSchemaTitles, simpleOneOfTypeLabel, menuToggle, nativeScrollbars, noAutoAuth, onlyRequiredInSamples, pathInMiddlePanel, requiredPropsFirst, scrollYOffset, showExtensions, sortPropsAlphabetically, suppressWarning, payloadSampleIdx, untrustedSpec, theme, extras)
+    }
+}

--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/ui/RedocOptionsTheme.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/ui/RedocOptionsTheme.kt
@@ -1,0 +1,250 @@
+package io.javalin.plugin.openapi.ui
+
+data class RedocOptionsTheme(
+    val spacingUnit: Int = 5,
+    val sectionHorizontal: Int = 40,
+    val sectionVertical: Int = 40,
+    val breakpointsSmall: String = "50rem",
+    val breakpointsMedium: String = "85rem",
+    val breakpointsLarge: String = "105rem",
+    val colorsTonalOffset: Double = 0.3,
+    val typographyFontSize: String = "14px",
+    val typographyLineHeight: String = "1.5em",
+    val typographyFontWeightRegular: String = "400",
+    val typographyFontWeightBold: String = "600",
+    val typographyFontWeightLight: String = "300",
+    val typographyFontFamily: String = "Roboto, sans-serif",
+    val typographySmoothing: String = "antialiased",
+    val isTypographyOptimizeSpeed: Boolean = true,
+    val typographyHeadingsFontFamily: String = "Montserrat, sans-serif",
+    val typographyHeadingsFontWeight: String = "400",
+    val typographyHeadingsLineHeight: String = "1.6em",
+    val typographyCodeFontSize: String = "13px",
+    val typographyCodeFontFamily: String = "Courier, monospace",
+    val typographyCodeColor: String = "#e53935",
+    val typographyCodeBackgroundColor: String = "rgba(38, 50, 56, 0.05)",
+    val isTypographyCodeWrap: Boolean = false,
+    val menuWidth: String = "260px",
+    val menuBackgroundColor: String = "#fafafa",
+    val menuTextColor: String = "#333333",
+    val menuGroupItemsTextTransform: String = "uppercase",
+    val menuLevel1ItemsTextTransform: String = "none",
+    val menuArrowSize: String = "1.5em",
+    val logoGutter: String = "2px",
+    val rightPanelBackgroundColor: String = "#263238",
+    val rightPanelWidth: String = "40%",
+    val rightPanelTextColor: String = "#ffffff"
+) {
+    
+    class Builder {
+        private var spacingUnit = 5
+        private var sectionHorizontal = 40
+        private var sectionVertical = 40
+
+        private var breakpointsSmall = "50rem"
+        private var breakpointsMedium = "85rem"
+        private var breakpointsLarge = "105rem"
+
+        private var colorsTonalOffset = 0.3
+
+        private var typographyFontSize = "14px"
+        private var typographyLineHeight = "1.5em"
+        private var typographyFontWeightRegular = "400"
+        private var typographyFontWeightBold = "600"
+        private var typographyFontWeightLight = "300"
+        private var typographyFontFamily = "Roboto, sans-serif"
+        private var typographySmoothing = "antialiased"
+        private var typographyOptimizeSpeed = true
+        private var typographyHeadingsFontFamily = "Montserrat, sans-serif"
+        private var typographyHeadingsFontWeight = "400"
+        private var typographyHeadingsLineHeight = "1.6em"
+        private var typographyCodeFontSize = "13px"
+        private var typographyCodeFontFamily = "Courier, monospace"
+        private var typographyCodeColor = "#e53935"
+        private var typographyCodeBackgroundColor = "rgba(38, 50, 56, 0.05)"
+        private var typographyCodeWrap = false
+
+        private var menuWidth = "260px"
+        private var menuBackgroundColor = "#fafafa"
+        private var menuTextColor = "#333333"
+        private var menuGroupItemsTextTransform = "uppercase"
+        private var menuLevel1ItemsTextTransform = "none"
+        private var menuArrowSize = "1.5em"
+
+        private var logoGutter = "2px"
+
+        private var rightPanelBackgroundColor = "#263238"
+        private var rightPanelWidth = "40%"
+        private var rightPanelTextColor = "#ffffff"
+
+        fun setSpacingUnit(spacingUnit: Int): Builder {
+            this.spacingUnit = spacingUnit
+            return this
+        }
+
+        fun setSectionHorizontal(sectionHorizontal: Int): Builder {
+            this.sectionHorizontal = sectionHorizontal
+            return this
+        }
+
+        fun setSectionVertical(sectionVertical: Int): Builder {
+            this.sectionVertical = sectionVertical
+            return this
+        }
+
+        fun setBreakpointsSmall(breakpointsSmall: String): Builder {
+            this.breakpointsSmall = breakpointsSmall
+            return this
+        }
+
+        fun setBreakpointsMedium(breakpointsMedium: String): Builder {
+            this.breakpointsMedium = breakpointsMedium
+            return this
+        }
+
+        fun setBreakpointsLarge(breakpointsLarge: String): Builder {
+            this.breakpointsLarge = breakpointsLarge
+            return this
+        }
+
+        fun setColorsTonalOffset(colorsTonalOffset: Double): Builder {
+            this.colorsTonalOffset = colorsTonalOffset
+            return this
+        }
+
+        fun setTypographyFontSize(typographyFontSize: String): Builder {
+            this.typographyFontSize = typographyFontSize
+            return this
+        }
+
+        fun setTypographyLineHeight(typographyLineHeight: String): Builder {
+            this.typographyLineHeight = typographyLineHeight
+            return this
+        }
+
+        fun setTypographyFontWeightRegular(typographyFontWeightRegular: String): Builder {
+            this.typographyFontWeightRegular = typographyFontWeightRegular
+            return this
+        }
+
+        fun setTypographyFontWeightBold(typographyFontWeightBold: String): Builder {
+            this.typographyFontWeightBold = typographyFontWeightBold
+            return this
+        }
+
+        fun setTypographyFontWeightLight(typographyFontWeightLight: String): Builder {
+            this.typographyFontWeightLight = typographyFontWeightLight
+            return this
+        }
+
+        fun setTypographyFontFamily(typographyFontFamily: String): Builder {
+            this.typographyFontFamily = typographyFontFamily
+            return this
+        }
+
+        fun setTypographySmoothing(typographySmoothing: String): Builder {
+            this.typographySmoothing = typographySmoothing
+            return this
+        }
+
+        fun setTypographyOptimizeSpeed(typographyOptimizeSpeed: Boolean): Builder {
+            this.typographyOptimizeSpeed = typographyOptimizeSpeed
+            return this
+        }
+
+        fun setTypographyHeadingsFontFamily(typographyHeadingsFontFamily: String): Builder {
+            this.typographyHeadingsFontFamily = typographyHeadingsFontFamily
+            return this
+        }
+
+        fun setTypographyHeadingsFontWeight(typographyHeadingsFontWeight: String): Builder {
+            this.typographyHeadingsFontWeight = typographyHeadingsFontWeight
+            return this
+        }
+
+        fun setTypographyHeadingsLineHeight(typographyHeadingsLineHeight: String): Builder {
+            this.typographyHeadingsLineHeight = typographyHeadingsLineHeight
+            return this
+        }
+
+        fun setTypographyCodeFontSize(typographyCodeFontSize: String): Builder {
+            this.typographyCodeFontSize = typographyCodeFontSize
+            return this
+        }
+
+        fun setTypographyCodeFontFamily(typographyCodeFontFamily: String): Builder {
+            this.typographyCodeFontFamily = typographyCodeFontFamily
+            return this
+        }
+
+        fun setTypographyCodeColor(typographyCodeColor: String): Builder {
+            this.typographyCodeColor = typographyCodeColor
+            return this
+        }
+
+        fun setTypographyCodeBackgroundColor(typographyCodeBackgroundColor: String): Builder {
+            this.typographyCodeBackgroundColor = typographyCodeBackgroundColor
+            return this
+        }
+
+        fun setTypographyCodeWrap(typographyCodeWrap: Boolean): Builder {
+            this.typographyCodeWrap = typographyCodeWrap
+            return this
+        }
+
+        fun setMenuWidth(menuWidth: String): Builder {
+            this.menuWidth = menuWidth
+            return this
+        }
+
+        fun setMenuBackgroundColor(menuBackgroundColor: String): Builder {
+            this.menuBackgroundColor = menuBackgroundColor
+            return this
+        }
+
+        fun setMenuTextColor(menuTextColor: String): Builder {
+            this.menuTextColor = menuTextColor
+            return this
+        }
+
+        fun setMenuGroupItemsTextTransform(menuGroupItemsTextTransform: String): Builder {
+            this.menuGroupItemsTextTransform = menuGroupItemsTextTransform
+            return this
+        }
+
+        fun setMenuLevel1ItemsTextTransform(menuLevel1ItemsTextTransform: String): Builder {
+            this.menuLevel1ItemsTextTransform = menuLevel1ItemsTextTransform
+            return this
+        }
+
+        fun setMenuArrowSize(menuArrowSize: String): Builder {
+            this.menuArrowSize = menuArrowSize
+            return this
+        }
+
+        fun setLogoGutter(logoGutter: String): Builder {
+            this.logoGutter = logoGutter
+            return this
+        }
+
+        fun setRightPanelBackgroundColor(rightPanelBackgroundColor: String): Builder {
+            this.rightPanelBackgroundColor = rightPanelBackgroundColor
+            return this
+        }
+
+        fun setRightPanelWidth(rightPanelWidth: String): Builder {
+            this.rightPanelWidth = rightPanelWidth
+            return this
+        }
+
+        fun setRightPanelTextColor(rightPanelTextColor: String): Builder {
+            this.rightPanelTextColor = rightPanelTextColor
+            return this
+        }
+
+        fun build(): RedocOptionsTheme {
+            return RedocOptionsTheme(spacingUnit, sectionHorizontal, sectionVertical, breakpointsSmall, breakpointsMedium, breakpointsLarge, colorsTonalOffset, typographyFontSize, typographyLineHeight, typographyFontWeightRegular, typographyFontWeightBold, typographyFontWeightLight, typographyFontFamily, typographySmoothing, typographyOptimizeSpeed, typographyHeadingsFontFamily, typographyHeadingsFontWeight, typographyHeadingsLineHeight, typographyCodeFontSize, typographyCodeFontFamily, typographyCodeColor, typographyCodeBackgroundColor, typographyCodeWrap, menuWidth, menuBackgroundColor, menuTextColor, menuGroupItemsTextTransform, menuLevel1ItemsTextTransform, menuArrowSize, logoGutter, rightPanelBackgroundColor, rightPanelWidth, rightPanelTextColor)
+        }
+    }
+
+}

--- a/javalin-openapi/src/test/java/io/javalin/examples/HelloWorldSwagger.java
+++ b/javalin-openapi/src/test/java/io/javalin/examples/HelloWorldSwagger.java
@@ -18,6 +18,8 @@ import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import io.javalin.plugin.openapi.ui.ReDocOptions;
+import io.javalin.plugin.openapi.ui.RedocOptionsObject;
+import io.javalin.plugin.openapi.ui.RedocOptionsTheme;
 import io.javalin.plugin.openapi.ui.SwaggerOptions;
 import io.swagger.v3.oas.models.info.Info;
 
@@ -31,7 +33,15 @@ public class HelloWorldSwagger {
             .activateAnnotationScanningFor("io.javalin.examples")
             .path("/swagger-docs")
             .swagger(new SwaggerOptions("/swagger").title("My Swagger Documentation"))
-            .reDoc(new ReDocOptions("/redoc").title("My ReDoc Documentation"));
+            .reDoc(new ReDocOptions("/redoc", new RedocOptionsObject.Builder()
+                    .setHideDownloadButton(true)
+                    .setTheme(
+                            new RedocOptionsTheme.Builder()
+                                    .setSpacingUnit(10)
+                                    .setTypographyOptimizeSpeed(true)
+                                    .build()
+                    ).build()
+            ).title("My ReDoc Documentation"));
 
         Javalin app = Javalin.create(config -> config.registerPlugin(new OpenApiPlugin(openApiOptions))).start(7070);
 

--- a/javalin-openapi/src/test/kotlin/io/javalin/examples/HelloWorldSwagger.kt
+++ b/javalin-openapi/src/test/kotlin/io/javalin/examples/HelloWorldSwagger.kt
@@ -13,6 +13,8 @@ import io.javalin.plugin.openapi.OpenApiPlugin
 import io.javalin.plugin.openapi.dsl.document
 import io.javalin.plugin.openapi.dsl.documented
 import io.javalin.plugin.openapi.ui.ReDocOptions
+import io.javalin.plugin.openapi.ui.RedocOptionsObject
+import io.javalin.plugin.openapi.ui.RedocOptionsTheme
 import io.javalin.plugin.openapi.ui.SwaggerOptions
 import io.swagger.v3.oas.models.info.Info
 
@@ -67,10 +69,16 @@ fun addUserHandler(ctx: Context) {
 fun main() {
     val app = Javalin.create {
         val openApiOptions = OpenApiOptions(Info().version("1.0").description("My Application"))
-                .path("/swagger-docs")
-                .swagger(SwaggerOptions("/swagger").title("My Swagger Documentation"))
-                .reDoc(ReDocOptions("/redoc").title("My ReDoc Documentation"))
-                .defaultDocumentation { documentation -> documentation.json<InternalServerErrorResponse>("500") }
+            .path("/swagger-docs")
+            .swagger(SwaggerOptions("/swagger").title("My Swagger Documentation"))
+            .reDoc(ReDocOptions("/redoc", RedocOptionsObject(
+                hideDownloadButton = true,
+                theme = RedocOptionsTheme(
+                    spacingUnit = 10,
+                    isTypographyOptimizeSpeed = true
+                )
+            )).title("My ReDoc Documentation"))
+            .defaultDocumentation { documentation -> documentation.json<InternalServerErrorResponse>("500") }
         it.registerPlugin(OpenApiPlugin(openApiOptions))
     }
 


### PR DESCRIPTION
Redoc contains a list of customizable options in its options object (https://github.com/Redocly/redoc#redoc-options-object). This commit enables that customization inside Javalin's DSL.

For each type of object, a builder was created to ease Java's usage, as the language doesn't support default arguments yet.

An important point to verify here is that the Theme option, although configurable, won't work with the standalone version currently, due to a bug in Redoc itself (https://github.com/Redocly/redoc/issues/1248). If it gets fixed, the code from this commit will automatically work with it.

Closes #1097