### PR TITLE
Rename WsHandlerController & WsHandler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ io.javalin
 ├── websocket/                  // Everything related to WebSockets
 │   ├── WsContext.kt            // Wrapper class for WebSockets
 │   ├── JavalinWsServlet.kt     // Responsible for WebSocket upgrade, as well as switching between WebSocket and HTTP
-│   └── WsHandlerController.kt  // Responsible for Websocket request lifecycle (before, endpoint, after, logging)
+│   └── WsConnection.kt         // Keeps state of a WebSocket connection and handles incoming events
 └── Javalin.java                // Main public API, responsible for setting up and configuring the server
 ```
 

--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -30,7 +30,7 @@ import io.javalin.http.sse.SseClient;
 import io.javalin.http.sse.SseHandler;
 import io.javalin.websocket.JavalinWsServlet;
 import io.javalin.websocket.WsExceptionHandler;
-import io.javalin.websocket.WsHandler;
+import io.javalin.websocket.WsHandlers;
 import io.javalin.websocket.WsHandlerType;
 import java.util.HashSet;
 import java.util.Set;
@@ -547,17 +547,17 @@ public class Javalin {
      * Adds a specific WebSocket handler for the given path to the instance.
      * Requires an access manager to be set on the instance.
      */
-    private Javalin addWsHandler(@NotNull WsHandlerType handlerType, @NotNull String path, @NotNull Consumer<WsHandler> wsHandler, @NotNull Set<Role> roles) {
-        wsServlet.addHandler(handlerType, path, wsHandler, roles);
-        eventManager.fireWsHandlerAddedEvent(new WsHandlerMetaInfo(handlerType, Util.prefixContextPath(servlet.getConfig().contextPath, path), wsHandler, roles));
+    private Javalin addWsHandler(@NotNull WsHandlerType handlerType, @NotNull String path, @NotNull Consumer<WsHandlers> wsHandlers, @NotNull Set<Role> roles) {
+        wsServlet.addHandler(handlerType, path, wsHandlers, roles);
+        eventManager.fireWsHandlerAddedEvent(new WsHandlerMetaInfo(handlerType, Util.prefixContextPath(servlet.getConfig().contextPath, path), wsHandlers, roles));
         return this;
     }
 
     /**
      * Adds a specific WebSocket handler for the given path to the instance.
      */
-    private Javalin addWsHandler(@NotNull WsHandlerType handlerType, @NotNull String path, @NotNull Consumer<WsHandler> wsHandler) {
-        return addWsHandler(handlerType, path, wsHandler, new HashSet<>());
+    private Javalin addWsHandler(@NotNull WsHandlerType handlerType, @NotNull String path, @NotNull Consumer<WsHandlers> wsHandlers) {
+        return addWsHandler(handlerType, path, wsHandlers, new HashSet<>());
     }
 
     /**
@@ -565,7 +565,7 @@ public class Javalin {
      *
      * @see <a href="https://javalin.io/documentation#websockets">WebSockets in docs</a>
      */
-    public Javalin ws(@NotNull String path, @NotNull Consumer<WsHandler> ws) {
+    public Javalin ws(@NotNull String path, @NotNull Consumer<WsHandlers> ws) {
         return ws(path, ws, new HashSet<>());
     }
 
@@ -576,36 +576,36 @@ public class Javalin {
      * @see AccessManager
      * @see <a href="https://javalin.io/documentation#websockets">WebSockets in docs</a>
      */
-    public Javalin ws(@NotNull String path, @NotNull Consumer<WsHandler> ws, @NotNull Set<Role> permittedRoles) {
+    public Javalin ws(@NotNull String path, @NotNull Consumer<WsHandlers> ws, @NotNull Set<Role> permittedRoles) {
         return addWsHandler(WsHandlerType.WEBSOCKET, path, ws, permittedRoles);
     }
 
     /**
      * Adds a WebSocket before handler for the specified path to the instance.
      */
-    public Javalin wsBefore(@NotNull String path, @NotNull Consumer<WsHandler> wsHandler) {
-        return addWsHandler(WsHandlerType.WS_BEFORE, path, wsHandler);
+    public Javalin wsBefore(@NotNull String path, @NotNull Consumer<WsHandlers> wsHandlers) {
+        return addWsHandler(WsHandlerType.WS_BEFORE, path, wsHandlers);
     }
 
     /**
      * Adds a WebSocket before handler for all routes in the instance.
      */
-    public Javalin wsBefore(@NotNull Consumer<WsHandler> wsHandler) {
-        return wsBefore("*", wsHandler);
+    public Javalin wsBefore(@NotNull Consumer<WsHandlers> wsHandlers) {
+        return wsBefore("*", wsHandlers);
     }
 
     /**
      * Adds a WebSocket after handler for the specified path to the instance.
      */
-    public Javalin wsAfter(@NotNull String path, @NotNull Consumer<WsHandler> wsHandler) {
-        return addWsHandler(WsHandlerType.WS_AFTER, path, wsHandler);
+    public Javalin wsAfter(@NotNull String path, @NotNull Consumer<WsHandlers> wsHandlers) {
+        return addWsHandler(WsHandlerType.WS_AFTER, path, wsHandlers);
     }
 
     /**
      * Adds a WebSocket after handler for all routes in the instance.
      */
-    public Javalin wsAfter(@NotNull Consumer<WsHandler> wsHandler) {
-        return wsAfter("*", wsHandler);
+    public Javalin wsAfter(@NotNull Consumer<WsHandlers> wsHandlers) {
+        return wsAfter("*", wsHandlers);
     }
 
 }

--- a/javalin/src/main/java/io/javalin/apibuilder/ApiBuilder.java
+++ b/javalin/src/main/java/io/javalin/apibuilder/ApiBuilder.java
@@ -11,7 +11,7 @@ import io.javalin.core.security.AccessManager;
 import io.javalin.core.security.Role;
 import io.javalin.http.Handler;
 import io.javalin.http.sse.SseClient;
-import io.javalin.websocket.WsHandler;
+import io.javalin.websocket.WsHandlers;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
@@ -374,7 +374,7 @@ public class ApiBuilder {
      *
      * @see <a href="https://javalin.io/documentation#websockets">WebSockets in docs</a>
      */
-    public static void ws(@NotNull String path, @NotNull Consumer<WsHandler> ws) {
+    public static void ws(@NotNull String path, @NotNull Consumer<WsHandlers> ws) {
         staticInstance().ws(prefixPath(path), ws);
     }
 
@@ -384,7 +384,7 @@ public class ApiBuilder {
      *
      * @see <a href="https://javalin.io/documentation#websockets">WebSockets in docs</a>
      */
-    public static void ws(@NotNull String path, @NotNull Consumer<WsHandler> ws, @NotNull Set<Role> permittedRoles) {
+    public static void ws(@NotNull String path, @NotNull Consumer<WsHandlers> ws, @NotNull Set<Role> permittedRoles) {
         staticInstance().ws(prefixPath(path), ws, permittedRoles);
     }
 
@@ -394,7 +394,7 @@ public class ApiBuilder {
      *
      * @see <a href="https://javalin.io/documentation#websockets">WebSockets in docs</a>
      */
-    public static void ws(@NotNull Consumer<WsHandler> ws) {
+    public static void ws(@NotNull Consumer<WsHandlers> ws) {
         staticInstance().ws(prefixPath(""), ws);
     }
 
@@ -404,7 +404,7 @@ public class ApiBuilder {
      *
      * @see <a href="https://javalin.io/documentation#websockets">WebSockets in docs</a>
      */
-    public static void ws(@NotNull Consumer<WsHandler> ws, @NotNull Set<Role> permittedRoles) {
+    public static void ws(@NotNull Consumer<WsHandlers> ws, @NotNull Set<Role> permittedRoles) {
         staticInstance().ws(prefixPath(""), ws, permittedRoles);
     }
 
@@ -412,32 +412,32 @@ public class ApiBuilder {
      * Adds a WebSocket before handler for the specified path to the {@link Javalin} instance.
      * The method can only be called inside a {@link Javalin#routes(EndpointGroup)}.
      */
-    public Javalin wsBefore(@NotNull String path, @NotNull Consumer<WsHandler> wsHandler) {
-        return staticInstance().wsBefore(prefixPath(path), wsHandler);
+    public Javalin wsBefore(@NotNull String path, @NotNull Consumer<WsHandlers> wsHandlers) {
+        return staticInstance().wsBefore(prefixPath(path), wsHandlers);
     }
 
     /**
      * Adds a WebSocket before handler for the current path to the {@link Javalin} instance.
      * The method can only be called inside a {@link Javalin#routes(EndpointGroup)}.
      */
-    public Javalin wsBefore(@NotNull Consumer<WsHandler> wsHandler) {
-        return staticInstance().wsBefore(prefixPath("/*"), wsHandler);
+    public Javalin wsBefore(@NotNull Consumer<WsHandlers> wsHandlers) {
+        return staticInstance().wsBefore(prefixPath("/*"), wsHandlers);
     }
 
     /**
      * Adds a WebSocket after handler for the specified path to the {@link Javalin} instance.
      * The method can only be called inside a {@link Javalin#routes(EndpointGroup)}.
      */
-    public Javalin wsAfter(@NotNull String path, @NotNull Consumer<WsHandler> wsHandler) {
-        return staticInstance().wsAfter(prefixPath(path), wsHandler);
+    public Javalin wsAfter(@NotNull String path, @NotNull Consumer<WsHandlers> wsHandlers) {
+        return staticInstance().wsAfter(prefixPath(path), wsHandlers);
     }
 
     /**
      * Adds a WebSocket after handler for the current path to the {@link Javalin} instance.
      * The method can only be called inside a {@link Javalin#routes(EndpointGroup)}.
      */
-    public Javalin wsAfter(@NotNull Consumer<WsHandler> wsHandler) {
-        return staticInstance().wsAfter(prefixPath("/*"), wsHandler);
+    public Javalin wsAfter(@NotNull Consumer<WsHandlers> wsHandlers) {
+        return staticInstance().wsAfter(prefixPath("/*"), wsHandlers);
     }
 
     // ********************************************************************************************

--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -26,7 +26,7 @@ import io.javalin.http.staticfiles.JettyResourceHandler;
 import io.javalin.http.staticfiles.Location;
 import io.javalin.http.staticfiles.ResourceHandler;
 import io.javalin.http.staticfiles.StaticFileConfig;
-import io.javalin.websocket.WsHandler;
+import io.javalin.websocket.WsHandlers;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -73,7 +73,7 @@ public class JavalinConfig {
         @NotNull public SinglePageHandler singlePageHandler = new SinglePageHandler();
         @Nullable public SessionHandler sessionHandler = null;
         @Nullable public Consumer<WebSocketServletFactory> wsFactoryConfig = null;
-        @Nullable public WsHandler wsLogger = null;
+        @Nullable public WsHandlers wsLogger = null;
         @Nullable public Server server = null;
         @Nullable public Consumer<ServletContextHandler> servletContextHandlerConsumer = null;
         @NotNull public CompressionStrategy compressionStrategy = CompressionStrategy.GZIP;
@@ -174,8 +174,8 @@ public class JavalinConfig {
         return this;
     }
 
-    public JavalinConfig wsLogger(@NotNull Consumer<WsHandler> ws) {
-        WsHandler logger = new WsHandler();
+    public JavalinConfig wsLogger(@NotNull Consumer<WsHandlers> ws) {
+        WsHandlers logger = new WsHandlers();
         ws.accept(logger);
         inner.wsLogger = logger;
         return this;

--- a/javalin/src/main/java/io/javalin/core/util/LogUtil.kt
+++ b/javalin/src/main/java/io/javalin/core/util/LogUtil.kt
@@ -11,7 +11,7 @@ import io.javalin.http.Context
 import io.javalin.http.HandlerType
 import io.javalin.http.PathMatcher
 import io.javalin.websocket.WsContext
-import io.javalin.websocket.WsHandler
+import io.javalin.websocket.WsHandlers
 import java.util.*
 
 object LogUtil {
@@ -71,7 +71,7 @@ object LogUtil {
     fun executionTimeMs(ctx: Context) = (System.nanoTime() - ctx.attribute<Long>("javalin-request-log-start-time")!!) / 1000000f
 
     @JvmStatic
-    fun wsDevLogger(ws: WsHandler) {
+    fun wsDevLogger(ws: WsHandlers) {
         ws.onConnect { ctx -> ctx.logEvent("onConnect") }
         ws.onMessage { ctx -> ctx.logEvent("onMessage", "Message (next line):\n${ctx.message()}") }
         ws.onBinaryMessage { ctx -> ctx.logEvent("onBinaryMessage", "Offset: ${ctx.offset()}, Length: ${ctx.length()}\nMessage (next line):\n${ctx.data()}") }

--- a/javalin/src/main/java/io/javalin/websocket/JavalinWsServlet.kt
+++ b/javalin/src/main/java/io/javalin/websocket/JavalinWsServlet.kt
@@ -75,8 +75,9 @@ class JavalinWsServlet(val config: JavalinConfig, private val httpServlet: Javal
         }
     }
 
-    fun addHandler(handlerType: WsHandlerType, path: String, ws: Consumer<WsHandler>, permittedRoles: Set<Role>) {
-        wsPathMatcher.add(WsEntry(handlerType, path, config.ignoreTrailingSlashes, WsHandler().apply { ws.accept(this) }, permittedRoles))
+    fun addHandler(handlerType: WsHandlerType, path: String, ws: Consumer<WsHandlers>, permittedRoles: Set<Role>) {
+        wsPathMatcher.add(WsEntry(handlerType, path, config.ignoreTrailingSlashes, WsHandlers()
+            .apply { ws.accept(this) }, permittedRoles))
     }
 }
 

--- a/javalin/src/main/java/io/javalin/websocket/JavalinWsServlet.kt
+++ b/javalin/src/main/java/io/javalin/websocket/JavalinWsServlet.kt
@@ -42,7 +42,7 @@ class JavalinWsServlet(val config: JavalinConfig, private val httpServlet: Javal
             val preUpgradeContext = req.httpServletRequest.getAttribute(upgradeContextKey) as Context
             req.httpServletRequest.setAttribute(upgradeContextKey, ContextUtil.changeBaseRequest(preUpgradeContext, req.httpServletRequest))
             req.httpServletRequest.setAttribute(upgradeSessionAttrsKey, req.session?.attributeNames?.asSequence()?.associateWith { req.session.getAttribute(it) })
-            return@WebSocketCreator WsHandlerController(wsPathMatcher, wsExceptionMapper, config.inner.wsLogger)
+            return@WebSocketCreator WsConnection(wsPathMatcher, wsExceptionMapper, config.inner.wsLogger)
         }
     }
 

--- a/javalin/src/main/java/io/javalin/websocket/WsConnection.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsConnection.kt
@@ -17,11 +17,11 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * A special WebSocket handler which delegates the handling of the specific WebSocket event to the
- * matching custom handlers.
+ * Is instantiated for every WebSocket connection. It keeps the session and sessionId and handles incoming events by
+ * delegating to the registered before, endpoint, after and logger handlers.
  */
 @WebSocket
-class WsHandlerController(val matcher: WsPathMatcher, val exceptionMapper: WsExceptionMapper, val wsLogger: WsHandler?) {
+class WsConnection(val matcher: WsPathMatcher, val exceptionMapper: WsExceptionMapper, val wsLogger: WsHandler?) {
 
     private val sessionIds = ConcurrentHashMap<Session, String>()
 

--- a/javalin/src/main/java/io/javalin/websocket/WsConnection.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsConnection.kt
@@ -20,47 +20,47 @@ import java.util.*
  * delegating to the registered before, endpoint, after and logger handlers.
  */
 @WebSocket
-class WsConnection(val matcher: WsPathMatcher, val exceptionMapper: WsExceptionMapper, val wsLogger: WsHandler?) {
+class WsConnection(val matcher: WsPathMatcher, val exceptionMapper: WsExceptionMapper, val wsLogger: WsHandlers?) {
 
     private val sessionId: String = UUID.randomUUID().toString()
 
     @OnWebSocketConnect
     fun onConnect(session: Session) {
         val ctx = WsConnectContext(sessionId, session)
-        tryBeforeAndEndpointHandlers(ctx) { it.handler.wsConnectHandler?.handleConnect(ctx) }
-        tryAfterHandlers(ctx) { it.handler.wsConnectHandler?.handleConnect(ctx) }
+        tryBeforeAndEndpointHandlers(ctx) { it.handlers.wsConnectHandler?.handleConnect(ctx) }
+        tryAfterHandlers(ctx) { it.handlers.wsConnectHandler?.handleConnect(ctx) }
         wsLogger?.wsConnectHandler?.handleConnect(ctx)
     }
 
     @OnWebSocketMessage
     fun onMessage(session: Session, message: String) {
         val ctx = WsMessageContext(sessionId, session, message)
-        tryBeforeAndEndpointHandlers(ctx) { it.handler.wsMessageHandler?.handleMessage(ctx) }
-        tryAfterHandlers(ctx) { it.handler.wsMessageHandler?.handleMessage(ctx) }
+        tryBeforeAndEndpointHandlers(ctx) { it.handlers.wsMessageHandler?.handleMessage(ctx) }
+        tryAfterHandlers(ctx) { it.handlers.wsMessageHandler?.handleMessage(ctx) }
         wsLogger?.wsMessageHandler?.handleMessage(ctx)
     }
 
     @OnWebSocketMessage
     fun onMessage(session: Session, buffer: ByteArray, offset: Int, length: Int) {
         val ctx = WsBinaryMessageContext(sessionId, session, buffer, offset, length)
-        tryBeforeAndEndpointHandlers(ctx) { it.handler.wsBinaryMessageHandler?.handleBinaryMessage(ctx) }
-        tryAfterHandlers(ctx) { it.handler.wsBinaryMessageHandler?.handleBinaryMessage(ctx) }
+        tryBeforeAndEndpointHandlers(ctx) { it.handlers.wsBinaryMessageHandler?.handleBinaryMessage(ctx) }
+        tryAfterHandlers(ctx) { it.handlers.wsBinaryMessageHandler?.handleBinaryMessage(ctx) }
         wsLogger?.wsBinaryMessageHandler?.handleBinaryMessage(ctx)
     }
 
     @OnWebSocketClose
     fun onClose(session: Session, statusCode: Int, reason: String?) {
         val ctx = WsCloseContext(sessionId, session, statusCode, reason)
-        tryBeforeAndEndpointHandlers(ctx) { it.handler.wsCloseHandler?.handleClose(ctx) }
-        tryAfterHandlers(ctx) { it.handler.wsCloseHandler?.handleClose(ctx) }
+        tryBeforeAndEndpointHandlers(ctx) { it.handlers.wsCloseHandler?.handleClose(ctx) }
+        tryAfterHandlers(ctx) { it.handlers.wsCloseHandler?.handleClose(ctx) }
         wsLogger?.wsCloseHandler?.handleClose(ctx)
     }
 
     @OnWebSocketError
     fun onError(session: Session, throwable: Throwable?) {
         val ctx = WsErrorContext(sessionId, session, throwable)
-        tryBeforeAndEndpointHandlers(ctx) { it.handler.wsErrorHandler?.handleError(ctx) }
-        tryAfterHandlers(ctx) { it.handler.wsErrorHandler?.handleError(ctx) }
+        tryBeforeAndEndpointHandlers(ctx) { it.handlers.wsErrorHandler?.handleError(ctx) }
+        tryAfterHandlers(ctx) { it.handlers.wsErrorHandler?.handleError(ctx) }
         wsLogger?.wsErrorHandler?.handleError(ctx)
     }
 

--- a/javalin/src/main/java/io/javalin/websocket/WsExceptionHandler.java
+++ b/javalin/src/main/java/io/javalin/websocket/WsExceptionHandler.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * A handler for use with {@link io.javalin.Javalin#wsException(Class, WsExceptionHandler)}.
- * Is triggered when an exception is thrown by a {@link WsHandler}.
+ * Is triggered when an exception is thrown by a {@link WsHandlers}.
  *
  * @see WsContext
  */

--- a/javalin/src/main/java/io/javalin/websocket/WsHandlers.java
+++ b/javalin/src/main/java/io/javalin/websocket/WsHandlers.java
@@ -8,7 +8,10 @@ package io.javalin.websocket;
 
 import org.jetbrains.annotations.NotNull;
 
-public class WsHandler {
+/**
+ * Holds the different WebSocket handlers for a specific {@link WsEntry} or the WebSocket logger.
+ */
+public class WsHandlers {
 
     WsConnectHandler wsConnectHandler = null;
     WsMessageHandler wsMessageHandler = null;

--- a/javalin/src/main/java/io/javalin/websocket/WsPathMatcher.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsPathMatcher.kt
@@ -10,7 +10,7 @@ import io.javalin.core.PathParser
 import io.javalin.core.security.Role
 import java.util.*
 
-data class WsEntry(val type: WsHandlerType, val path: String, val ignoreTrailingSlashes: Boolean, val handler: WsHandler, val permittedRoles: Set<Role>) {
+data class WsEntry(val type: WsHandlerType, val path: String, val ignoreTrailingSlashes: Boolean, val handlers: WsHandlers, val permittedRoles: Set<Role>) {
     private val pathParser = PathParser(path, ignoreTrailingSlashes)
     fun matches(path: String) = pathParser.matches(path)
     fun extractPathParams(path: String) = pathParser.extractPathParams(path)

--- a/javalin/src/test/java/io/javalin/routeoverview/VisualTest.java
+++ b/javalin/src/test/java/io/javalin/routeoverview/VisualTest.java
@@ -11,7 +11,7 @@ import io.javalin.core.util.RouteOverviewPlugin;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.http.HandlerType;
-import io.javalin.websocket.WsHandler;
+import io.javalin.websocket.WsHandlers;
 import static io.javalin.TestAccessManager.MyRoles.ROLE_ONE;
 import static io.javalin.TestAccessManager.MyRoles.ROLE_THREE;
 import static io.javalin.TestAccessManager.MyRoles.ROLE_TWO;
@@ -74,8 +74,8 @@ public class VisualTest {
         });
     }
 
-    private static void wsMethodRef(WsHandler wsHandler) {
-        wsHandler.onConnect(ctx -> ctx.session.getRemote().sendString("Connected!"));
+    private static void wsMethodRef(WsHandlers wsHandlers) {
+        wsHandlers.onConnect(ctx -> ctx.session.getRemote().sendString("Connected!"));
     }
 
     private static void methodReference(Context context) {


### PR DESCRIPTION
This PR follows up on https://github.com/tipsy/javalin/issues/1191#issuecomment-794137985

Besides the rename there are small documentation improvements and a pointless HashMap is removed from WsHandlerController. 