### PR TITLE
ApiBuilder - replaced static fields with ThreadLocals

### DIFF
--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -253,8 +253,11 @@ public class Javalin {
      */
     public Javalin routes(@NotNull EndpointGroup endpointGroup) {
         ApiBuilder.setStaticJavalin(this);
-        endpointGroup.addEndpoints();
-        ApiBuilder.clearStaticJavalin();
+        try {
+            endpointGroup.addEndpoints();
+        } finally {
+            ApiBuilder.clearStaticJavalin();
+        }
         return this;
     }
 


### PR DESCRIPTION
So that Javalin instances can be created in parallel by multiple threads.