### PR TITLE
use operation name in graphql execution

### DIFF
--- a/javalin-graphql/src/main/java/io/javalin/plugin/graphql/GraphQLHandler.kt
+++ b/javalin-graphql/src/main/java/io/javalin/plugin/graphql/GraphQLHandler.kt
@@ -42,10 +42,12 @@ class GraphQLHandler(val options: GraphQLOptions) {
     private fun genericExecute(body: Map<*, *>): GraphQLRun {
         val query = body.get("query").toString()
         val variables: Map<String, Any> = if (body["variables"] == null) emptyMap() else body["variables"] as Map<String, Any>
+        val operationName = body.get("operationName")?.toString()
 
         return GraphQLRun(graphQL)
                 .withQuery(query)
                 .withVariables(variables)
+                .withOperationName(operationName)
                 .withContext(options.context);
     }
 

--- a/javalin-graphql/src/main/java/io/javalin/plugin/graphql/graphql/GraphQLRun.kt
+++ b/javalin-graphql/src/main/java/io/javalin/plugin/graphql/graphql/GraphQLRun.kt
@@ -12,11 +12,14 @@ import java.util.concurrent.CompletableFuture
 class GraphQLRun(private val graphql: GraphQL) {
     private var context: Any? = null
     private var query: String = ""
+    private var operationName: String? = null
     private var variables: Map<String, Any> = emptyMap()
 
     fun withQuery(query: String): GraphQLRun = apply { this.query = query }
 
     fun withVariables(variables: Map<String, Any>): GraphQLRun = apply { this.variables = variables }
+
+    fun withOperationName(operationName: String?) = apply { this.operationName = operationName }
 
     fun withContext(context: Any?): GraphQLRun = apply { this.context = context }
 
@@ -31,6 +34,7 @@ class GraphQLRun(private val graphql: GraphQL) {
         return ExecutionInput.newExecutionInput()
                 .variables(variables)
                 .query(query)
+                .operationName(operationName)
                 .context(context)
                 .build()
     }

--- a/javalin-graphql/src/test/kotlin/io/javalin/plugin/graphql/TestGraphQL.kt
+++ b/javalin-graphql/src/test/kotlin/io/javalin/plugin/graphql/TestGraphQL.kt
@@ -9,6 +9,7 @@ import io.javalin.plugin.graphql.helpers.SubscriptionExample
 import io.javalin.testing.HttpUtil
 import io.javalin.testing.TestUtil
 import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertFalse
 import org.assertj.core.api.Assertions.assertThat
 import org.java_websocket.client.WebSocketClient
 import org.java_websocket.drafts.Draft_6455
@@ -39,6 +40,19 @@ class TestGraphQL {
         val mutation = "mutation { changeMessage(newMessage: \\\"$newMessage\\\") }"
         val json = sendPetition(httpUtil,  "{\"query\": \"$mutation\"}")
         assertEquals(json.getJSONObject("data").getString("changeMessage"), newMessage)
+    }
+
+    @Test
+    fun multiQuery() = TestUtil.test(shortTimeoutServer()) { server, httpUtil ->
+        val queries = "query X { hello } query Y { echo(message: \\\"$newMessage\\\") }"
+
+        val jsonX = sendPetition(httpUtil, "{\"query\": \"$queries\", \"operationName\": \"X\"}")
+        assertEquals(jsonX.getJSONObject("data").getString("hello"), message)
+        assertFalse(jsonX.getJSONObject("data").has("echo"))
+
+        val jsonY = sendPetition(httpUtil, "{\"query\": \"$queries\", \"operationName\": \"Y\"}")
+        assertFalse(jsonY.getJSONObject("data").has("hello"))
+        assertEquals(jsonY.getJSONObject("data").getString("echo"), newMessage)
     }
 
     @Test

--- a/javalin-graphql/src/test/kotlin/io/javalin/plugin/graphql/helpers/QueryExample.kt
+++ b/javalin-graphql/src/test/kotlin/io/javalin/plugin/graphql/helpers/QueryExample.kt
@@ -6,6 +6,8 @@ import io.javalin.plugin.graphql.graphql.QueryGraphql
 class QueryExample(val message: String) : QueryGraphql {
     fun hello(): String = message
 
+    fun echo(message: String): String = message
+
     fun context(@GraphQLContext context: ContextExample): ContextExample {
         return context
     }


### PR DESCRIPTION
Currently the graphql plugin does not use a operation name which is provided in a graphql query resulting in an exeption if more than one query is sent by a client, for example by GraphiQL. This Pull request changes that.