### PR TITLE
Disable regex routing by default

### DIFF
--- a/javalin/src/main/java/io/javalin/core/routing/ParserState.kt
+++ b/javalin/src/main/java/io/javalin/core/routing/ParserState.kt
@@ -16,7 +16,7 @@ internal fun convertSegment(segment: String, rawPath: String): PathSegment {
         bracketsCount % 2 != 0 -> throw MissingBracketsException(segment, rawPath)
         adjacentViolations.any { it in segment } -> throw WildcardBracketAdjacentException(segment, rawPath)
         segment == "*" -> PathSegment.Wildcard // a wildcard segment
-        bracketsCount == 0 && wildcardCount == 0 -> PathSegment.Normal(segment) // a normal segment, no params or wildcards
+        bracketsCount == 0 && wildcardCount == 0 -> createNormal(segment) // a normal segment, no params or wildcards
         bracketsCount == 2 && segment.isEnclosedBy('{', '}') -> createSlashIgnoringParam(segment.stripEnclosing('{', '}')) // simple path param (no slashes)
         bracketsCount == 2 && segment.isEnclosedBy('<', '>') -> createSlashAcceptingParam(segment.stripEnclosing('<', '>')) // simple path param (slashes)
         else -> parseAsPathSegment(segment, rawPath) // complicated path segment, need to parse
@@ -41,7 +41,7 @@ private fun parseAsPathSegment(segment: String, rawPath: String): PathSegment {
                 segment,
                 rawPath
             ) // cannot start with a closing delimiter
-            else -> PathSegment.Normal(char.toString()) // the single characters will be merged later
+            else -> createNormal(char.toString()) // the single characters will be merged later
         }
         ParserState.INSIDE_SLASH_IGNORING_BRACKETS -> when (char) {
             '}' -> {
@@ -87,7 +87,7 @@ private fun parseAsPathSegment(segment: String, rawPath: String): PathSegment {
                 lastAddition == null -> PathSegment.MultipleSegments(listOf(pathSegment))
                 lastAddition is PathSegment.Wildcard && pathSegment is PathSegment.Wildcard -> acc
                 lastAddition is PathSegment.Normal && pathSegment is PathSegment.Normal -> PathSegment.MultipleSegments(
-                    acc.innerSegments.dropLast(1) + PathSegment.Normal(lastAddition.content + pathSegment.content)
+                    acc.innerSegments.dropLast(1) + createNormal(lastAddition.content + pathSegment.content)
                 )
                 else -> PathSegment.MultipleSegments(acc.innerSegments + pathSegment)
             }

--- a/javalin/src/main/java/io/javalin/core/routing/PathSegment.kt
+++ b/javalin/src/main/java/io/javalin/core/routing/PathSegment.kt
@@ -8,10 +8,17 @@ sealed class PathSegment {
 
     internal abstract fun asGroupedRegexString(): String
 
-    class Normal(val content: String) : PathSegment() {
+    sealed class Normal(val content: String) : PathSegment() {
         // do not group static content
-        override fun asRegexString(): String = content
-        override fun asGroupedRegexString(): String = content
+        class RegexEscaped(content: String): Normal(content) {
+            override fun asRegexString(): String = Regex.escape(content)
+            override fun asGroupedRegexString(): String = Regex.escape(content)
+        }
+
+        class RegexAllowed(content: String): Normal(content) {
+            override fun asRegexString(): String = content
+            override fun asGroupedRegexString(): String = content
+        }
     }
 
     sealed class Parameter(val name: String) : PathSegment() {
@@ -48,6 +55,11 @@ sealed class PathSegment {
 
 }
 
+internal fun createNormal(string: String, enableRegex: Boolean = false) = if (enableRegex) {
+    PathSegment.Normal.RegexAllowed(string)
+} else {
+    PathSegment.Normal.RegexEscaped(string)
+}
 internal fun createSlashIgnoringParam(string: String) = PathSegment.Parameter.SlashIgnoringParameter(string)
 internal fun createSlashAcceptingParam(string: String) = PathSegment.Parameter.SlashAcceptingParameter(string)
 

--- a/javalin/src/main/java/io/javalin/http/util/RedirectToLowercasePathPlugin.kt
+++ b/javalin/src/main/java/io/javalin/http/util/RedirectToLowercasePathPlugin.kt
@@ -27,14 +27,14 @@ class RedirectToLowercasePathPlugin : Plugin, PluginLifecycleInit {
         app.events { e ->
             e.handlerAdded { h ->
                 val parser = PathParser(h.path, app._conf.ignoreTrailingSlashes)
-                parser.segments.filterIsInstance<PathSegment.Normal>().map { it.asRegexString() }.forEach {
+                parser.segments.filterIsInstance<PathSegment.Normal>().map { it.content }.forEach {
                     if (it != it.lowercase(Locale.ROOT)) throw IllegalArgumentException("Paths must be lowercase when using RedirectToLowercasePathPlugin")
                 }
                 parser.segments
                     .filterIsInstance<PathSegment.MultipleSegments>()
                     .flatMap { it.innerSegments }
                     .filterIsInstance<PathSegment.Normal>()
-                    .map { it.asRegexString() }
+                    .map { it.content }
                     .forEach {
                         if (it != it.lowercase(Locale.ROOT)) {
                             throw IllegalArgumentException("Paths must be lowercase when using RedirectToLowercasePathPlugin")

--- a/javalin/src/test/java/io/javalin/TestRouting.kt
+++ b/javalin/src/test/java/io/javalin/TestRouting.kt
@@ -18,6 +18,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Ignore
 import org.junit.Test
 import java.net.URLEncoder
 
@@ -145,6 +146,8 @@ class TestRouting {
         assertThat(response.body).isEqualTo("world/hi")
     }
 
+    // looking for a solution to enable this on a per-path basis
+    @Ignore
     @Test
     fun `path regex works`() = TestUtil.test { app, http ->
         app.get("/{path-param}/[0-9]+/") { ctx -> ctx.result(ctx.pathParam("path-param")) }

--- a/javalin/src/test/java/io/javalin/TestTrailingSlashes.kt
+++ b/javalin/src/test/java/io/javalin/TestTrailingSlashes.kt
@@ -13,6 +13,7 @@ import io.javalin.testing.TestUtil
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.Test
 import java.net.URLEncoder
 
@@ -123,6 +124,8 @@ class TestTrailingSlashes {
         assertThat(http.getBody("/SomeCamelCasedValue/")).isEqualTo("SomeCamelCasedValue/")
     }
 
+    // looking for a solution to enable this on a per-path basis
+    @Ignore
     @Test
     fun `path regex works`() = TestUtil.test(javalin) { app, http ->
         app.get("/{path-param}/[0-9]+") { ctx -> ctx.result(ctx.pathParam("path-param")) }


### PR DESCRIPTION
Still looking for a way to allow configuration on a per-path basis.