### PR TITLE
Request welcome dirs with a trailing slash

### DIFF
--- a/javalin/src/test/java/io/javalin/TestStaticDirectorySlash.kt
+++ b/javalin/src/test/java/io/javalin/TestStaticDirectorySlash.kt
@@ -18,6 +18,7 @@ class TestStaticDirectorySlash {
 
     @Test
     fun `normal javalin ignores static directory slashes`() = TestUtil.test(normalJavalin) { _, http ->
+        http.disableUnirestRedirects()
         assertThat(http.getBody("/subpage")).isEqualTo("TEST") // ok, is directory
         assertThat(http.getBody("/subpage/")).isEqualTo("TEST") // ok, is directory
     }


### PR DESCRIPTION
When we know a request is for a directory with an index.html, pass along
the request with a trailing slash, which means we are requesting the
resource as a directory.

This is independent of Jetty -- we would do the same request for a welcome
directory if we were using tomcat, jetty, or any other backend.

fixes #1459