### PR TITLE
[rendering] decode html-encoding on path, query params on client

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/rendering/vue/JavalinVue.kt
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/vue/JavalinVue.kt
@@ -69,7 +69,16 @@ object JavalinVue {
         |        pathParams: ${JavalinJson.toJson(ctx.pathParamMap().mapKeys { escape(it.key) }.mapValues { escape(it.value) })},
         |        queryParams: ${JavalinJson.toJson(ctx.queryParamMap().mapKeys { escape(it.key) }.mapValues { it.value.map { escape(it) } })},
         |        state: ${JavalinJson.toJson(state ?: stateFunction(ctx))}
-        |    }""".trimMargin() + "\n</script>\n"
+        |    }""".trimMargin() +
+        """function decodeHtmlEntities(t) {
+            var textArea = document.createElement('textarea');
+            textArea.innerHTML = t;
+            return textArea.value;
+        }
+        ["queryParams", "pathParams", "state"].forEach((key) => {
+            Vue.prototype.${"$"}javalin[key] = JSON.parse(decodeHTMLEntities(JSON.stringify(Vue.prototype.${"$"}javalin[key])));
+        });""" +
+        "\n</script>\n"
 
     private fun String.replaceWebjarsWithCdn() =
             this.replace("@cdnWebjar/", if (isDev == true) "/webjars/" else "https://cdn.jsdelivr.net/webjars/org.webjars.npm/")

--- a/javalin/src/test/java/io/javalin/TestJavalinVueWebBrowser.kt
+++ b/javalin/src/test/java/io/javalin/TestJavalinVueWebBrowser.kt
@@ -1,0 +1,85 @@
+/*
+ * Javalin - https://javalin.io
+ * Copyright 2017 David Åse
+ * Licensed under Apache 2.0: https://github.com/tipsy/javalin/blob/master/LICENSE
+ */
+
+package io.javalin
+
+import io.github.bonigarcia.wdm.WebDriverManager
+import io.javalin.core.util.Header
+import io.javalin.http.Context
+import io.javalin.http.staticfiles.Location
+import io.javalin.http.util.SeekableWriter.chunkSize
+import io.javalin.plugin.rendering.vue.JavalinVue
+import io.javalin.plugin.rendering.vue.VueComponent
+import io.javalin.testing.TestLoggingUtil.captureStdOut
+import io.javalin.testing.TestUtil
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.nio.file.Paths
+import java.util.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.AfterClass
+import org.junit.Assume
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.WebDriver
+
+class TestJavalinVueWebBrowser {
+
+    @Before
+    fun setup() {
+        JavalinVue.isDev = null // reset
+        JavalinVue.stateFunction = { ctx -> mapOf<String, String>() } // reset
+        JavalinVue.rootDirectory("src/test/resources/vue", Location.EXTERNAL) // src/main -> src/test
+        JavalinVue.optimizeDependencies = false
+    }
+
+    data class User(val name: String, val email: String)
+    data class Role(val name: String)
+    data class State(val user: User, val role: Role)
+
+    private val state = State(User("tipsy", "tipsy@tipsy.tipsy"), Role("Maintainer"))
+
+
+    companion object {
+
+        lateinit var driver: ChromeDriver
+
+        @BeforeClass
+        @JvmStatic
+        fun setupClass() {
+            val os: String = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH)
+            Assume.assumeTrue("mac" !in os && "darwin" !in os)
+            WebDriverManager.chromedriver().setup()
+            driver = ChromeDriver(ChromeOptions().apply {
+            })
+        }
+
+
+        @AfterClass
+        @JvmStatic
+        fun teardownClass() {
+            if (Companion::driver.isInitialized) {
+                driver.quit()
+            }
+        }
+
+    }
+
+    @Test
+    fun `path params are not html-encoded on the client`() = TestUtil.test { app, http ->
+        app.get("/vue/:zeisty", VueComponent("<path-params-in-body-component></path-params-in-body-component>"))
+        driver.get(http.origin + "/vue/odd&co")
+        assertThat(driver.pageSource).contains(""""zeisty":"odd&amp;co"},""") // source loaded on client, before js is executed
+        assertThat(driver.pageSource).contains("""<div id="test">odd&co</div>""")
+        val pathParams = driver.executeScript("return Vue.prototype.\$javalin.pathParams[\"my-param\"]") as String
+        assertThat(pathParams).contains("odd&co")
+    }
+}

--- a/javalin/src/test/resources/vue/layout.html
+++ b/javalin/src/test/resources/vue/layout.html
@@ -1,4 +1,5 @@
 <head>
+    <script>function Vue(){}</script>
     @componentRegistration
     <script>@inlineFile("/vue/scripts.js")</script>
     <script>@inlineFileDev("/vue/scripts-dev.js")</script>

--- a/javalin/src/test/resources/vue/path-params-in-body.vue
+++ b/javalin/src/test/resources/vue/path-params-in-body.vue
@@ -1,0 +1,8 @@
+<template id="path-params-in-body-component">
+    <div id="test">hello</div>
+</template>
+<script>
+Vue.component("path-params-in-body-component", {template: "#path-params-in-body-component"});
+document.getElementById("test").innerText = Vue.prototype.$javalin.pathParams["zeisty"]
+console.log(Vue.prototype.$javalin.pathParams["zeisty"])
+</script>


### PR DESCRIPTION
- Resolves issue https://github.com/tipsy/javalin/issues/1124
- I haven't written any tests for this as I couldn't figure out how to evaluate the result of js code run on the client without rendering it as HTML, which defeats the purpose of this fix. Pointers/tips would be appreciated.