### PR TITLE
Bump jte to version 1.12.0

### DIFF
--- a/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
+++ b/javalin/src/main/java/io/javalin/core/util/OptionalDependency.kt
@@ -31,8 +31,8 @@ enum class OptionalDependency(val displayName: String, val testClass: String, va
     JVMBROTLI("Jvm-Brotli", "com.nixxcode.jvmbrotli.common.BrotliLoader", "com.nixxcode.jvmbrotli", "jvmbrotli", "0.2.0"),
 
     // Templating
-    JTE("jte", "gg.jte.TemplateEngine", "gg.jte", "jte", "1.11.0"),
-    JTE_KOTLIN("jte-kotlin", "gg.jte.compiler.kotlin.KotlinClassCompiler", "gg.jte", "jte-kotlin", "1.11.0"),
+    JTE("jte", "gg.jte.TemplateEngine", "gg.jte", "jte", "1.12.0"),
+    JTE_KOTLIN("jte-kotlin", "gg.jte.compiler.kotlin.KotlinClassCompiler", "gg.jte", "jte-kotlin", "1.12.0"),
     VELOCITY("Velocity", "org.apache.velocity.app.VelocityEngine", "org.apache.velocity", "velocity-engine-core", "2.3"),
     FREEMARKER("Freemarker", "freemarker.template.Configuration", "org.freemarker", "freemarker", "2.3.30"),
     THYMELEAF("Thymeleaf", "org.thymeleaf.TemplateEngine", "org.thymeleaf", "thymeleaf", "3.0.12.RELEASE"),

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <swagger.ui.version>3.43.0</swagger.ui.version>
         <thymeleaf.version>3.0.12.RELEASE</thymeleaf.version>
         <velocity.version>2.3</velocity.version>
-        <jte.version>1.11.0</jte.version>
+        <jte.version>1.12.0</jte.version>
         <graphql-kotlin.version>4.1.1</graphql-kotlin.version>
         <reactor-core.version>3.2.9.RELEASE</reactor-core.version>
 


### PR DESCRIPTION
This brings some 1.11.x bugfixes and faster hot reload of jte templates (https://github.com/casid/jte/releases/tag/1.12.0).
