### PR TITLE
Enable OSGi bundle packaging for Javalin

### DIFF
--- a/javalin-osgi/README.md
+++ b/javalin-osgi/README.md
@@ -1,3 +1,2 @@
 Produced OSGi bundle of Javalin, currently exporting all the packages.
-Uses [Embed-Dependency](http://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#_embedding_dependencies)
-instruction to include a standard Javalin Jar into the bundle providing a suitable OSGi manifest file. 
+Re-packaging Javalin JAR into OSGi bundle providing a suitable OSGi manifest file. 

--- a/javalin-osgi/README.md
+++ b/javalin-osgi/README.md
@@ -1,2 +1,2 @@
 Produced OSGi bundle of Javalin, currently exporting all the packages.
-Re-packaging Javalin JAR into OSGi bundle providing a suitable OSGi manifest file. 
+This is done by re-packaging Javalin JAR into OSGi bundle and generating a suitable OSGi manifest file. 

--- a/javalin-osgi/README.md
+++ b/javalin-osgi/README.md
@@ -1,0 +1,1 @@
+Produced OSGi bundle of Javalin, currently exporting all the packages 

--- a/javalin-osgi/README.md
+++ b/javalin-osgi/README.md
@@ -1,1 +1,3 @@
-Produced OSGi bundle of Javalin, currently exporting all the packages 
+Produced OSGi bundle of Javalin, currently exporting all the packages.
+Uses [Embed-Dependency](http://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#_embedding_dependencies)
+instruction to include a standard Javalin Jar into the bundle providing a suitable OSGi manifest file. 

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -27,7 +27,16 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.1</version>
                 <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <supportedProjectTypes>
                         <supportedProjectType>jar</supportedProjectType>
@@ -35,6 +44,7 @@
                     </supportedProjectTypes>
                     <instructions>
                         <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
+                        <Bundle-Description>Module: ${project.name}</Bundle-Description>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
                         <Embed-Dependency>javalin</Embed-Dependency>
                         <Export-Package>io.javalin.*</Export-Package>

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -37,6 +37,7 @@
                         <Bundle-SymbolicName>${bundle-symbolic-name};singleton:=true</Bundle-SymbolicName>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
                         <Embed-Dependency>javalin</Embed-Dependency>
+                        <Export-Package>io.javalin.*</Export-Package>
                         <Import-Package>
                             org.eclipse.jetty.util.component,\
                             com.github.mustachejava;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -67,6 +67,7 @@
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
                         <Import-Package>
                             org.eclipse.jetty.util.component,\
+                            com.github.mustachejava;resolution:=optional,\
                             com.mitchellbosecke.pebble;resolution:=optional,\
                             com.mitchellbosecke.pebble.loader;resolution:=optional,\
                             com.mitchellbosecke.pebble.template;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -65,8 +65,13 @@
                         <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
                         <Bundle-Description>Bundle: ${project.name}</Bundle-Description>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
+                        <Export-Package>
+                            org.eclipse.jetty.util.component,
+                            *
+                        </Export-Package>
                         <Import-Package>
-                            org.eclipse.jetty.util.component,\
+                            com.fasterxml.jackson.databind;resolution:=optional,\
+                            com.fasterxml.jackson.module.kotlin;resolution:=optional,\
                             com.github.mustachejava;resolution:=optional,\
                             com.mitchellbosecke.pebble;resolution:=optional,\
                             com.mitchellbosecke.pebble.loader;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -65,11 +65,8 @@
                         <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
                         <Bundle-Description>Bundle: ${project.name}</Bundle-Description>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
-                        <Export-Package>
-                            org.eclipse.jetty.util.component,
-                            *
-                        </Export-Package>
                         <Import-Package>
+                            org.eclipse.jetty.util.component,\
                             com.fasterxml.jackson.databind;resolution:=optional,\
                             com.fasterxml.jackson.module.kotlin;resolution:=optional,\
                             com.github.mustachejava;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -69,6 +69,8 @@
                         <Import-Package>
                             kotlin.*, io.javalin.*,\
                             org.eclipse.jetty.util.component,\
+                            org.slf4j,\
+                            javax.servlet.http,\
                             com.github.mustachejava;resolution:=optional,\
                             com.mitchellbosecke.pebble;resolution:=optional,\
                             com.mitchellbosecke.pebble.loader;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -49,7 +49,7 @@
                         <Embed-Dependency>javalin</Embed-Dependency>
                         <Export-Package>io.javalin.*</Export-Package>
                         <Import-Package>
-                            io.javalin.*,\
+                            kotlin.*, io.javalin.*,\
                             org.eclipse.jetty.util.component,\
                             com.github.mustachejava;resolution:=optional,\
                             com.mitchellbosecke.pebble;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -61,10 +61,8 @@
                             org.thymeleaf;resolution:=optional,\
                             org.thymeleaf.context;resolution:=optional,\
                             org.thymeleaf.templatemode;resolution:=optional,\
-                            org.thymeleaf.templateresolver;resolution:=optional,\
-                            *
+                            org.thymeleaf.templateresolver;resolution:=optional
                         </Import-Package>
-                        <Fragment-Host>system.bundle;extension:=framework</Fragment-Host>
                     </instructions>
                 </configuration>
             </plugin>

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -67,10 +67,8 @@
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
                         <Export-Package>io.javalin.*</Export-Package>
                         <Import-Package>
-                            kotlin.*, io.javalin.*,\
+                            *,\
                             org.eclipse.jetty.util.component,\
-                            org.slf4j,\
-                            javax.servlet.http,\
                             com.github.mustachejava;resolution:=optional,\
                             com.mitchellbosecke.pebble;resolution:=optional,\
                             com.mitchellbosecke.pebble.loader;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -34,7 +34,7 @@
                         <supportedProjectType>bundle</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
-                        <Bundle-SymbolicName>${bundle-symbolic-name};singleton:=true</Bundle-SymbolicName>
+                        <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
                         <Embed-Dependency>javalin</Embed-Dependency>
                         <Export-Package>io.javalin.*</Export-Package>

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.1</version>
+                <version>5.1.2</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -44,11 +44,12 @@
                     </supportedProjectTypes>
                     <instructions>
                         <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
-                        <Bundle-Description>Module: ${project.name}</Bundle-Description>
+                        <Bundle-Description>Bundle: ${project.name}</Bundle-Description>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
                         <Embed-Dependency>javalin</Embed-Dependency>
                         <Export-Package>io.javalin.*</Export-Package>
                         <Import-Package>
+                            io.javalin.*,\
                             org.eclipse.jetty.util.component,\
                             com.github.mustachejava;resolution:=optional,\
                             com.mitchellbosecke.pebble;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>javalin-parent</artifactId>
+        <groupId>io.javalin</groupId>
+        <version>3.13.12-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>javalin-osgi</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <packaging>jar</packaging>
+    <properties>
+        <bundle-symbolic-name>${project.groupId}.${project.artifactId}</bundle-symbolic-name>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${bundle-symbolic-name};singleton:=true</Bundle-SymbolicName>
+                        <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
+                        <Import-Package>
+                            org.eclipse.jetty.util.component,\
+                            com.github.mustachejava;resolution:=optional,\
+                            com.mitchellbosecke.pebble;resolution:=optional,\
+                            com.mitchellbosecke.pebble.loader;resolution:=optional,\
+                            com.mitchellbosecke.pebble.template;resolution:=optional,\
+                            com.nixxcode.jvmbrotli.common;resolution:=optional,\
+                            com.nixxcode.jvmbrotli.enc;resolution:=optional,\
+                            freemarker.template;resolution:=optional,\
+                            gg.jte;resolution:=optional,\
+                            gg.jte.output;resolution:=optional,\
+                            gg.jte.resolve;resolution:=optional,\
+                            io.micrometer.core.instrument;resolution:=optional,\
+                            io.micrometer.core.instrument.binder.http;resolution:=optional,\
+                            io.micrometer.core.instrument.binder.jetty;resolution:=optional,\
+                            io.micrometer.core.instrument.composite;resolution:=optional,\
+                            io.swagger.util;resolution:=optional,\
+                            io.swagger.v3.parser;resolution:=optional,\
+                            io.swagger.v3.parser.core.models;resolution:=optional,\
+                            org.apache.velocity;resolution:=optional,\
+                            org.apache.velocity.app;resolution:=optional,\
+                            org.apache.velocity.context;resolution:=optional,\
+                            org.commonmark.node;resolution:=optional,\
+                            org.commonmark.parser;resolution:=optional,\
+                            org.commonmark.renderer.html;resolution:=optional,\
+                            org.jtwig;resolution:=optional,\
+                            org.jtwig.environment;resolution:=optional,\
+                            org.thymeleaf;resolution:=optional,\
+                            org.thymeleaf.context;resolution:=optional,\
+                            org.thymeleaf.templatemode;resolution:=optional,\
+                            org.thymeleaf.templateresolver;resolution:=optional,\
+                            *
+                        </Import-Package>
+                        <Fragment-Host>system.bundle;extension:=framework</Fragment-Host>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
     </dependencies>
 
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <properties>
         <bundle-symbolic-name>${project.groupId}.${project.artifactId}</bundle-symbolic-name>
     </properties>
@@ -27,10 +27,16 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
+                    <supportedProjectTypes>
+                        <supportedProjectType>jar</supportedProjectType>
+                        <supportedProjectType>bundle</supportedProjectType>
+                    </supportedProjectTypes>
                     <instructions>
                         <Bundle-SymbolicName>${bundle-symbolic-name};singleton:=true</Bundle-SymbolicName>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
+                        <Embed-Dependency>javalin</Embed-Dependency>
                         <Import-Package>
                             org.eclipse.jetty.util.component,\
                             com.github.mustachejava;resolution:=optional,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -25,19 +25,38 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-everything</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>compile</includeScope>
+                            <includeGroupIds>${project.parent.groupId}</includeGroupIds>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <excludes>**/MANIFEST.MF</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <version>5.1.2</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
-                            <goal>manifest</goal>
+                            <goal>bundle</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
+                    <excludeDependencies>true</excludeDependencies>
                     <supportedProjectTypes>
                         <supportedProjectType>jar</supportedProjectType>
                         <supportedProjectType>bundle</supportedProjectType>
@@ -46,7 +65,6 @@
                         <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
                         <Bundle-Description>Bundle: ${project.name}</Bundle-Description>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
-                        <Embed-Dependency>javalin</Embed-Dependency>
                         <Export-Package>io.javalin.*</Export-Package>
                         <Import-Package>
                             kotlin.*, io.javalin.*,\

--- a/javalin-osgi/pom.xml
+++ b/javalin-osgi/pom.xml
@@ -65,11 +65,8 @@
                         <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
                         <Bundle-Description>Bundle: ${project.name}</Bundle-Description>
                         <Bundle-Name>Javalin OSGi bundle</Bundle-Name>
-                        <Export-Package>io.javalin.*</Export-Package>
                         <Import-Package>
-                            *,\
                             org.eclipse.jetty.util.component,\
-                            com.github.mustachejava;resolution:=optional,\
                             com.mitchellbosecke.pebble;resolution:=optional,\
                             com.mitchellbosecke.pebble.loader;resolution:=optional,\
                             com.mitchellbosecke.pebble.template;resolution:=optional,\
@@ -97,7 +94,8 @@
                             org.thymeleaf;resolution:=optional,\
                             org.thymeleaf.context;resolution:=optional,\
                             org.thymeleaf.templatemode;resolution:=optional,\
-                            org.thymeleaf.templateresolver;resolution:=optional
+                            org.thymeleaf.templateresolver;resolution:=optional,
+                            kotlin.*, *
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
         <module>javalin-graphql</module>
         <module>javalin-bundle</module>
         <module>javalin-without-jetty</module>
+        <module>javalin-osgi</module>
     </modules>
 
     <parent>
@@ -60,6 +61,7 @@
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <jar.plugin.version>3.2.0</jar.plugin.version>
         <surefire.plugin.version>2.22.2</surefire.plugin.version>
+		<bundle.plugin.version>5.1.1</bundle.plugin.version>
 
         <!-- DEPENDENCIES -->
         <classgraph.version>4.8.90</classgraph.version>
@@ -445,6 +447,18 @@
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
                 </configuration>
             </plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<executions>
+					<execution>
+					<phase>process-classes</phase>
+					<goals>
+						<goal>manifest</goal>
+					</goals>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
 
         <pluginManagement>
@@ -454,6 +468,30 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${jar.plugin.version}</version>
                 </plugin>
+				<plugin>
+				  <groupId>org.apache.felix</groupId>
+				  <artifactId>maven-bundle-plugin</artifactId>
+				  <version>${bundle.plugin.version}</version>
+				  <extensions>true</extensions>
+				  <configuration>
+					<supportedProjectTypes>
+					  <supportedProjectType>jar</supportedProjectType>
+					  <supportedProjectType>maven-plugin</supportedProjectType>
+					</supportedProjectTypes>
+					<instructions>
+					  <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
+					  <Bundle-Description>Javalin module for ${project.name}</Bundle-Description>
+					  <Bundle-Classpath>.</Bundle-Classpath>
+					  <Import-Package>
+						${osgi.slf4j.import.packages},
+						*
+					  </Import-Package>
+					  <_provider-policy><![CDATA[$<range;[===,=+)>]]></_provider-policy>
+					  <_consumer-policy><![CDATA[$<range;[===,+)>]]></_consumer-policy>
+					  <_noee>true</_noee>
+					</instructions>
+				  </configuration>
+				</plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <jar.plugin.version>3.2.0</jar.plugin.version>
         <surefire.plugin.version>2.22.2</surefire.plugin.version>
-		<bundle.plugin.version>5.1.1</bundle.plugin.version>
 
         <!-- DEPENDENCIES -->
         <classgraph.version>4.8.90</classgraph.version>
@@ -447,18 +446,6 @@
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
                 </configuration>
             </plugin>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<executions>
-					<execution>
-					<phase>process-classes</phase>
-					<goals>
-						<goal>manifest</goal>
-					</goals>
-					</execution>
-				</executions>
-			</plugin>
         </plugins>
 
         <pluginManagement>
@@ -468,30 +455,6 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${jar.plugin.version}</version>
                 </plugin>
-				<plugin>
-				  <groupId>org.apache.felix</groupId>
-				  <artifactId>maven-bundle-plugin</artifactId>
-				  <version>${bundle.plugin.version}</version>
-				  <extensions>true</extensions>
-				  <configuration>
-					<supportedProjectTypes>
-					  <supportedProjectType>jar</supportedProjectType>
-					  <supportedProjectType>maven-plugin</supportedProjectType>
-					</supportedProjectTypes>
-					<instructions>
-					  <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
-					  <Bundle-Description>Module: ${project.name}</Bundle-Description>
-					  <Bundle-Classpath>.</Bundle-Classpath>
-					  <Import-Package>
-						${osgi.slf4j.import.packages},
-						*
-					  </Import-Package>
-					  <_provider-policy><![CDATA[$<range;[===,=+)>]]></_provider-policy>
-					  <_consumer-policy><![CDATA[$<range;[===,+)>]]></_consumer-policy>
-					  <_noee>true</_noee>
-					</instructions>
-				  </configuration>
-				</plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
 					</supportedProjectTypes>
 					<instructions>
 					  <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
-					  <Bundle-Description>Javalin module for ${project.name}</Bundle-Description>
+					  <Bundle-Description>Module: ${project.name}</Bundle-Description>
 					  <Bundle-Classpath>.</Bundle-Classpath>
 					  <Import-Package>
 						${osgi.slf4j.import.packages},


### PR DESCRIPTION
As discussed at: https://github.com/tipsy/javalin/issues/1375

Testing with out OSGi enabled application been performed to ensure that newly introduced module `javalin-osgi` works as expected.