### PR TITLE
Catch and ignore TimeoutException when writing a response

### DIFF
--- a/javalin/src/main/java/io/javalin/core/util/Util.kt
+++ b/javalin/src/main/java/io/javalin/core/util/Util.kt
@@ -217,4 +217,8 @@ object Util {
     // jetty throws if client aborts during response writing. testing name avoids hard dependency on jetty.
     fun isClientAbortException(t: Throwable) = t::class.java.name == "org.eclipse.jetty.io.EofException"
 
+    // Jetty may timeout connections to avoid having broken connections that remain open forever
+    // This is rare, but intended (see issues #163 and #1277)
+    fun isJettyTimeoutException(t: Throwable) = t::class.java.name == "java.util.concurrent.TimeoutException"
+
 }

--- a/javalin/src/main/java/io/javalin/http/ExceptionMapper.kt
+++ b/javalin/src/main/java/io/javalin/http/ExceptionMapper.kt
@@ -48,6 +48,7 @@ class ExceptionMapper {
 
     internal fun handleUnexpectedThrowable(res: HttpServletResponse, throwable: Throwable) {
         if (Util.isClientAbortException(throwable)) return // aborts can be ignored
+        if (Util.isJettyTimeoutException(throwable)) return // jetty timeouts can be ignored
         res.status = 500
         JavalinLogger.error("Exception occurred while servicing http-request", throwable)
     }

--- a/javalin/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
+++ b/javalin/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
@@ -10,7 +10,6 @@ import io.javalin.core.util.Header.IF_NONE_MATCH
 import io.javalin.core.util.Util
 import java.io.InputStream
 import java.io.OutputStream
-import java.util.concurrent.TimeoutException
 import java.util.zip.GZIPOutputStream
 import javax.servlet.ServletOutputStream
 import javax.servlet.WriteListener
@@ -54,12 +53,7 @@ class JavalinResponseWrapper(val res: HttpServletResponse, private val rwc: Resp
                 return // don't write body
             }
         }
-        try {
-            inputStream.copyTo(outputStreamWrapper)
-        } catch (e: TimeoutException) {
-            // Jetty may timeout connections to avoid having broken connections that remain open forever
-            // This is rare, but intended (see issues #163 and #1277)
-        }
+        inputStream.copyTo(outputStreamWrapper)
         inputStream.close()
         outputStreamWrapper.finalize()
     }

--- a/javalin/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
+++ b/javalin/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
@@ -10,6 +10,7 @@ import io.javalin.core.util.Header.IF_NONE_MATCH
 import io.javalin.core.util.Util
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.concurrent.TimeoutException
 import java.util.zip.GZIPOutputStream
 import javax.servlet.ServletOutputStream
 import javax.servlet.WriteListener
@@ -53,7 +54,12 @@ class JavalinResponseWrapper(val res: HttpServletResponse, private val rwc: Resp
                 return // don't write body
             }
         }
-        inputStream.copyTo(outputStreamWrapper)
+        try {
+            inputStream.copyTo(outputStreamWrapper)
+        } catch (e: TimeoutException) {
+            // Jetty may timeout connections to avoid having broken connections that remain open forever
+            // This is rare, but intended (see issues #163 and #1277)
+        }
         inputStream.close()
         outputStreamWrapper.finalize()
     }


### PR DESCRIPTION
#1277 

I *think* this is the appropriate place to catch this exception. Since it's a regular TimeoutException, it might be useful in other places so we shouldn't hide it more broadly like we do with `isClientAbortException`'s handling of `EofException` in `Util.kt`.

```
2021-06-13 18:47:47.563 GMT ERROR io.javalin.Javalin - Exception occurred while servicing http-request
java.io.IOException: java.util.concurrent.TimeoutException: Idle timeout expired: 30000/30000 ms
at org.eclipse.jetty.util.SharedBlockingCallback$Blocker.block(SharedBlockingCallback.java:257)
at org.eclipse.jetty.server.HttpOutput.channelWrite(HttpOutput.java:270)
at org.eclipse.jetty.server.HttpOutput.write(HttpOutput.java:1045)
>>> at io.javalin.http.OutputStreamWrapper.write(JavalinResponseWrapper.kt:120)
at java.io.OutputStream.write(OutputStream.java:116)
>>> at io.javalin.http.OutputStreamWrapper.write(JavalinResponseWrapper.kt:103)
at kotlin.io.ByteStreamsKt.copyTo(IOStreams.kt:108)
at kotlin.io.ByteStreamsKt.copyTo$default(IOStreams.kt:103)
>>> at io.javalin.http.JavalinResponseWrapper.write(JavalinResponseWrapper.kt:56)
>>> at io.javalin.http.JavalinServlet.service(JavalinServlet.kt:85)**
at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
>>> at io.javalin.websocket.JavalinWsServlet.service(JavalinWsServlet.kt:51)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:791)
at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:550)
at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
>>> at io.javalin.core.JavalinServer$start$wsAndHttpHandler$1.doHandle(JavalinServer.kt:49)
```

These are the places where Javalin code shows up in the stacktrace. I think catching in `JavalinWsServlet`/`JavalinServer` is probably too high up and might incorrectly catch other timeouts. `JavalinResponseWrapper` line 56, which I wrapped with a try-catch, seems to be the correct scope - it's writing a stream into the output response and all my stacktraces have that line.
