### PR TITLE
1045: Fix for multipart form disk caching

### DIFF
--- a/javalin/src/main/java/io/javalin/http/util/MultipartUtil.kt
+++ b/javalin/src/main/java/io/javalin/http/util/MultipartUtil.kt
@@ -13,9 +13,13 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.Part
 
 object MultipartUtil {
+    private const val MULTIPART_CONFIG_ATTRIBUTE = "org.eclipse.jetty.multipartConfig";
 
     var preUploadFunction: (HttpServletRequest) -> Unit = { req ->
-        req.setAttribute("org.eclipse.jetty.multipartConfig", MultipartConfigElement(System.getProperty("java.io.tmpdir")))
+        val existingConfig = req.getAttribute(MULTIPART_CONFIG_ATTRIBUTE)
+        if (existingConfig == null) {
+            req.setAttribute(MULTIPART_CONFIG_ATTRIBUTE, MultipartConfigElement(System.getProperty("java.io.tmpdir")))
+        }
     }
 
     fun getUploadedFiles(req: HttpServletRequest, partName: String): List<UploadedFile> {

--- a/javalin/src/main/java/io/javalin/http/util/MultipartUtil.kt
+++ b/javalin/src/main/java/io/javalin/http/util/MultipartUtil.kt
@@ -18,7 +18,8 @@ object MultipartUtil {
     var preUploadFunction: (HttpServletRequest) -> Unit = { req ->
         val existingConfig = req.getAttribute(MULTIPART_CONFIG_ATTRIBUTE)
         if (existingConfig == null) {
-            req.setAttribute(MULTIPART_CONFIG_ATTRIBUTE, MultipartConfigElement(System.getProperty("java.io.tmpdir")))
+            req.setAttribute(MULTIPART_CONFIG_ATTRIBUTE,
+                    MultipartConfigElement(System.getProperty("java.io.tmpdir"), -1, -1, 1))
         }
     }
 


### PR DESCRIPTION
Fix for issues mentioned in https://github.com/tipsy/javalin/issues/1045 (uploading large files bloats JVM heap).

**Issue breakdown**
On each access to `uploadedFiles` methods, underlying `MultipartUtil` calls `preUploadFunction`. Under the hood it executes:
```java
req.setAttribute("org.eclipse.jetty.multipartConfig", MultipartConfigElement(System.getProperty("java.io.tmpdir")))
```
which in the long form looks something like this
```java
req.setAttribute("org.eclipse.jetty.multipartConfig", MultipartConfigElement(System.getProperty("java.io.tmpdir"), -1, -1, 0))
```
In your discussions with @Mynameisbt you were incorrect in assumption that `MultipartConfigElement`'s `fileSizeThreshold`, when set to `0`, always caches to disk. 

Unfortunately this is not the case and `0` actually disables caching behavoir:
```java
# Class org.eclipse.jetty.util.MultiPartInputStreamParser write methods

protected void write(int b) throws IOException {
    if (MultiPartInputStreamParser.this._config.getMaxFileSize() > 0L && this._size + 1L > MultiPartInputStreamParser.this._config.getMaxFileSize()) {
        throw new IllegalStateException("Multipart Mime part " + this._name + " exceeds max filesize");
    } else {
        if (MultiPartInputStreamParser.this._config.getFileSizeThreshold() > 0 && this._size + 1L > (long)MultiPartInputStreamParser.this._config.getFileSizeThreshold() && this._file == null) {
            this.createFile();
        }
        this._out.write(b);
        ++this._size;
    }
}
protected void write(byte[] bytes, int offset, int length) throws IOException {
    if (MultiPartInputStreamParser.this._config.getMaxFileSize() > 0L && this._size + (long)length > MultiPartInputStreamParser.this._config.getMaxFileSize()) {
        throw new IllegalStateException("Multipart Mime part " + this._name + " exceeds max filesize");
    } else {
        if (MultiPartInputStreamParser.this._config.getFileSizeThreshold() > 0 && this._size + (long)length > (long)MultiPartInputStreamParser.this._config.getFileSizeThreshold() && this._file == null) {
            this.createFile();
        }
        this._out.write(bytes, offset, length);
        this._size += (long)length;
    }
}

```

First condition `MultiPartInputStreamParser.this._config.getMaxFileSize() > 0L` is always `false` since `maxFileSize` was set to `-1`. 
So we end up in `else` branch where `MultiPartInputStreamParser.this._config.getFileSizeThreshold() > 0` is also `false` as `fileSizeThreashold` was set to `0`. 

This poses a big issue, since it's not possible to properly set up `org.eclipse.jetty.multipartConfig` anywhere and use `uploadFiles` methods. The only workaround is opt for `HttpServletRequest` api directly.

**The fix**
This PR addresses this issue by first checking if `org.eclipse.jetty.multipartConfig` is already set in request:

- If `true` - do nothing as developers already took care of proper limits
- If `false` - retained original behavior (although we can discuss and change to `MultipartConfigElement(System.getProperty("java.io.tmpdir"), -1, -1, 1)` which would enable disk caching as soon as 1 byte is received

**Testing**
Created test `custom multipart properties applied correctly` in `TestMultipartForms` which demonstrates that `org.eclipse.jetty.multipartConfig` set by developer now takes precedence over default behavior.

fixes #1045 

