### PR TITLE
Fixes #1361

### DIFF
--- a/javalin/src/main/java/io/javalin/jetty/JettyPrecompressingResourceHandler.kt
+++ b/javalin/src/main/java/io/javalin/jetty/JettyPrecompressingResourceHandler.kt
@@ -40,8 +40,9 @@ object JettyPrecompressingResourceHandler {
             val target = req.getAttribute("jetty-target") as String
             var acceptCompressType = CompressType.getByAcceptEncoding(req.getHeader(Header.ACCEPT_ENCODING) ?: "")
             val contentType = MimeTypes.getDefaultMimeByExtension(target) // get content type by file extension
-            if (excludedMimeType(contentType))
+            if (contentType == null || excludedMimeType(contentType)) {
                 acceptCompressType = CompressType.NONE
+            }
             val resultByteArray = getStaticResourceByteArray(resource, target, acceptCompressType) ?: return false
             res.setContentLength(resultByteArray.size)
             res.setHeader(Header.CONTENT_TYPE, contentType)

--- a/javalin/src/test/java/io/javalin/http/ContentTypeTest.kt
+++ b/javalin/src/test/java/io/javalin/http/ContentTypeTest.kt
@@ -1,5 +1,8 @@
 package io.javalin.http
 
+import io.javalin.Javalin
+import io.javalin.core.util.Header
+import io.javalin.testing.TestUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -25,6 +28,22 @@ class ContentTypeTest {
     @Test
     fun `string representation should return mime type`() {
         assertThat(ContentType.TEXT_PLAIN.toString()).isEqualTo(ContentType.TEXT_PLAIN.mimeType)
+    }
+
+    @Test
+    fun `file should be served even if content type isn't set`() {
+        val precompressingApp = Javalin.create { config ->
+            config.addStaticFiles {
+                it.precompress = true
+                it.directory = "/markdown"
+            }
+        }
+        TestUtil.test(precompressingApp) { _, http ->
+            val response = http.get("/test.md")
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body).contains("# Hello Markdown!")
+            assertThat(response.headers.getFirst(Header.CONTENT_TYPE)).isNull()
+        }
     }
 
 }


### PR DESCRIPTION
Fixes [bug](https://github.com/tipsy/javalin/issues/1361).

Added null check for checking the value of contentType, so java.lang.NullPointerException should not be raised.

So the file should be served even if content type isn't set.