### PR TITLE
[logging] Avoid logging EofException and TimeoutException thrown by async responses

### DIFF
--- a/javalin/src/main/java/io/javalin/http/ExceptionMapper.kt
+++ b/javalin/src/main/java/io/javalin/http/ExceptionMapper.kt
@@ -40,7 +40,8 @@ class ExceptionMapper {
     }
 
     internal fun handleUnexpectedThrowable(res: HttpServletResponse, throwable: Throwable): Nothing? {
-        if (JettyUtil.isClientAbortException(throwable) || JettyUtil.isJettyTimeoutException(throwable)) {
+        val unwrapped = (throwable as? CompletionException)?.cause ?: throwable
+        if (JettyUtil.isClientAbortException(unwrapped) || JettyUtil.isJettyTimeoutException(unwrapped)) {
             JavalinLogger.debug("Client aborted or timed out", throwable)
             return null // jetty aborts and timeouts happen when clients disconnect, they are not actually unexpected
         }


### PR DESCRIPTION
Updates `ExceptionMapper` to "unwrap" `CompletionException` so that it detects `EofException` and `TimeoutException` when using `ctx.future`.

The new line looks a bit long to me but not sure what the right formatting should be (reformatting in IntelliJ changed a heap of other formatting so my settings must be different somehow).

And there wasn't a test for the existing suppression of EofException that I could see so wasn't sure how to add one (first foray into this codebase and I'm not a Kotlin dev...).

closes #1544