### PR TITLE
Prevent SSE Buffering with nginx

### DIFF
--- a/javalin/src/main/java/io/javalin/core/util/Header.kt
+++ b/javalin/src/main/java/io/javalin/core/util/Header.kt
@@ -79,4 +79,5 @@ object Header {
     const val X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options"
     const val X_HTTP_METHOD_OVERRIDE = "X-HTTP-Method-Override"
     const val X_PERMITTED_CROSS_DOMAIN_POLICIES = "X-Permitted-Cross-Domain-Policies"
+    const val X_ACCEL_BUFFERING = "X-Accel-Buffering"
 }

--- a/javalin/src/main/java/io/javalin/http/sse/SseHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/SseHandler.kt
@@ -16,6 +16,7 @@ class SseHandler(private val clientConsumer: Consumer<SseClient>) : Handler {
                 contentType = "text/event-stream"
                 addHeader(Header.CONNECTION, "close")
                 addHeader(Header.CACHE_CONTROL, "no-cache")
+                addHeader("X-Accel-Buffering", "no") // See https://serverfault.com/a/801629
                 flushBuffer()
             }
             ctx.req.startAsync(ctx.req, ctx.res)

--- a/javalin/src/main/java/io/javalin/http/sse/SseHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/sse/SseHandler.kt
@@ -16,7 +16,7 @@ class SseHandler(private val clientConsumer: Consumer<SseClient>) : Handler {
                 contentType = "text/event-stream"
                 addHeader(Header.CONNECTION, "close")
                 addHeader(Header.CACHE_CONTROL, "no-cache")
-                addHeader("X-Accel-Buffering", "no") // See https://serverfault.com/a/801629
+                addHeader(Header.X_ACCEL_BUFFERING, "no") // See https://serverfault.com/a/801629
                 flushBuffer()
             }
             ctx.req.startAsync(ctx.req, ctx.res)


### PR DESCRIPTION
When proxied through nginx, server sent events currently have a delay of about 3 seconds.

After some trial and error I found this post: https://serverfault.com/a/801629
Setting the response header `X-Accel-Buffering=no` removes this delay. As mentioned in the article, it is recommended to set this header in the application, so buffering is only disabled for SSE requests and not all requests.

Currently, there is no mechanism to customize the SSE response headers. For now, I've hacked the SseHandler class in my application as a workaround.

This PR does the same as my class hack and simply sets `X-Accel-Buffering=no` in SseHandler.kt.

@tipsy what do you think to add this header by default? It doesn't cause much overhead and should be helpful for other users with an nginx proxy.

