### PR TITLE
Load Context form/query parameters lazily into map

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -150,10 +150,14 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     /** Gets a list of form params for the specified key, or empty list. */
     fun formParams(key: String): List<String> = formParamMap()[key] ?: emptyList()
 
-    /** Gets a map with all the form param keys and values. */
-    fun formParamMap(): Map<String, List<String>> =
+    /** using an additional map lazily so no new objects are created whenever ctx.formParam*() is called */
+    private val formParams by lazy {
         if (isMultipartFormData()) MultipartUtil.getFieldMap(req)
         else ContextUtil.splitKeyValueStringAndGroupByKey(body(), characterEncoding)
+    }
+
+    /** Gets a map with all the form param keys and values. */
+    fun formParamMap(): Map<String, List<String>> = formParams
 
     /**
      * Gets a path param by name (ex: pathParam("param").
@@ -258,8 +262,13 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     /** Gets a list of query params for the specified key, or empty list. */
     fun queryParams(key: String): List<String> = queryParamMap()[key] ?: emptyList()
 
+    /** using an additional map lazily so no new objects are created whenever ctx.formParam*() is called */
+    private val queryParams by lazy {
+        ContextUtil.splitKeyValueStringAndGroupByKey(queryString() ?: "", characterEncoding)
+    }
+
     /** Gets a map with all the query param keys and values. */
-    fun queryParamMap(): Map<String, List<String>> = ContextUtil.splitKeyValueStringAndGroupByKey(queryString() ?: "", characterEncoding)
+    fun queryParamMap(): Map<String, List<String>> = queryParams
 
     /** Gets the request query string, or null. */
     fun queryString(): String? = req.queryString


### PR DESCRIPTION
In order to prevent new creation of a map, whenever a single value via
ctx.formParam*() or ctx.queryParam*() method is accessed, this commit
lazily intializes a map, which then gets used with any future access.

Closes #1322