### PR TITLE
Added in an option to set a list of explicitly included paths for the OpenAPI Plugin

### DIFF
--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/OpenApiHandler.kt
@@ -35,14 +35,7 @@ class OpenApiHandler(app: Javalin, val options: OpenApiOptions) : Handler {
     fun createOpenAPISchema(): OpenAPI {
         val schema = JavalinOpenApi.createSchema(
                 CreateSchemaOptions(
-                        handlerMetaInfoList = handlerMetaInfoList.filter { handler ->
-                            options.ignoredPaths.none { (path, methods) ->
-                                PathParser(path, true).matches(handler.path) && methods.any { method ->
-                                    // HttpMethod is implemented two times :(
-                                    method.name == handler.httpMethod.name
-                                }
-                            }
-                        },
+                        handlerMetaInfoList = handlerMetaInfoList.filter(::matchesInclusionCriteria),
                         initialConfigurationCreator = options.initialConfigurationCreator,
                         default = options.default,
                         modelConverterFactory = options.modelConverterFactory,
@@ -65,6 +58,45 @@ class OpenApiHandler(app: Javalin, val options: OpenApiOptions) : Handler {
         }
 
         return schema
+    }
+
+    /**
+     * This function returns true if the given handler matches the inclusion and exclusion criteria provided when
+     * configuring the OpenAPI options.  Specifically, the logic works as follows
+     *
+     * 1. By default a path is always included unless we have specified explicit inclusion criteria
+     * 2. If explicit inclusion criteria are specified then a path is only included if it matches
+     * 3. Regardless of whether we are using explicit inclusion criteria or not, exclusion criteria take preference so
+     *    that a path which is both explicitly included and excluded will end up being excluded.  This is simply down
+     *    to security - deny criteria should always be considered "higher priority" than allow criteria
+     *
+     * @param handler : the handler we want to know if matches the inclusion criteria
+     */
+    private fun matchesInclusionCriteria(handler: HandlerMetaInfo): Boolean{
+        //by default all paths are included
+        var included = true
+
+        //but if we have explicitly set an include path then the handler is only included in OpenAPI if the path and
+        //method have been explicitly specified
+        if(options.includedPaths.isNotEmpty()){
+            included = options.includedPaths.any { (path, methods) ->
+                PathParser(path, true).matches(handler.path) && methods.any { method ->
+                    // HttpMethod is implemented two times :(
+                    method.name == handler.httpMethod.name
+                }
+            }
+        }
+
+        //a path is excluded if the path and methods are included in the list of excluded paths
+        val excluded = !options.ignoredPaths.none { (path, methods) ->
+            PathParser(path, true).matches(handler.path) && methods.any { method ->
+                // HttpMethod is implemented two times :(
+                method.name == handler.httpMethod.name
+            }
+        }
+
+        //and finally a handler should be included if it is included and not explicitly excluded
+        return included && !excluded
     }
 
     // This function is synchronized because an attacker can trigger the openapi schema generation very often

--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/OpenApiOptions.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/OpenApiOptions.kt
@@ -67,6 +67,12 @@ class OpenApiOptions constructor(val initialConfigurationCreator: InitialConfigu
     var ignoredPaths: MutableList<Pair<String, List<HttpMethod>>> = mutableListOf()
 
     /**
+     * A list of the only paths which will be considered as part of the OpenAPI documentation.  If this list is empty
+     * it will be considered as meaning that all paths should be included with the exception of the ignored paths
+     */
+    val includedPaths: MutableList<Pair<String, List<HttpMethod>>> = mutableListOf()
+
+    /**
      * Validate the generated schema with the swagger parser
      * (prints warnings if schema is invalid)
      */
@@ -127,6 +133,16 @@ class OpenApiOptions constructor(val initialConfigurationCreator: InitialConfigu
 
     fun ignorePath(path: String, vararg httpMethod: HttpMethod) = apply {
         ignoredPaths.add(Pair(path, httpMethod.asList().ifEmpty { HttpMethod.values().asList() }))
+    }
+
+    /**
+     * adds the given path and methods to the list of paths which should be scanned by OpenAPI
+     *
+     * @param path : the path to include in the paths to scan
+     * @param httpMethod : the list of http methods to include in the scan (as a vararg)
+     */
+    fun includePath(path: String, vararg httpMethod: HttpMethod) = apply {
+        includedPaths.add(Pair(path, httpMethod.asList().ifEmpty { HttpMethod.values().asList() }))
     }
 }
 

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiIncludePath.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiIncludePath.kt
@@ -1,0 +1,63 @@
+package io.javalin.plugin.openapi
+
+import io.javalin.Javalin
+import io.javalin.plugin.openapi.dsl.document
+import io.javalin.plugin.openapi.dsl.documented
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class TestOpenApiIncludePath {
+    @Test
+    /**
+     * The aim of this test is to show that using the "includePath" method correctly only includes the selected paths
+     */
+    fun testIncludedMethods() {
+        val defaultApp = Javalin.create {
+            it.registerPlugin(
+                OpenApiPlugin(
+                    OpenApiOptions {
+                        OpenAPI().info(Info().title("Example").version("1.0.0"))
+                    }
+                )
+            )
+        }
+        defaultApp.get("path1", documented(path1Documentation()) { it -> it.result("path1") })
+        defaultApp.get("path2", documented(path2Documentation()) { it -> it.result("path2") })
+        defaultApp.get("path3", documented(path2Documentation()) { it -> it.result("path3") })
+
+        val includedApp = Javalin.create {
+            it.registerPlugin(
+                OpenApiPlugin(
+                    OpenApiOptions {
+                        OpenAPI().info(Info().title("Example").version("1.0.0"))
+                    }
+                    .includePath("path1")
+                    .includePath("path2")
+                )
+            )
+        }
+        includedApp.get("path1", documented(path1Documentation()) { it -> it.result("path1") })
+        includedApp.get("path2", documented(path2Documentation()) { it -> it.result("path2") })
+        includedApp.get("path3", documented(path2Documentation()) { it -> it.result("path2") })
+
+        val defaultSchema = JavalinOpenApi.createSchema(defaultApp).toString().toLowerCase()
+        val includedSchema = JavalinOpenApi.createSchema(includedApp).toString().toLowerCase()
+
+        assertThat(defaultSchema).isNotEqualTo(includedSchema)
+        //the default schema contains no inclusion criteria so should contain paths for path1, 2 and 3
+        assertThat(defaultSchema).contains("/path1=class PathItem".toLowerCase())
+        assertThat(defaultSchema).contains("/path2=class PathItem".toLowerCase())
+        assertThat(defaultSchema).contains("/path3=class PathItem".toLowerCase())
+
+        //the included schema has include paths for path1 and path 2 so should only contain them and not path 3
+        assertThat(includedSchema).contains("/path1=class PathItem".toLowerCase())
+        assertThat(includedSchema).contains("/path2=class PathItem".toLowerCase())
+        assertThat(includedSchema).doesNotContain("/path3=class PathItem".toLowerCase())
+
+    }
+
+    private fun path1Documentation() = document().operation { it.summary="path1" }.result<String>("200")
+    private fun path2Documentation() = document().operation { it.summary="path2" }.result<String>("200")
+}

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiIncludePath.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiIncludePath.kt
@@ -25,7 +25,7 @@ class TestOpenApiIncludePath {
         }
         defaultApp.get("path1", documented(path1Documentation()) { it -> it.result("path1") })
         defaultApp.get("path2", documented(path2Documentation()) { it -> it.result("path2") })
-        defaultApp.get("path3", documented(path2Documentation()) { it -> it.result("path3") })
+        defaultApp.get("path3", documented(path3Documentation()) { it -> it.result("path3") })
 
         val includedApp = Javalin.create {
             it.registerPlugin(
@@ -40,7 +40,7 @@ class TestOpenApiIncludePath {
         }
         includedApp.get("path1", documented(path1Documentation()) { it -> it.result("path1") })
         includedApp.get("path2", documented(path2Documentation()) { it -> it.result("path2") })
-        includedApp.get("path3", documented(path2Documentation()) { it -> it.result("path2") })
+        includedApp.get("path3", documented(path3Documentation()) { it -> it.result("path2") })
 
         val defaultSchema = JavalinOpenApi.createSchema(defaultApp).toString().toLowerCase()
         val includedSchema = JavalinOpenApi.createSchema(includedApp).toString().toLowerCase()
@@ -60,4 +60,5 @@ class TestOpenApiIncludePath {
 
     private fun path1Documentation() = document().operation { it.summary="path1" }.result<String>("200")
     private fun path2Documentation() = document().operation { it.summary="path2" }.result<String>("200")
+    private fun path3Documentation() = document().operation { it.summary="path3" }.result<String>("200")
 }

--- a/javalin-openapi/src/test/kotlin/io/javalin/examples/HelloWorldMultiSwagger.kt
+++ b/javalin-openapi/src/test/kotlin/io/javalin/examples/HelloWorldMultiSwagger.kt
@@ -82,7 +82,13 @@ fun main() {
                 .swagger(SwaggerOptions("/swagger-items").title("My Swagger Documentation -- ITEMS only"))
                 .defaultDocumentation { documentation -> documentation.json<InternalServerErrorResponse>("500") }
                 .ignorePath("/users*")
-        it.registerPlugin(OpenApiPlugin(fullOpenApiOptions, itemsOnly))
+        val includeOnly = OpenApiOptions(Info().version("1.0").description("My Application"))
+            .path("/swagger-docs-includeonly")
+            .swagger(SwaggerOptions("/swagger-includeonly").title("My Swagger Documentation -- included paths only"))
+            .defaultDocumentation { documentation -> documentation.json<InternalServerErrorResponse>("500") }
+            .includePath("/items/*")
+
+        it.registerPlugin(OpenApiPlugin(fullOpenApiOptions, itemsOnly, includeOnly))
     }
 
     with(app) {


### PR DESCRIPTION
The aim of this pull request is to add an includePath option to the OpenAPI configuration.  If includedPaths are defined then the OpenAPI plugin will only include paths which match (and which are not explicitly excluded).  Effectively it is a "whitelist" as opposed to ignorePaths which are a "blacklist".

Note that, when doing this I noticed what I think is a bug in the OpenAPI plugin but I wasn't sure of the best way to resolve it.  Specifically, the logic being used to see whether a handler matches an included/excluded path uses PathParser.matches but this seems not to return the results you might expect.

For example, specifying an ignore path of "/users*" does not exclude /users/:id - this can be seen in the example HelloWorldMultiSwagger.kt which does exactly that.  The test for "items only" adds an ignorePath of "/users*" but the generated documentation still included /users/:id
