### PR TITLE
Bump jte to version 1.5.0

### DIFF
--- a/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -26,5 +26,5 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
     SWAGGER_CORE("Swagger Core", "io.swagger.v3.oas.models.OpenAPI", "io.swagger.core.v3", "swagger-models", "2.1.2"),
     CLASS_GRAPH("ClassGraph", "io.github.classgraph.ClassGraph", "io.github.classgraph", "classgraph", "4.8.66"),
     JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),
-    JTE("jte", "gg.jte.TemplateEngine", "gg.jte", "jte", "1.4.0"),
+    JTE("jte", "gg.jte.TemplateEngine", "gg.jte", "jte", "1.5.0"),
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <swagger.ui.version>3.25.2</swagger.ui.version>
         <thymeleaf.version>3.0.11.RELEASE</thymeleaf.version>
         <velocity.version>2.2</velocity.version>
-        <jte.version>1.4.0</jte.version>
+        <jte.version>1.5.0</jte.version>
 
         <!-- TEST DEPENDENCIES -->
         <assertj.version>3.15.0</assertj.version>


### PR DESCRIPTION
@tipsy thanks for bumping to jte 1.4.0 👍 

I just bumped to jte 1.5.0, which adds some minor fixes and improvements: https://github.com/casid/jte/releases/tag/1.5.0