### PR TITLE
[github] Add Java 18 to actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [8, 11, 17]
+        java_version: [8, 11, 17, 18] # Test all LTS releases and the latest one
         os: [windows-latest, macOS-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Java 18 has been release a few days ago, might be a good idea to run Javalin tests against it. I've added it as a 4th target, so we're declaring support for all LTS versions + the latest one. Sounds like a fair policy. 