### PR TITLE
Add mechanism to track bytes sent

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -374,6 +374,8 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
         return this
     }
 
+    var writeCallback: ((Long, Long) -> Unit)? = null
+
     /** Writes the specified inputStream as a seekable stream */
     fun seekableStream(inputStream: InputStream, contentType: String) = SeekableWriter.write(this, inputStream, contentType)
 

--- a/javalin/src/main/java/io/javalin/http/JavalinServlet.kt
+++ b/javalin/src/main/java/io/javalin/http/JavalinServlet.kt
@@ -82,7 +82,7 @@ class JavalinServlet(val config: JavalinConfig) : HttpServlet() {
             if (ctx.resultFuture() == null) { // finish request synchronously
                 tryErrorHandlers()
                 tryAfterHandlers()
-                JavalinResponseWrapper(rawRes, rwc).write(ctx.resultStream())
+                JavalinResponseWrapper(rawRes, rwc).write(ctx)
                 config.inner.requestLogger?.handle(ctx, LogUtil.executionTimeMs(ctx))
             } else { // finish request asynchronously
                 val asyncContext = wrappedReq.startAsync().apply { timeout = config.asyncRequestTimeout }
@@ -101,7 +101,7 @@ class JavalinServlet(val config: JavalinConfig) : HttpServlet() {
                     tryErrorHandlers()
                     tryAfterHandlers()
                     val asyncRes = asyncContext.response as HttpServletResponse
-                    JavalinResponseWrapper(asyncRes, rwc).write(ctx.resultStream())
+                    JavalinResponseWrapper(asyncRes, rwc).write(ctx)
                     config.inner.requestLogger?.handle(ctx, LogUtil.executionTimeMs(ctx))
                     asyncContext.complete() // async lifecycle complete
                 }

--- a/javalin/src/test/kotlin/io/javalin/examples/TrackableStreamResult.kt
+++ b/javalin/src/test/kotlin/io/javalin/examples/TrackableStreamResult.kt
@@ -1,0 +1,19 @@
+package io.javalin.examples
+
+import io.javalin.Javalin
+import io.javalin.apibuilder.ApiBuilder.get
+import java.io.FileInputStream
+
+fun main(args: Array<String>) {
+
+    val app = Javalin.create().start(1337)
+
+    app.routes {
+        get("/file") { ctx ->
+            ctx.writeCallback = { sent, all ->
+                println("$sent $all")
+            }
+            ctx.seekableStream(FileInputStream("/path/to/some/big/file"), "binary")
+        }
+    }
+}


### PR DESCRIPTION
Quick draft of a "callback mechanism" which lets the developer track the bytes which have already been sent to a connected client via a `Context` `result`/`seekableStream`

Related to #1145