### PR TITLE
Update Gradle example to use implementation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ General information:
 #### Gradle
 
 ```groovy
-compile "io.javalin:javalin:3.13.8"
+implementation "io.javalin:javalin:3.13.8"
 ```
 
 ### Start programming (Java)


### PR DESCRIPTION
The `compile` configuration has been deprecated and removed in Gradle
7.0. `implementation` configuration should be used instead.