### PR TITLE
GH-1488 Disable lookup for DevToolsActivePort file

### DIFF
--- a/javalin/src/test/java/io/javalin/TestWebBrowser.kt
+++ b/javalin/src/test/java/io/javalin/TestWebBrowser.kt
@@ -43,6 +43,7 @@ class TestWebBrowser {
                 addArguments("--disable-dev-shm-usage")
                 addArguments("--headless")
                 addArguments("--disable-gpu")
+                addArguments("--remote-debugging-port=9222") // Disables lookup for DevToolsActivePort file at all
             })
         }
 


### PR DESCRIPTION
Let's just don't use devtools by specifying random port explicitly

References:
* https://bugs.chromium.org/p/chromedriver/issues/detail?id=2473