### PR TITLE
[meta] Upgrade workflow steps and cache Maven deps (#1254)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,16 +9,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [1.8, 11, 15]
+        java_version: [8, 11, 15]
         os: [windows-latest, macOS-latest, ubuntu-latest]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java_version }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java_version }}
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Make Maven Wrapper executable
         if: contains(matrix.os, 'win') == false
         run: chmod +x ./mvnw


### PR DESCRIPTION
Upgrades both [actions/checkout](https://github.com/actions/checkout/blob/main/CHANGELOG.md) and [actions/setup-java](https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md) to v2. 

Also introduce caching for dependencies downloaded by Maven. According to the [docs at actions/cache](https://github.com/actions/cache#cache-limits) we have a budget of 5GB for cached files which do get overwritten should hit we the limit. 
Cached files older than one week are also deleted automatically.
The cache action configuration is a [textbook example from their documentation.](https://github.com/actions/cache/blob/main/examples.md#java---maven)

Fixes #1254 

