### PR TITLE
Add support for kotlin templates

### DIFF
--- a/javalin/pom.xml
+++ b/javalin/pom.xml
@@ -87,6 +87,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>gg.jte</groupId>
+            <artifactId>jte-kotlin</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
             <optional>true</optional>

--- a/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -26,5 +26,5 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
     SWAGGER_CORE("Swagger Core", "io.swagger.v3.oas.models.OpenAPI", "io.swagger.core.v3", "swagger-models", "2.1.6"),
     CLASS_GRAPH("ClassGraph", "io.github.classgraph.ClassGraph", "io.github.classgraph", "classgraph", "4.8.102"),
     JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),
-    JTE("jte", "gg.jte.TemplateEngine", "gg.jte", "jte", "1.6.0"),
+    JTE("jte", "gg.jte.TemplateEngine", "gg.jte", "jte", "1.9.0"),
 }

--- a/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -27,4 +27,5 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
     CLASS_GRAPH("ClassGraph", "io.github.classgraph.ClassGraph", "io.github.classgraph", "classgraph", "4.8.102"),
     JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),
     JTE("jte", "gg.jte.TemplateEngine", "gg.jte", "jte", "1.9.0"),
+    JTE_KOTLIN("jte-kotlin", "gg.jte.compiler.kotlin.KotlinClassCompiler", "gg.jte", "jte-kotlin", "1.9.0"),
 }

--- a/javalin/src/main/java/io/javalin/plugin/rendering/JavalinRenderer.kt
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/JavalinRenderer.kt
@@ -29,7 +29,7 @@ object JavalinRenderer {
         register(JavalinPebble, ".peb", ".pebble")
         register(JavalinThymeleaf, ".html", ".tl", ".thyme", ".thymeleaf")
         register(JavalinCommonmark, ".md", ".markdown")
-        register(JavalinJte, ".jte")
+        register(JavalinJte, ".jte", ".kte")
     }
 
     @JvmField

--- a/javalin/src/main/java/io/javalin/plugin/rendering/template/JavalinJte.kt
+++ b/javalin/src/main/java/io/javalin/plugin/rendering/template/JavalinJte.kt
@@ -13,10 +13,14 @@ import gg.jte.resolve.DirectoryCodeResolver
 import io.javalin.core.util.OptionalDependency
 import io.javalin.core.util.Util
 import io.javalin.http.Context
+import io.javalin.http.util.ContextUtil.isLocalhost
 import io.javalin.plugin.rendering.FileRenderer
 import java.io.File
 
 object JavalinJte : FileRenderer {
+
+    internal var isDev: Boolean? = null // cached and easily accessible, is set on first request (can't be configured directly by end user)
+    @JvmField var isDevFunction: (Context) -> Boolean = { it.isLocalhost() } // used to set isDev, will be called once
 
     private var templateEngine: TemplateEngine? = null
     private val defaultTemplateEngine: TemplateEngine by lazy { defaultJteEngine() }
@@ -28,6 +32,11 @@ object JavalinJte : FileRenderer {
 
     override fun render(filePath: String, model: Map<String, Any?>, ctx: Context): String {
         Util.ensureDependencyPresent(OptionalDependency.JTE)
+
+        isDev = isDev ?: isDevFunction(ctx)
+        if (isDev == true && filePath.endsWith(".kte")) {
+            Util.ensureDependencyPresent(OptionalDependency.JTE_KOTLIN)
+        }
 
         val stringOutput = StringOutput()
         (templateEngine ?: defaultTemplateEngine).render(filePath, model, stringOutput)

--- a/javalin/src/test/java/io/javalin/TestTemplates.kt
+++ b/javalin/src/test/java/io/javalin/TestTemplates.kt
@@ -12,7 +12,6 @@ import com.mitchellbosecke.pebble.loader.ClasspathLoader
 import gg.jte.ContentType
 import gg.jte.TemplateEngine
 import gg.jte.resolve.ResourceCodeResolver
-import io.javalin.plugin.rendering.FileRenderer
 import io.javalin.plugin.rendering.JavalinRenderer
 import io.javalin.plugin.rendering.template.JavalinJte
 import io.javalin.plugin.rendering.template.JavalinJtwig
@@ -186,7 +185,7 @@ class TestTemplates {
 
     @Test
     fun `registering custom renderer works`() = TestUtil.test { app, http ->
-        JavalinRenderer.register(FileRenderer { _, _, _ -> "Hah." }, ".lol")
+        JavalinRenderer.register({ _, _, _ -> "Hah." }, ".lol")
         app.get("/hello") { ctx -> ctx.render("/markdown/test.lol") }
         assertThat(http.getBody("/hello")).isEqualTo("Hah.")
     }
@@ -205,14 +204,14 @@ class TestTemplates {
 
     @Test
     fun `base Model works`() = TestUtil.test { app, http ->
-        JavalinRenderer.baseModelFunction = { ctx -> defaultBaseModel + mapOf("queryParams" to ctx.queryParamMap(), "pathParams" to ctx.pathParamMap()) };
+        JavalinRenderer.baseModelFunction = { ctx -> defaultBaseModel + mapOf("queryParams" to ctx.queryParamMap(), "pathParams" to ctx.pathParamMap()) }
         app.get("/hello/:pp") { ctx -> ctx.render("/templates/freemarker/test-with-base.ftl", model("message", "Hello Freemarker!")) }
         assertThat(http.getBody("/hello/world?im=good")).isEqualTo("<h1>good</h1><h2>world</h2><h3>bar</h3>")
     }
 
     @Test
     fun `base model overwrite works`() = TestUtil.test { app, http ->
-        JavalinRenderer.baseModelFunction = { ctx -> defaultBaseModel + mapOf("queryParams" to ctx.queryParamMap(), "pathParams" to ctx.pathParamMap()) };
+        JavalinRenderer.baseModelFunction = { ctx -> defaultBaseModel + mapOf("queryParams" to ctx.queryParamMap(), "pathParams" to ctx.pathParamMap()) }
         app.get("/hello/:pp") { ctx -> ctx.render("/templates/freemarker/test-with-base.ftl", model("foo", "baz")) }
         assertThat(http.getBody("/hello/world?im=good")).isEqualTo("<h1>good</h1><h2>world</h2><h3>baz</h3>")
     }

--- a/javalin/src/test/java/io/javalin/TestTemplates.kt
+++ b/javalin/src/test/java/io/javalin/TestTemplates.kt
@@ -146,24 +146,16 @@ class TestTemplates {
 
     @Test
     fun `jte works`() = TestUtil.test { app, http ->
-        try {
-            JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath(), ContentType.Html))
-            app.get("/hello") { ctx -> ctx.render("test.jte", model("page", JteTestPage("hello", "world"))) }
-            assertThat(http.getBody("/hello")).isEqualToIgnoringNewLines("<h1>hello world!</h1>")
-        } catch (e: UnsupportedClassVersionError) {
-            // jte does require JDK 11+ to work
-        }
+        JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath(), ContentType.Html))
+        app.get("/hello") { ctx -> ctx.render("test.jte", model("page", JteTestPage("hello", "world"))) }
+        assertThat(http.getBody("/hello")).isEqualToIgnoringNewLines("<h1>hello world!</h1>")
     }
 
     @Test
     fun `jte multiple params work`() = TestUtil.test { app, http ->
-        try {
-            JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath(), ContentType.Html))
-            app.get("/hello") { ctx -> ctx.render("multiple-params.jte", model("one", "hello", "two", "world")) }
-            assertThat(http.getBody("/hello")).isEqualToIgnoringNewLines("<h1>hello world!</h1>")
-        } catch (e: UnsupportedClassVersionError) {
-            // jte does require JDK 11+ to work
-        }
+        JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath(), ContentType.Html))
+        app.get("/hello") { ctx -> ctx.render("multiple-params.jte", model("one", "hello", "two", "world")) }
+        assertThat(http.getBody("/hello")).isEqualToIgnoringNewLines("<h1>hello world!</h1>")
     }
 
     @Test

--- a/javalin/src/test/java/io/javalin/TestTemplates.kt
+++ b/javalin/src/test/java/io/javalin/TestTemplates.kt
@@ -159,6 +159,20 @@ class TestTemplates {
     }
 
     @Test
+    fun `jte kotlin works`() = TestUtil.test { app, http ->
+        JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath(), ContentType.Html))
+        app.get("/hello") { ctx -> ctx.render("test.kte", model("page", JteTestPage("hello", "world"))) }
+        assertThat(http.getBody("/hello")).isEqualToIgnoringNewLines("<h1>hello world!</h1>")
+    }
+
+    @Test
+    fun `jte kotlin multiple params work`() = TestUtil.test { app, http ->
+        JavalinJte.configure(TemplateEngine.create(ResourceCodeResolver("templates/jte"), File("target/jte").toPath(), ContentType.Html))
+        app.get("/hello") { ctx -> ctx.render("multiple-params.kte", model("one", "hello", "two", "world")) }
+        assertThat(http.getBody("/hello")).isEqualToIgnoringNewLines("<h1>hello world!</h1>")
+    }
+
+    @Test
     fun `markdown works`() = TestUtil.test { app, http ->
         app.get("/hello") { ctx -> ctx.render("/markdown/test.md") }
         assertThat(http.getBody("/hello")).isEqualTo("<h1>Hello Markdown!</h1>\n")

--- a/javalin/src/test/resources/templates/jte/multiple-params.kte
+++ b/javalin/src/test/resources/templates/jte/multiple-params.kte
@@ -1,0 +1,3 @@
+@param one:String
+@param two:String
+<h1>${one} ${two}!</h1>

--- a/javalin/src/test/resources/templates/jte/test.kte
+++ b/javalin/src/test/resources/templates/jte/test.kte
@@ -1,0 +1,3 @@
+@import io.javalin.TestTemplates.JteTestPage
+@param page:JteTestPage
+<h1>${page.hello} ${page.world}!</h1>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
                 <version>${jte.version}</version>
             </dependency>
             <dependency>
+                <groupId>gg.jte</groupId>
+                <artifactId>jte-kotlin</artifactId>
+                <version>${jte.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.commonmark</groupId>
                 <artifactId>commonmark</artifactId>
                 <version>${commonmark.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <swagger.ui.version>3.43.0</swagger.ui.version>
         <thymeleaf.version>3.0.12.RELEASE</thymeleaf.version>
         <velocity.version>2.2</velocity.version>
-        <jte.version>1.6.0</jte.version>
+        <jte.version>1.9.0</jte.version>
 
         <!-- TEST DEPENDENCIES -->
         <assertj.version>3.15.0</assertj.version>


### PR DESCRIPTION
jte allows template expression in Kotlin instead of Java since [version 1.8.0](https://github.com/casid/jte/releases/tag/1.8.0), which would be a nice fit for Javalin.

See this issue for more details: https://github.com/tipsy/javalin/issues/1206
