### PR TITLE
Set default path to root URL

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -32,31 +32,15 @@ import javax.servlet.http.HttpServletResponse
  * @see <a href="https://javalin.io/documentation#context">Context in docs</a>
  */
 // don't suppress warnings, since annotated classes are ignored by dokka (yeah...)
-open class Context(
-    @JvmField val req: HttpServletRequest,
-    @JvmField val res: HttpServletResponse,
-    private val appAttributes: Map<Class<*>, Any> = mapOf()
-) {
+open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: HttpServletResponse, private val appAttributes: Map<Class<*>, Any> = mapOf()) {
 
     // @formatter:off
-    @get:JvmSynthetic
-    @set:JvmSynthetic
-    internal var inExceptionHandler = false
-    @get:JvmSynthetic
-    @set:JvmSynthetic
-    internal var matchedPath = ""
-    @get:JvmSynthetic
-    @set:JvmSynthetic
-    internal var endpointHandlerPath = ""
-    @get:JvmSynthetic
-    @set:JvmSynthetic
-    internal var pathParamMap = mapOf<String, String>()
-    @get:JvmSynthetic
-    @set:JvmSynthetic
-    internal var handlerType = HandlerType.BEFORE
-    @get:JvmSynthetic
-    @set:JvmSynthetic
-    internal var splatList = listOf<String>()
+    @get:JvmSynthetic @set:JvmSynthetic internal var inExceptionHandler = false
+    @get:JvmSynthetic @set:JvmSynthetic internal var matchedPath = ""
+    @get:JvmSynthetic @set:JvmSynthetic internal var endpointHandlerPath = ""
+    @get:JvmSynthetic @set:JvmSynthetic internal var pathParamMap = mapOf<String, String>()
+    @get:JvmSynthetic @set:JvmSynthetic internal var handlerType = HandlerType.BEFORE
+    @get:JvmSynthetic @set:JvmSynthetic internal var splatList = listOf<String>()
     // @formatter:on
 
     private val cookieStore by lazy { CookieStore(cookie(CookieStore.COOKIE_NAME)) }
@@ -177,16 +161,15 @@ open class Context(
      * Throws [BadRequestResponse] if validation fails.
      */
     @JvmOverloads
-    fun <T> formParam(key: String, clazz: Class<T>, default: String? = null) =
-        Validator.create(clazz, formParam(key, default), "Form parameter '$key' with value '${formParam(key, default)}'", key)
+    fun <T> formParam(key: String, clazz: Class<T>, default: String? = null) = Validator.create(clazz, formParam(key, default), "Form parameter '$key' with value '${formParam(key, default)}'", key)
 
     /** Gets a list of form params for the specified key, or empty list. */
     fun formParams(key: String): List<String> = formParamMap()[key] ?: emptyList()
 
     /** Gets a map with all the form param keys and values. */
     fun formParamMap(): Map<String, List<String>> =
-        if (isMultipartFormData()) MultipartUtil.getFieldMap(req)
-        else ContextUtil.splitKeyValueStringAndGroupByKey(body(), characterEncoding)
+            if (isMultipartFormData()) MultipartUtil.getFieldMap(req)
+            else ContextUtil.splitKeyValueStringAndGroupByKey(body(), characterEncoding)
 
     /**
      * Gets a path param by name (ex: pathParam("param").
@@ -201,8 +184,7 @@ open class Context(
      * Creates a [Validator] for the pathParam() value, with the prefix "Path parameter '$key' with value '$value'"
      * Throws [BadRequestResponse] if validation fails.
      */
-    fun <T> pathParam(key: String, clazz: Class<T>) =
-        Validator.create(clazz, pathParam(key), "Path parameter '$key' with value '${pathParam(key)}'", key)
+    fun <T> pathParam(key: String, clazz: Class<T>) = Validator.create(clazz, pathParam(key), "Path parameter '$key' with value '${pathParam(key)}'", key)
 
     /** Gets a map of all the [pathParam] keys and values. */
     fun pathParamMap(): Map<String, String> = Collections.unmodifiableMap(pathParamMap)
@@ -248,8 +230,7 @@ open class Context(
     fun header(header: String): String? = req.getHeader(header)
 
     /** Creates a [Validator] for the header() value, with the prefix "Request header '$header' with the value '$value'" */
-    fun <T> header(header: String, clazz: Class<T>): Validator<T> =
-        Validator.create(clazz, header(header), "Request header '$header' with value '${header(header)}'", header)
+    fun <T> header(header: String, clazz: Class<T>): Validator<T> = Validator.create(clazz, header(header), "Request header '$header' with value '${header(header)}'", header)
 
     /** Gets a map with all the header keys and values on the request. */
     fun headerMap(): Map<String, String> = req.headerNames.asSequence().associate { it to header(it)!! }
@@ -291,8 +272,7 @@ open class Context(
      * Throws [BadRequestResponse] if validation fails.
      */
     @JvmOverloads
-    fun <T> queryParam(key: String, clazz: Class<T>, default: String? = null) =
-        Validator.create(clazz, queryParam(key, default), "Query parameter '$key' with value '${queryParam(key, default)}'", key)
+    fun <T> queryParam(key: String, clazz: Class<T>, default: String? = null) = Validator.create(clazz, queryParam(key, default), "Query parameter '$key' with value '${queryParam(key, default)}'", key)
 
     /** Gets a list of query params for the specified key, or empty list. */
     fun queryParams(key: String): List<String> = queryParamMap()[key] ?: emptyList()
@@ -312,7 +292,7 @@ open class Context(
     /** Gets specified attribute from the user session, or null. */
     @JvmOverloads
     fun <T> sessionAttribute(key: String, consume: Boolean = false): T? =
-        (req.session.getAttribute(key) as? T).also { if (consume) this.sessionAttribute(key, null) }
+            (req.session.getAttribute(key) as? T).also { if (consume) this.sessionAttribute(key, null) }
 
     /** Sets an attribute for the user session, and caches it on the request */
     fun cachedSessionAttribute(key: String, value: Any?) = ContextUtil.cacheAndSetSessionAttribute(key, value, req)

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -32,15 +32,31 @@ import javax.servlet.http.HttpServletResponse
  * @see <a href="https://javalin.io/documentation#context">Context in docs</a>
  */
 // don't suppress warnings, since annotated classes are ignored by dokka (yeah...)
-open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: HttpServletResponse, private val appAttributes: Map<Class<*>, Any> = mapOf()) {
+open class Context(
+    @JvmField val req: HttpServletRequest,
+    @JvmField val res: HttpServletResponse,
+    private val appAttributes: Map<Class<*>, Any> = mapOf()
+) {
 
     // @formatter:off
-    @get:JvmSynthetic @set:JvmSynthetic internal var inExceptionHandler = false
-    @get:JvmSynthetic @set:JvmSynthetic internal var matchedPath = ""
-    @get:JvmSynthetic @set:JvmSynthetic internal var endpointHandlerPath = ""
-    @get:JvmSynthetic @set:JvmSynthetic internal var pathParamMap = mapOf<String, String>()
-    @get:JvmSynthetic @set:JvmSynthetic internal var handlerType = HandlerType.BEFORE
-    @get:JvmSynthetic @set:JvmSynthetic internal var splatList = listOf<String>()
+    @get:JvmSynthetic
+    @set:JvmSynthetic
+    internal var inExceptionHandler = false
+    @get:JvmSynthetic
+    @set:JvmSynthetic
+    internal var matchedPath = ""
+    @get:JvmSynthetic
+    @set:JvmSynthetic
+    internal var endpointHandlerPath = ""
+    @get:JvmSynthetic
+    @set:JvmSynthetic
+    internal var pathParamMap = mapOf<String, String>()
+    @get:JvmSynthetic
+    @set:JvmSynthetic
+    internal var handlerType = HandlerType.BEFORE
+    @get:JvmSynthetic
+    @set:JvmSynthetic
+    internal var splatList = listOf<String>()
     // @formatter:on
 
     private val cookieStore by lazy { CookieStore(cookie(CookieStore.COOKIE_NAME)) }
@@ -161,15 +177,16 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
      * Throws [BadRequestResponse] if validation fails.
      */
     @JvmOverloads
-    fun <T> formParam(key: String, clazz: Class<T>, default: String? = null) = Validator.create(clazz, formParam(key, default), "Form parameter '$key' with value '${formParam(key, default)}'", key)
+    fun <T> formParam(key: String, clazz: Class<T>, default: String? = null) =
+        Validator.create(clazz, formParam(key, default), "Form parameter '$key' with value '${formParam(key, default)}'", key)
 
     /** Gets a list of form params for the specified key, or empty list. */
     fun formParams(key: String): List<String> = formParamMap()[key] ?: emptyList()
 
     /** Gets a map with all the form param keys and values. */
     fun formParamMap(): Map<String, List<String>> =
-            if (isMultipartFormData()) MultipartUtil.getFieldMap(req)
-            else ContextUtil.splitKeyValueStringAndGroupByKey(body(), characterEncoding)
+        if (isMultipartFormData()) MultipartUtil.getFieldMap(req)
+        else ContextUtil.splitKeyValueStringAndGroupByKey(body(), characterEncoding)
 
     /**
      * Gets a path param by name (ex: pathParam("param").
@@ -184,7 +201,8 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
      * Creates a [Validator] for the pathParam() value, with the prefix "Path parameter '$key' with value '$value'"
      * Throws [BadRequestResponse] if validation fails.
      */
-    fun <T> pathParam(key: String, clazz: Class<T>) = Validator.create(clazz, pathParam(key), "Path parameter '$key' with value '${pathParam(key)}'", key)
+    fun <T> pathParam(key: String, clazz: Class<T>) =
+        Validator.create(clazz, pathParam(key), "Path parameter '$key' with value '${pathParam(key)}'", key)
 
     /** Gets a map of all the [pathParam] keys and values. */
     fun pathParamMap(): Map<String, String> = Collections.unmodifiableMap(pathParamMap)
@@ -230,7 +248,8 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     fun header(header: String): String? = req.getHeader(header)
 
     /** Creates a [Validator] for the header() value, with the prefix "Request header '$header' with the value '$value'" */
-    fun <T> header(header: String, clazz: Class<T>): Validator<T> = Validator.create(clazz, header(header), "Request header '$header' with value '${header(header)}'", header)
+    fun <T> header(header: String, clazz: Class<T>): Validator<T> =
+        Validator.create(clazz, header(header), "Request header '$header' with value '${header(header)}'", header)
 
     /** Gets a map with all the header keys and values on the request. */
     fun headerMap(): Map<String, String> = req.headerNames.asSequence().associate { it to header(it)!! }
@@ -272,7 +291,8 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
      * Throws [BadRequestResponse] if validation fails.
      */
     @JvmOverloads
-    fun <T> queryParam(key: String, clazz: Class<T>, default: String? = null) = Validator.create(clazz, queryParam(key, default), "Query parameter '$key' with value '${queryParam(key, default)}'", key)
+    fun <T> queryParam(key: String, clazz: Class<T>, default: String? = null) =
+        Validator.create(clazz, queryParam(key, default), "Query parameter '$key' with value '${queryParam(key, default)}'", key)
 
     /** Gets a list of query params for the specified key, or empty list. */
     fun queryParams(key: String): List<String> = queryParamMap()[key] ?: emptyList()
@@ -292,7 +312,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     /** Gets specified attribute from the user session, or null. */
     @JvmOverloads
     fun <T> sessionAttribute(key: String, consume: Boolean = false): T? =
-            (req.session.getAttribute(key) as? T).also { if (consume) this.sessionAttribute(key, null) }
+        (req.session.getAttribute(key) as? T).also { if (consume) this.sessionAttribute(key, null) }
 
     /** Sets an attribute for the user session, and caches it on the request */
     fun cachedSessionAttribute(key: String, value: Any?) = ContextUtil.cacheAndSetSessionAttribute(key, value, req)

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -424,7 +424,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
 
     /** Removes cookie specified by name and path (optional). */
     @JvmOverloads
-    fun removeCookie(name: String, path: String? = null): Context {
+    fun removeCookie(name: String, path: String? = "/"): Context {
         res.addCookie(Cookie(name, "").apply {
             this.path = path
             this.maxAge = 0

--- a/javalin/src/test/java/io/javalin/TestCookie.kt
+++ b/javalin/src/test/java/io/javalin/TestCookie.kt
@@ -12,8 +12,8 @@ class TestCookie {
     fun `cookie set on unspecified path is set to root URL`() = TestUtil.test { app, http ->
         app.get("/cookie-path") { it.cookie(Cookie("key", "value").apply { path = "/" }) }
 
-        val requestToCookiePath = http.get("/cookie-path")
-        val cookiePath = requestToCookiePath.headers.getFirst(Header.SET_COOKIE).split(";")[1].replaceFirst(" ", "")
+        val requestSetCookie = http.get("/cookie-path")
+        val cookiePath = requestSetCookie.headers.getFirst(Header.SET_COOKIE).split(";")[1].replaceFirst(" ", "")
 
         assertThat(cookiePath).isEqualTo("Path=/")
     }

--- a/javalin/src/test/java/io/javalin/TestCookie.kt
+++ b/javalin/src/test/java/io/javalin/TestCookie.kt
@@ -1,0 +1,56 @@
+package io.javalin
+
+import io.javalin.core.util.Header
+import io.javalin.testing.TestUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import javax.servlet.http.Cookie
+
+class TestCookie {
+
+    @Test
+    fun `cookie set on unspecified path is set to root URL`() = TestUtil.test { app, http ->
+        app.get("/cookie-path") { it.cookie(Cookie("key", "value").apply { path = "/" }) }
+
+        val requestToCookiePath = http.get("/cookie-path")
+        val cookiePath = requestToCookiePath.headers.getFirst(Header.SET_COOKIE).split(";")[1].replaceFirst(" ", "")
+
+        assertThat(cookiePath).isEqualTo("Path=/")
+    }
+
+    @Test
+    fun `removing cookie without specifying path will remove cookie set to root URL`() = TestUtil.test { app, http ->
+        val cookie = Cookie("key", "value").apply {
+            path = "/"
+        }
+        app.get("/cookie-path") { it.cookie(cookie) }
+        app.get("/cookie-path-remove") { it.removeCookie(cookie.name) }
+
+        val requestSetCookie = http.get("/cookie-path")
+        assertThat(requestSetCookie.headers.getFirst(Header.SET_COOKIE)).isEqualTo("key=value; Path=/")
+        val requestRemoveCookie = http.get("/cookie-path-remove")
+
+        assertThat(cookieIsEffectivelyRemoved(requestRemoveCookie.headers.getFirst(Header.SET_COOKIE))).isTrue
+    }
+
+    @Test
+    fun `removing cookie without specifying path will not remove cookie set to non-root URL`() = TestUtil.test { app, http ->
+        val cookie = Cookie("key", "value").apply {
+            path = "/some-path"
+        }
+        app.get("/cookie-path") { it.cookie(cookie) }
+        app.get("/cookie-path-remove") { it.removeCookie(cookie.name) }
+
+        val requestSetCookie = http.get("/cookie-path")
+        assertThat(requestSetCookie.headers.getFirst(Header.SET_COOKIE)).isEqualTo("key=value; Path=/some-path")
+        val requestRemoveCookie = http.get("/cookie-path-remove")
+
+        assertThat(cookieIsEffectivelyRemoved(requestRemoveCookie.headers.getFirst(Header.SET_COOKIE))).isTrue
+    }
+
+    private fun cookieIsEffectivelyRemoved(cookie: String): Boolean {
+        val expiresEpoch = cookie.split(";")[2] == " Expires=Thu, 01-Jan-1970 00:00:00 GMT"
+        val maxAgeZero = cookie.split(";")[3] == " Max-Age=0"
+        return expiresEpoch && maxAgeZero
+    }
+}

--- a/javalin/src/test/java/io/javalin/TestCookie.kt
+++ b/javalin/src/test/java/io/javalin/TestCookie.kt
@@ -1,5 +1,6 @@
 package io.javalin
 
+import com.mashape.unirest.http.Unirest
 import io.javalin.core.util.Header
 import io.javalin.testing.TestUtil
 import org.assertj.core.api.Assertions.assertThat
@@ -46,6 +47,79 @@ class TestCookie {
         val removeCookieResponse = http.get("/cookie-remove")
 
         assertThat(cookieIsEffectivelyRemoved(removeCookieResponse.headers.getFirst(Header.SET_COOKIE), "/some-path")).isFalse
+    }
+
+    /*
+     * Requests
+     */
+    @Test
+    fun `single cookie returns null when missing`() = TestUtil.test { app, http ->
+        app.get("/read-cookie-1") { ctx -> ctx.result("" + ctx.cookie("my-cookie")) }
+        assertThat(http.getBody("/read-cookie-1")).isEqualTo("null")
+    }
+
+    @Test
+    fun `single cookie works`() = TestUtil.test { app, http ->
+        app.get("/read-cookie-2") { ctx -> ctx.result(ctx.cookie("my-cookie")!!) }
+        val response = Unirest.get("${http.origin}/read-cookie-2").header(Header.COOKIE, "my-cookie=my-cookie-value").asString()
+        assertThat(response.body).isEqualTo("my-cookie-value")
+    }
+
+    @Test
+    fun `cookie-map returns empty when no cookies are set`() = TestUtil.test { app, http ->
+        app.get("/read-cookie-3") { ctx -> ctx.result(ctx.cookieMap().toString()) }
+        assertThat(http.getBody("/read-cookie-3")).isEqualTo("{}")
+    }
+
+    @Test
+    fun `cookie-map returns all cookies if cookies are set`() = TestUtil.test { app, http ->
+        app.get("/read-cookie-4") { ctx -> ctx.result(ctx.cookieMap().toString()) }
+        val response = Unirest.get("${http.origin}/read-cookie-4").header(Header.COOKIE, "k1=v1;k2=v2;k3=v3").asString()
+        assertThat(response.body).isEqualTo("{k1=v1, k2=v2, k3=v3}")
+    }
+
+    /*
+     * Responses
+     */
+    @Test
+    fun `setting a cookie works`() = TestUtil.test { app, http ->
+        app.get("/create-cookie") { ctx -> ctx.cookie("Test", "Tast") }
+        app.get("/get-cookie") { ctx -> ctx.result(ctx.cookie("Test")!!) }
+        assertThat(http.get("/create-cookie").headers.getFirst(Header.SET_COOKIE)).isEqualTo("Test=Tast; Path=/")
+        assertThat(http.getBody("/get-cookie")).isEqualTo("Tast")
+    }
+
+    @Test
+    fun `setting a Cookie object works`() = TestUtil.test { app, http ->
+        app.get("/create-cookie") { ctx -> ctx.cookie(Cookie("Hest", "Hast").apply { maxAge = 7 }) }
+        assertThat(http.get("/create-cookie").headers.getFirst(Header.SET_COOKIE)).contains("Hest=Hast")
+        assertThat(http.get("/create-cookie").headers.getFirst(Header.SET_COOKIE)).contains("Max-Age=7")
+    }
+
+    @Test
+    fun `can't set duplicate cookies when other cookies set`() = TestUtil.test { app, http ->
+        app.get("/create-cookies") {
+            it.cookie("Test-1", "1")
+            it.cookie("Test-2", "2")
+            it.cookie("Test-3", "3")
+            it.cookie("Test-3", "4")  // duplicate
+        }
+        val response = http.get("/create-cookies");
+        assertThat(response.headers[Header.SET_COOKIE]!!).contains("Test-1=1; Path=/")
+        assertThat(response.headers[Header.SET_COOKIE]!!).contains("Test-2=2; Path=/")
+        assertThat(response.headers[Header.SET_COOKIE]!!).contains("Test-3=4; Path=/")
+        assertThat(response.headers[Header.SET_COOKIE]!!.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `can't set duplicate cookies when no other cookies set`() = TestUtil.test { app, http ->
+        app.get("/create-cookies") {
+            it.cookie("MyCookie", "A")
+            it.cookie("MyCookie", "B")  // duplicate
+        }
+        val response = http.get("/create-cookies");
+        assertThat(response.headers[Header.SET_COOKIE]!!).contains("MyCookie=B; Path=/")
+        assertThat(response.headers[Header.SET_COOKIE]!!.size).isEqualTo(1)
     }
 
     private fun cookieIsEffectivelyRemoved(cookie: String, path: String): Boolean {

--- a/javalin/src/test/java/io/javalin/TestCookie.kt
+++ b/javalin/src/test/java/io/javalin/TestCookie.kt
@@ -10,9 +10,9 @@ class TestCookie {
 
     @Test
     fun `cookie set on unspecified path is set to root URL`() = TestUtil.test { app, http ->
-        app.get("/cookie-path") { it.cookie(Cookie("key", "value").apply { path = "/" }) }
+        app.get("/cookie") { it.cookie(Cookie("key", "value").apply { path = "/" }) }
 
-        val setCookieResponse = http.get("/cookie-path")
+        val setCookieResponse = http.get("/cookie")
         val cookiePath = setCookieResponse.headers.getFirst(Header.SET_COOKIE).split(";")[1].replaceFirst(" ", "")
 
         assertThat(cookiePath).isEqualTo("Path=/")
@@ -23,12 +23,12 @@ class TestCookie {
         val cookie = Cookie("key", "value").apply {
             path = "/"
         }
-        app.get("/cookie-path") { it.cookie(cookie) }
-        app.get("/cookie-path-remove") { it.removeCookie(cookie.name) }
-        val setCookieResponse = http.get("/cookie-path")
+        app.get("/cookie") { it.cookie(cookie) }
+        app.get("/cookie-remove") { it.removeCookie(cookie.name) }
+        val setCookieResponse = http.get("/cookie")
         assertThat(setCookieResponse.headers.getFirst(Header.SET_COOKIE)).isEqualTo("key=value; Path=/")
 
-        val removeCookieResponse = http.get("/cookie-path-remove")
+        val removeCookieResponse = http.get("/cookie-remove")
 
         assertThat(cookieIsEffectivelyRemoved(removeCookieResponse.headers.getFirst(Header.SET_COOKIE), "/")).isTrue
     }
@@ -38,12 +38,12 @@ class TestCookie {
         val cookie = Cookie("key", "value").apply {
             path = "/some-path"
         }
-        app.get("/cookie-path") { it.cookie(cookie) }
-        app.get("/cookie-path-remove") { it.removeCookie(cookie.name) }
-        val setCookieResponse = http.get("/cookie-path")
+        app.get("/cookie") { it.cookie(cookie) }
+        app.get("/cookie-remove") { it.removeCookie(cookie.name) }
+        val setCookieResponse = http.get("/cookie")
         assertThat(setCookieResponse.headers.getFirst(Header.SET_COOKIE)).isEqualTo("key=value; Path=/some-path")
 
-        val removeCookieResponse = http.get("/cookie-path-remove")
+        val removeCookieResponse = http.get("/cookie-remove")
 
         assertThat(cookieIsEffectivelyRemoved(removeCookieResponse.headers.getFirst(Header.SET_COOKIE), "/some-path")).isFalse
     }

--- a/javalin/src/test/java/io/javalin/TestRequest.kt
+++ b/javalin/src/test/java/io/javalin/TestRequest.kt
@@ -110,35 +110,6 @@ class TestRequest {
     }
 
     /*
-     * Cookies
-     */
-    @Test
-    fun `single cookie returns null when missing`() = TestUtil.test { app, http ->
-        app.get("/read-cookie-1") { ctx -> ctx.result("" + ctx.cookie("my-cookie")) }
-        assertThat(http.getBody("/read-cookie-1")).isEqualTo("null")
-    }
-
-    @Test
-    fun `single cookie works`() = TestUtil.test { app, http ->
-        app.get("/read-cookie-2") { ctx -> ctx.result(ctx.cookie("my-cookie")!!) }
-        val response = Unirest.get("${http.origin}/read-cookie-2").header(Header.COOKIE, "my-cookie=my-cookie-value").asString()
-        assertThat(response.body).isEqualTo("my-cookie-value")
-    }
-
-    @Test
-    fun `cookie-map returns empty when no cookies are set`() = TestUtil.test { app, http ->
-        app.get("/read-cookie-3") { ctx -> ctx.result(ctx.cookieMap().toString()) }
-        assertThat(http.getBody("/read-cookie-3")).isEqualTo("{}")
-    }
-
-    @Test
-    fun `cookie-map returns all cookies if cookies are set`() = TestUtil.test { app, http ->
-        app.get("/read-cookie-4") { ctx -> ctx.result(ctx.cookieMap().toString()) }
-        val response = Unirest.get("${http.origin}/read-cookie-4").header(Header.COOKIE, "k1=v1;k2=v2;k3=v3").asString()
-        assertThat(response.body).isEqualTo("{k1=v1, k2=v2, k3=v3}")
-    }
-
-    /*
      * Path params
      */
     @Test

--- a/javalin/src/test/java/io/javalin/TestResponse.kt
+++ b/javalin/src/test/java/io/javalin/TestResponse.kt
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.*
+import javax.servlet.http.Cookie
 
 class TestResponse {
 
@@ -135,15 +136,15 @@ class TestResponse {
     }
 
     private fun getSeekableInput(repeats: Int = SeekableWriter.chunkSize) = ByteArrayInputStream(
-        setOf("a", "b", "c").joinToString("") { it.repeat(repeats) }.toByteArray(Charsets.UTF_8)
+            setOf("a", "b", "c").joinToString("") { it.repeat(repeats) }.toByteArray(Charsets.UTF_8)
     )
 
     @Test
     fun `seekable - range works`() = TestUtil.test { app, http ->
         app.get("/seekable") { ctx -> ctx.seekableStream(getSeekableInput(), "text/plain") }
         val response = Unirest.get(http.origin + "/seekable")
-            .headers(mapOf(Header.RANGE to "bytes=${SeekableWriter.chunkSize}-${SeekableWriter.chunkSize * 2 - 1}"))
-            .asString().body
+                .headers(mapOf(Header.RANGE to "bytes=${SeekableWriter.chunkSize}-${SeekableWriter.chunkSize * 2 - 1}"))
+                .asString().body
         assertThat(response).doesNotContain("a").contains("b").doesNotContain("c")
     }
 
@@ -158,8 +159,8 @@ class TestResponse {
     fun `seekable - overreaching range works`() = TestUtil.test { app, http ->
         app.get("/seekable-3") { ctx -> ctx.seekableStream(getSeekableInput(), "text/plain") }
         val response = Unirest.get(http.origin + "/seekable-3")
-            .headers(mapOf(Header.RANGE to "bytes=0-${SeekableWriter.chunkSize * 4}"))
-            .asString().body
+                .headers(mapOf(Header.RANGE to "bytes=0-${SeekableWriter.chunkSize * 4}"))
+                .asString().body
         assertThat(response.length).isEqualTo(SeekableWriter.chunkSize * 3)
     }
 
@@ -167,8 +168,8 @@ class TestResponse {
     fun `seekable - file smaller than chunksize works`() = TestUtil.test { app, http ->
         app.get("/seekable-4") { ctx -> ctx.seekableStream(getSeekableInput(repeats = 50), "text/plain") }
         val response = Unirest.get(http.origin + "/seekable-4")
-            .headers(mapOf(Header.RANGE to "bytes=0-${SeekableWriter.chunkSize}"))
-            .asString().body
+                .headers(mapOf(Header.RANGE to "bytes=0-${SeekableWriter.chunkSize}"))
+                .asString().body
         assertThat(response.length).isEqualTo(150)
     }
 


### PR DESCRIPTION
This PR sets "/" as default path when removing cookies. 
Please see [issue 1257](https://github.com/tipsy/javalin/issues/1257) for details.

A new test class has been added as I could not see any existing test class where the test cases would fit. 
