### PR TITLE
Optionally tagging 3xx and 404 responses in the Micrometer plugin

### DIFF
--- a/javalin/src/main/java/io/javalin/plugin/metrics/MicrometerPlugin.kt
+++ b/javalin/src/main/java/io/javalin/plugin/metrics/MicrometerPlugin.kt
@@ -27,8 +27,8 @@ import javax.servlet.http.HttpServletResponse
 class MicrometerPlugin @JvmOverloads constructor(private val registry: MeterRegistry = Metrics.globalRegistry,
                                                  private val tags: Iterable<Tag> = Tags.empty(),
                                                  private val tagExceptionName: Boolean = false,
-                                                 private val tagRedirectResponses: Boolean = false,
-                                                 private val tagNotFoundResponses: Boolean = false) : Plugin {
+                                                 private val tagRedirectPaths: Boolean = false,
+                                                 private val tagNotFoundMappedPaths: Boolean = false) : Plugin {
     override fun apply(app: Javalin) {
         app.server()?.server()?.let { server ->
             if (tagExceptionName) {
@@ -52,10 +52,10 @@ class MicrometerPlugin @JvmOverloads constructor(private val registry: MeterRegi
                             .map(HandlerEntry::path)
                             .map { path: String -> if (path == "/" || StringUtils.isBlank(path)) "root" else path }
                             .map { path: String ->
-                                if (!tagRedirectResponses && response.status in 300..399) "REDIRECTION" else path
+                                if (!tagRedirectPaths && response.status in 300..399) "REDIRECTION" else path
                             }
                             .map { path: String ->
-                                if (!tagNotFoundResponses && response.status == 404) "NOT_FOUND" else path
+                                if (!tagNotFoundMappedPaths && response.status == 404) "NOT_FOUND" else path
                             }
                             .orElse("NOT_FOUND")
                     return Tags.concat(

--- a/javalin/src/test/java/io/javalin/testing/HttpUtil.kt
+++ b/javalin/src/test/java/io/javalin/testing/HttpUtil.kt
@@ -21,6 +21,7 @@ class HttpUtil(port: Int) {
 
     // Unirest
     fun get(path: String) = Unirest.get(origin + path).asString()
+    fun get(path: String, headers: Map<String, String>) = Unirest.get(origin + path).headers(headers).asString()
 
     fun getBody(path: String) = Unirest.get(origin + path).asString().body
     fun getBody(path: String, headers: Map<String, String>) = Unirest.get(origin + path).headers(headers).asString().body


### PR DESCRIPTION
Currently, the Micrometer plugin tags 3xx and 404 responses with the values `REDIRECTION` and `NOT_FOUND`, respectively. This PR adds configuration parameters on the plugin constructor to make it possible for the paths to requests like these to be tagged normally.

(In my case, the biggest motivator for this is for 304 responses generated via `config.autoGenerateEtags`)