### PR TITLE
Fix Jetty TimeoutException detection to check a thrown IOException's cause

### DIFF
--- a/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
@@ -60,7 +60,7 @@ object JettyUtil {
 
     // Jetty may timeout connections to avoid having broken connections that remain open forever
     // This is rare, but intended (see issues #163 and #1277)
-    fun isJettyTimeoutException(t: Throwable) = t::class.java.name == "java.util.concurrent.TimeoutException"
+    fun isJettyTimeoutException(t: Throwable) = t::class.java.name == "java.io.IOException" && t.cause?.javaClass?.name == "java.util.concurrent.TimeoutException"
 
     class NoopLogger : org.eclipse.jetty.util.log.Logger {
         override fun getName() = "noop"

--- a/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
@@ -9,6 +9,8 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.StatisticsHandler
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.eclipse.jetty.util.thread.ThreadPool
+import java.io.IOException
+import java.util.concurrent.TimeoutException
 
 private var defaultLogger: org.eclipse.jetty.util.log.Logger? = null
 
@@ -60,7 +62,7 @@ object JettyUtil {
 
     // Jetty may timeout connections to avoid having broken connections that remain open forever
     // This is rare, but intended (see issues #163 and #1277)
-    fun isJettyTimeoutException(t: Throwable) = t::class.java is java.io.IOException && t.cause?.javaClass is java.util.concurrent.TimeoutException
+    fun isJettyTimeoutException(t: Throwable) = t is IOException && t.cause is TimeoutException
 
     class NoopLogger : org.eclipse.jetty.util.log.Logger {
         override fun getName() = "noop"

--- a/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyUtil.kt
@@ -60,7 +60,7 @@ object JettyUtil {
 
     // Jetty may timeout connections to avoid having broken connections that remain open forever
     // This is rare, but intended (see issues #163 and #1277)
-    fun isJettyTimeoutException(t: Throwable) = t::class.java.name == "java.io.IOException" && t.cause?.javaClass?.name == "java.util.concurrent.TimeoutException"
+    fun isJettyTimeoutException(t: Throwable) = t::class.java is java.io.IOException && t.cause?.javaClass is java.util.concurrent.TimeoutException
 
     class NoopLogger : org.eclipse.jetty.util.log.Logger {
         override fun getName() = "noop"


### PR DESCRIPTION
#1277 

Following your suggestion of checking the cause's class name. I looked through our logs and every time we got this timeout it was a TimeoutException wrapped in an IOException, so I think it would be most precise to first check if the throwable is an IOException before checking the throwable's cause for TimeoutException.