### PR TITLE
Ensure retrieving session attributes does not create a session

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -286,7 +286,7 @@ open class Context(@JvmField val req: HttpServletRequest, @JvmField val res: Htt
     fun sessionAttribute(key: String, value: Any?) = req.session.setAttribute(key, value)
 
     /** Gets specified attribute from the user session, or null. */
-    fun <T> sessionAttribute(key: String): T? = req.session.getAttribute(key) as? T
+    fun <T> sessionAttribute(key: String): T? = req.getSession(false)?.getAttribute(key) as? T
 
     fun <T> consumeSessionAttribute(key: String) = sessionAttribute<T?>(key).also { this.sessionAttribute(key, null) }
 

--- a/javalin/src/test/java/io/javalin/TestRequest.kt
+++ b/javalin/src/test/java/io/javalin/TestRequest.kt
@@ -43,6 +43,14 @@ class TestRequest {
     }
 
     @Test
+    fun `session-attribute retrieval does not create session`() = TestUtil.test { app, http ->
+        app.get("/read-session") { ctx -> ctx.result("" + ctx.sessionAttribute<String>("nonexisting")) }
+        app.get("/has-session") { ctx -> ctx.result("" + (ctx.req.getSession(false) != null)) }
+        assertThat(http.getBody("/read-session")).isEqualTo("null")
+        assertThat(http.getBody("/has-session")).isEqualTo("false")
+    }
+
+    @Test
     fun `session-attribute can be consumed easily`() = TestUtil.test { app, http ->
         app.get("/store-attr") { it.sessionAttribute("attr", "Rowin") }
         app.get("/read-attr") { it.result(it.consumeSessionAttribute("attr") ?: "Consumed") }


### PR DESCRIPTION
When retrieving session attributes via `ctx.sessionAttribute()` there is
no requirement to create a session on retrieval - as opposed to setting
an attribute.

Closes #1470