### PR TITLE
GH-1351 Remove unnecessary println call from constructor

### DIFF
--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -59,7 +59,6 @@ public class Javalin {
     protected Javalin() {
         this.jettyServer = new JettyServer(_conf);
         this.javalinJettyServlet = new JavalinJettyServlet(_conf, javalinServlet);
-        System.out.println();
     }
 
     public Javalin(JettyServer jettyServer, JavalinJettyServlet jettyServlet) {


### PR DESCRIPTION
That's my fault, introduced in #1351. I'm not quite sure how it happened as I didn't really touch this class during related PR. 