### PR TITLE
Allow contentType to be null to fix an IllegalStateException that occ…

### DIFF
--- a/javalin/src/main/java/io/javalin/http/UploadedFile.kt
+++ b/javalin/src/main/java/io/javalin/http/UploadedFile.kt
@@ -18,4 +18,4 @@ import java.io.InputStream
  * @see Context.uploadedFile
  * @see <a href="https://javalin.io/documentation#faq">Uploads in FAQ</a>
  */
-data class UploadedFile(val content: InputStream, val contentType: String, @Deprecated("Use UploadedFile.size", replaceWith = ReplaceWith("size")) val contentLength: Int, val filename: String, val extension: String, val size: Long)
+data class UploadedFile(val content: InputStream, val contentType: String?, @Deprecated("Use UploadedFile.size", replaceWith = ReplaceWith("size")) val contentLength: Int, val filename: String, val extension: String, val size: Long)

--- a/javalin/src/test/java/io/javalin/testing/UploadInfo.kt
+++ b/javalin/src/test/java/io/javalin/testing/UploadInfo.kt
@@ -6,4 +6,4 @@
 
 package io.javalin.testing
 
-class UploadInfo(val filename: String = "", val size: Long = 0L, val contentType: String = "", val extension: String = "")
+class UploadInfo(val filename: String = "", val size: Long = 0L, val contentType: String? = "", val extension: String = "")


### PR DESCRIPTION
…urs when a client uploads a file without a content type