### PR TITLE
gh-1361 : Fixed support for custom mime types

### DIFF
--- a/javalin/src/test/java/io/javalin/http/ContentTypeTest.kt
+++ b/javalin/src/test/java/io/javalin/http/ContentTypeTest.kt
@@ -1,7 +1,13 @@
 package io.javalin.http
 
+import io.javalin.Javalin
+import io.javalin.core.util.Header
+import io.javalin.http.staticfiles.Location
+import io.javalin.testing.TestUtil
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.jetty.servlet.ServletContextHandler
 import org.junit.Test
+import io.javalin.jetty.JettyPrecompressingResourceHandler
 
 class ContentTypeTest {
 
@@ -25,6 +31,28 @@ class ContentTypeTest {
     @Test
     fun `string representation should return mime type`() {
         assertThat(ContentType.TEXT_PLAIN.toString()).isEqualTo(ContentType.TEXT_PLAIN.mimeType)
+    }
+
+    @Test
+    fun `custom mime type should work when precompression is turned on`() {
+        TestUtil.test(Javalin.create { config ->
+            config.addStaticFiles { staticFiles ->
+                staticFiles.hostedPath = "/"
+                staticFiles.directory = "/markdown"
+                staticFiles.location = Location.CLASSPATH
+                staticFiles.precompress = true
+            }
+
+            config.configureServletContextHandler {
+                context: ServletContextHandler -> context.mimeTypes.addMimeMapping("md", ContentType.PLAIN)
+                JettyPrecompressingResourceHandler.servletContextHandler = context
+            }
+
+            config.enableDevLogging()
+        }) { _, http ->
+            assertThat(http.get("/test.md").status).isEqualTo(200)
+            assertThat(http.get("/test.md").headers.getFirst(Header.CONTENT_TYPE)).contains(ContentType.PLAIN)
+        }
     }
 
 }


### PR DESCRIPTION
Fixes [bug](https://github.com/tipsy/javalin/issues/1361)

Added a reference to `ServletContextHandler` in `JettyPrecompressingResourceHandler`, to make it able to access the context variables directly i.e. `MimeTypes`.

However, this adds a dependency for user to manually register the context at startup.
Maybe, this can be done in a better way.