### PR TITLE
Fix SSE terminator

### DIFF
--- a/javalin/src/main/java/io/javalin/http/sse/Emitter.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/Emitter.kt
@@ -28,6 +28,7 @@ class Emitter(private var asyncContext: AsyncContext) {
             output.print("data: ")
             data.copyTo(output)
             output.print(newline)
+            output.print(newline)
             asyncContext.response.flushBuffer()
         } catch (e: IOException) {
             closed = true


### PR DESCRIPTION
> Each notification is sent as a block of text terminated by a pair of newlines.