### PR TITLE
bump Jetty in order to address CVE-2021-28165

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <freemarker.version>2.3.30</freemarker.version>
         <guava.version>30.1-jre</guava.version>
         <jackson.version>2.12.1</jackson.version>
-        <jetty.version>9.4.38.v20210224</jetty.version>
+        <jetty.version>9.4.39.v20210325</jetty.version>
         <jtwig.version>5.87.0.RELEASE</jtwig.version>
         <jvmbrotli.version>0.2.0</jvmbrotli.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
Hello, just a little dependency bump for Jetty to resolve CVE-2021-28165