### PR TITLE
[openapi] update openapi deps

### DIFF
--- a/javalin-openapi/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
+++ b/javalin-openapi/src/main/java/io/javalin/plugin/openapi/jackson/JacksonToJsonMapper.kt
@@ -1,14 +1,9 @@
 package io.javalin.plugin.openapi.jackson
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import io.javalin.plugin.openapi.utils.LazyDefaultValue
-import io.swagger.v3.core.jackson.mixin.SchemaMixin
-import io.swagger.v3.oas.models.media.Schema
-import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.core.util.Json
 
 /**
  * Default jackson mapper for creating the object api schema json.
@@ -23,18 +18,7 @@ class JacksonToJsonMapper(
 
     companion object {
         val defaultObjectMapper: ObjectMapper by LazyDefaultValue {
-            createObjectMapperWithDefaults()
-        }
-
-        fun createObjectMapperWithDefaults(): ObjectMapper {
-            return jacksonObjectMapper()
-                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                    .addMixIn(Schema::class.java, SchemaMixin::class.java)
-                    .registerModule(
-                            SimpleModule()
-                                    .addSerializer(SecurityScheme.Type::class.java, ToStringSerializer())
-                                    .addSerializer(SecurityScheme.In::class.java, ToStringSerializer())
-                    )
+            Json.mapper().registerModule(kotlinModule())
         }
     }
 

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApi.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApi.kt
@@ -35,6 +35,7 @@ import io.javalin.plugin.openapi.dsl.documentedContent
 import io.javalin.plugin.openapi.dsl.oneOf
 import io.javalin.plugin.openapi.jackson.JacksonToJsonMapper
 import io.javalin.testing.TestUtil
+import io.swagger.v3.core.util.Json
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
@@ -478,10 +479,7 @@ class TestOpenApi {
 
     @Test
     fun `createSchema works with Instants as timestamps`() {
-        val customMapper = JacksonToJsonMapper.createObjectMapperWithDefaults()
-
         val openApiOptions = OpenApiOptions(Info().title("Example").version("1.0.0"))
-            .jacksonMapper(customMapper)
         val app = Javalin.create {
             it.registerPlugin(OpenApiPlugin(openApiOptions))
         }
@@ -502,10 +500,7 @@ class TestOpenApi {
 
     @Test
     fun `createSchema Instants respect annotations`() {
-        val customMapper = JacksonToJsonMapper.createObjectMapperWithDefaults()
-
         val openApiOptions = OpenApiOptions(Info().title("Example").version("1.0.0"))
-            .jacksonMapper(customMapper)
         val app = Javalin.create {
             it.registerPlugin(OpenApiPlugin(openApiOptions))
         }
@@ -526,12 +521,8 @@ class TestOpenApi {
 
     @Test
     fun `createSchema works with Instants as strings`() {
-        val customMapper = JacksonToJsonMapper.createObjectMapperWithDefaults()
-            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-
         val openApiOptions = OpenApiOptions(
-            Info().title("Example").version("1.0.0")
-        ).jacksonMapper(customMapper)
+            Info().title("Example").version("1.0.0"))
         val app = Javalin.create {
             it.registerPlugin(OpenApiPlugin(openApiOptions))
         }

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApi.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApi.kt
@@ -494,8 +494,8 @@ class TestOpenApi {
         val actual = JavalinOpenApi.createSchema(app)
         val schema = actual.components.schemas["Log"]!!
         val timestampSchemaType = schema.properties["timestamp"]!!
-        assertThat(timestampSchemaType.type).isEqualTo("integer")
-        assertThat(timestampSchemaType.format).isEqualTo("int64")
+        assertThat(timestampSchemaType.type).isEqualTo("string")
+        assertThat(timestampSchemaType.format).isEqualTo("date-time")
     }
 
     @Test

--- a/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiHandler.kt
+++ b/javalin-openapi/src/test/java/io/javalin/plugin/openapi/TestOpenApiHandler.kt
@@ -1,0 +1,120 @@
+package io.javalin.plugin.openapi
+
+import io.javalin.Javalin
+import io.javalin.plugin.openapi.dsl.document
+import io.javalin.plugin.openapi.dsl.documented
+import io.swagger.v3.oas.models.info.Info
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class TestOpenApiHandler {
+
+    private val expectedJson = """
+        {
+          "openapi" : "3.0.1",
+          "info" : {
+            "title" : "testApp",
+            "version" : "1.0"
+          },
+          "paths" : {
+            "/user" : {
+              "get" : {
+                "summary" : "Get user",
+                "operationId" : "getUser",
+                "responses" : {
+                  "200" : {
+                    "description" : "OK",
+                    "content" : {
+                      "application/json" : {
+                        "schema" : {
+                          "$ref" : "#/components/schemas/TestUser"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "/address" : {
+              "get" : {
+                "summary" : "Get address",
+                "operationId" : "getAddress",
+                "responses" : {
+                  "200" : {
+                    "description" : "OK",
+                    "content" : {
+                      "application/json" : {
+                        "schema" : {
+                          "$ref" : "#/components/schemas/TestAddress"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "components" : {
+            "schemas" : {
+              "TestAddress" : {
+                "required" : [ "number", "street" ],
+                "type" : "object",
+                "properties" : {
+                  "street" : {
+                    "type" : "string"
+                  },
+                  "number" : {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }
+                }
+              },
+              "TestUser" : {
+                "required" : [ "address", "name" ],
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string"
+                  },
+                  "address" : {
+                    "$ref" : "#/components/schemas/TestAddress"
+                  }
+                }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    private data class TestUser(val name: String, val address: TestAddress)
+    private data class TestAddress(val street: String, val number: Int)
+
+    private fun createApp(openApiPlugin: OpenApiPlugin) = Javalin.create {
+        it.registerPlugin(openApiPlugin)
+    }.apply {
+        get("/user", documented(document().result<TestUser>("200")) {})
+        get("/address", documented(document().result<TestAddress>("200")) {})
+    }
+
+    @Test
+    fun `schema validates without warning about unexpected exampleSetFlag`() {
+        // title and version required for validation
+        val info = Info().title("testApp").version("1.0")
+
+        // enable validation
+        val app = createApp(OpenApiPlugin(OpenApiOptions(info).apply {
+            validateSchema(true)
+        }))
+
+        // generate the schema
+        val openApiSchema = JavalinOpenApi.createSchema(app)
+
+        // re-validate the schema to verify no error messages were generated
+        val handler = app._conf.getPlugin(OpenApiPlugin::class.java).openApiHandler
+        val validated = handler.validateOpenAPISchema(openApiSchema)
+
+        Assertions.assertThat(validated.messages).isEmpty()
+        Assertions.assertThat(openApiSchema.asJsonString()).isEqualTo(expectedJson.formatJson())
+    }
+
+}

--- a/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -19,9 +19,9 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
 
     // OpenAPI
     SWAGGERUI("Swagger UI", "STATIC-FILES", "org.webjars", "swagger-ui", "3.43.0"),
-    SWAGGERPARSER("Swagger Parser", "io.swagger.v3.parser.OpenAPIV3Parser", "io.swagger.parser.v3", "swagger-parser", "2.0.24"),
+    SWAGGERPARSER("Swagger Parser", "io.swagger.v3.parser.OpenAPIV3Parser", "io.swagger.parser.v3", "swagger-parser", "2.0.27"),
     REDOC("ReDoc", "STATIC-FILES", "org.webjars.npm", "redoc", "2.0.0-rc.45"),
-    SWAGGER_CORE("Swagger Core", "io.swagger.v3.oas.models.OpenAPI", "io.swagger.core.v3", "swagger-models", "2.1.6"),
+    SWAGGER_CORE("Swagger Core", "io.swagger.v3.oas.models.OpenAPI", "io.swagger.core.v3", "swagger-models", "2.1.10"),
     CLASS_GRAPH("ClassGraph", "io.github.classgraph.ClassGraph", "io.github.classgraph", "classgraph", "4.8.102"),
 
     // Monitoring

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
         <pebble.version>3.1.5</pebble.version>
         <redoc.version>2.0.0-rc.45</redoc.version>
         <slf4j.version>1.7.31</slf4j.version>
-        <swagger.core.version>2.1.6</swagger.core.version>
-        <swagger.parser.version>2.0.24</swagger.parser.version>
+        <swagger.core.version>2.1.10</swagger.core.version>
+        <swagger.parser.version>2.0.27</swagger.parser.version>
         <swagger.ui.version>3.43.0</swagger.ui.version>
         <thymeleaf.version>3.0.12.RELEASE</thymeleaf.version>
         <velocity.version>2.3</velocity.version>


### PR DESCRIPTION
- openapi dependencies are now on the latest version
- removed reference to 1.x branch dep in validation
- added test to check for exampleSetFlag leakage
- use json mapper from swagger-core instead of a custom one