### PR TITLE
[core] Ensure LeveledGzipStream is properly closed

### DIFF
--- a/javalin/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
+++ b/javalin/src/main/java/io/javalin/http/JavalinResponseWrapper.kt
@@ -108,7 +108,7 @@ class OutputStreamWrapper(val res: HttpServletResponse, private val rwc: Respons
     fun finalize() {
         when {
             brotliEnabled && res.getHeader(CONTENT_ENCODING) == BR -> (compressingStream as BrotliOutputStream).close()
-            gzipEnabled && res.getHeader(CONTENT_ENCODING) == GZIP -> (compressingStream as LeveledGzipStream).finish()
+            gzipEnabled && res.getHeader(CONTENT_ENCODING) == GZIP -> (compressingStream as LeveledGzipStream).close()
         }
     }
 


### PR DESCRIPTION
Just to note, I haven't managed to test this fix on 4.x as I only use 3.x!