### PR TITLE
Add a "server stop failed" lifecycle event

### DIFF
--- a/javalin/src/main/java/io/javalin/Javalin.java
+++ b/javalin/src/main/java/io/javalin/Javalin.java
@@ -209,7 +209,9 @@ public class Javalin implements AutoCloseable {
         try {
             jettyServer.server().stop();
         } catch (Exception e) {
+            eventManager.fireEvent(JavalinEvent.SERVER_STOP_FAILED);
             JavalinLogger.error("Javalin failed to stop gracefully", e);
+            throw new JavalinException(e);
         }
         JavalinLogger.info("Javalin has stopped");
         eventManager.fireEvent(JavalinEvent.SERVER_STOPPED);

--- a/javalin/src/main/java/io/javalin/core/event/EventListener.java
+++ b/javalin/src/main/java/io/javalin/core/event/EventListener.java
@@ -21,6 +21,7 @@ public class EventListener {
     public void serverStarting(@NotNull EventHandler eventHandler)    {  addLifecycleEvent(JavalinEvent.SERVER_STARTING,     eventHandler); }
     public void serverStarted(@NotNull EventHandler eventHandler)     {  addLifecycleEvent(JavalinEvent.SERVER_STARTED,      eventHandler); }
     public void serverStartFailed(@NotNull EventHandler eventHandler) {  addLifecycleEvent(JavalinEvent.SERVER_START_FAILED, eventHandler); }
+    public void serverStopFailed(@NotNull EventHandler eventHandler)  {  addLifecycleEvent(JavalinEvent.SERVER_STOP_FAILED, eventHandler); }
     public void serverStopping(@NotNull EventHandler eventHandler)    {  addLifecycleEvent(JavalinEvent.SERVER_STOPPING,     eventHandler); }
     public void serverStopped(@NotNull EventHandler eventHandler)     {  addLifecycleEvent(JavalinEvent.SERVER_STOPPED,      eventHandler); }
     // @formatter:on

--- a/javalin/src/main/java/io/javalin/core/event/EventManager.kt
+++ b/javalin/src/main/java/io/javalin/core/event/EventManager.kt
@@ -20,6 +20,6 @@ class EventManager {
     fun fireWsHandlerAddedEvent(metaInfo: WsHandlerMetaInfo) = wsHandlerAddedHandlers.apply { this.forEach { it.accept(metaInfo) } }
 }
 
-enum class JavalinEvent { SERVER_STARTING, SERVER_STARTED, SERVER_START_FAILED, SERVER_STOPPING, SERVER_STOPPED }
+enum class JavalinEvent { SERVER_STARTING, SERVER_STARTED, SERVER_START_FAILED, SERVER_STOP_FAILED, SERVER_STOPPING, SERVER_STOPPED }
 data class HandlerMetaInfo(val httpMethod: HandlerType, val path: String, val handler: Any, val roles: Set<RouteRole>)
 data class WsHandlerMetaInfo(val handlerType: WsHandlerType, val path: String, val handler: Any, val roles: Set<RouteRole>)


### PR DESCRIPTION
Hi Tipsy. 

Resolves #1442. Tried to maintain your code style. If merged, the [docs](https://javalin.io/documentation#lifecycle-events) need updating. Let me know your thoughts. Note: this changes the contract for `stop()` because it now throws, as it should have originally.

Thanks.