### PR TITLE
Upgrade jetty to solve CVE-2020-27223

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <freemarker.version>2.3.30</freemarker.version>
         <guava.version>28.2-jre</guava.version>
         <jackson.version>2.10.3</jackson.version>
-        <jetty.version>9.4.35.v20201120</jetty.version>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <jtwig.version>5.87.0.RELEASE</jtwig.version>
         <jvmbrotli.version>0.2.0</jvmbrotli.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
Upgraded the jetty version to ```9.4.38.v20210224``` to solve ```CVE-2020-272231``` and resolve: https://github.com/tipsy/javalin/issues/1190