### PR TITLE
GH-1495 Make default future callback configurable

### DIFF
--- a/javalin/src/main/java/io/javalin/core/JavalinConfig.java
+++ b/javalin/src/main/java/io/javalin/core/JavalinConfig.java
@@ -23,6 +23,7 @@ import io.javalin.core.util.Headers;
 import io.javalin.core.util.HeadersPlugin;
 import io.javalin.core.util.LogUtil;
 import io.javalin.http.ContentType;
+import io.javalin.http.Context;
 import io.javalin.http.ContextResolver;
 import io.javalin.http.Handler;
 import io.javalin.http.RequestLogger;
@@ -39,6 +40,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -50,6 +52,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static io.javalin.http.ContextResolverKt.CONTEXT_RESOLVER_KEY;
+import static io.javalin.http.ContextResolverKt.createDefaultFutureCallback;
 import static io.javalin.http.util.ContextUtil.maxRequestSizeKey;
 import static io.javalin.plugin.json.JsonMapperKt.JSON_MAPPER_KEY;
 
@@ -81,6 +84,7 @@ public class JavalinConfig {
         @Nullable public Server server = null;
         @Nullable public Consumer<ServletContextHandler> servletContextHandlerConsumer = null;
         @NotNull public CompressionStrategy compressionStrategy = CompressionStrategy.GZIP;
+        @NotNull public BiConsumer<Context, Object> defaultFutureCallback = createDefaultFutureCallback();
     }
     // @formatter:on
 

--- a/javalin/src/main/java/io/javalin/http/ContextResolver.kt
+++ b/javalin/src/main/java/io/javalin/http/ContextResolver.kt
@@ -1,8 +1,8 @@
 package io.javalin.http
 
 import io.javalin.core.util.Header
-import javax.servlet.http.HttpServletRequest
-
+import java.io.InputStream
+import java.util.function.BiConsumer
 
 const val CONTEXT_RESOLVER_KEY = "contextResolver"
 
@@ -16,4 +16,13 @@ class ContextResolver {
     @JvmField var url: (Context) -> String = { it.req.requestURL.toString() }
     @JvmField var fullUrl: (Context) -> String = { it.url() + if (it.queryString() != null) "?" + it.queryString() else "" }
     // @formatter:on
+}
+
+internal fun createDefaultFutureCallback(): BiConsumer<Context, Any?> = BiConsumer { ctx, result ->
+    when (result) {
+        is Unit -> {}
+        is InputStream -> ctx.result(result)
+        is String -> ctx.result(result)
+        is Any -> ctx.json(result)
+    }
 }

--- a/javalin/src/main/java/io/javalin/http/JavalinServletHandler.kt
+++ b/javalin/src/main/java/io/javalin/http/JavalinServletHandler.kt
@@ -106,7 +106,7 @@ class JavalinServletHandler(
             .also { result -> if (ctx.isAsync()) ctx.req.asyncContext.addTimeoutListener { result.future.cancel(true) } }
             .let { result ->
                 result.future
-                    .thenAccept { any -> (result.callback ?: defaultFutureCallback()).accept(any) } // callback after future resolves - modifies ctx result, status, etc
+                    .thenAccept { any -> result.callback?.accept(any) ?: config.inner.defaultFutureCallback.accept(ctx, any) } // callback after future resolves - modifies ctx result, status, etc
                     .thenApply { ctx.resultStream() ?: previousResult } // set value of future to be resultStream (or previous stream)
                     .exceptionally { throwable -> exceptionMapper.handleFutureException(ctx, throwable) } // standard exception handler
                     .thenApply { inputStream -> inputStream.also { queueNextTaskOrFinish() } } // we have to attach the "also" to the input stream to avoid mapping a void
@@ -132,16 +132,6 @@ class JavalinServletHandler(
             exceptionMapper.handleUnexpectedThrowable(ctx.res, throwable) // handle any unexpected error, e.g. write failure
         } finally {
             if (ctx.isAsync()) ctx.req.asyncContext.complete() // guarantee completion of async context to eliminate the possibility of hanging connections
-        }
-    }
-
-    /** Runs after a future is resolved, if not user defined callback exists */
-    private fun defaultFutureCallback(): Consumer<Any?> = Consumer { result ->
-        when (result) {
-            is Unit -> {}
-            is InputStream -> ctx.result(result)
-            is String -> ctx.result(result)
-            is Any -> ctx.json(result)
         }
     }
 


### PR DESCRIPTION
* #1495

I've added `@NotNull public BiConsumer<Context, Object> defaultFutureCallback = createDefaultFutureCallback();` field to inner config, as it's won't be widely used feature.

`createDefaultFutureCallback()` is located in `ContextResolver` because it's associated with context resolution and that class is already in Kotlin, so it's just easier to provide this default impl using `when`. I don't think that this method should be located in `Context` directly, even through `ContextResolver`, because we don't want to expose this value outside of the context, it's just a value we can use as a fallback in servlet handler, so indeed it should be only accessible from configuration.