### PR TITLE
[websocket] Add sendPing() method

### DIFF
--- a/javalin/src/main/java/io/javalin/websocket/WsContext.kt
+++ b/javalin/src/main/java/io/javalin/websocket/WsContext.kt
@@ -33,6 +33,8 @@ abstract class WsContext(val sessionId: String, @JvmField val session: Session) 
     fun send(message: String) = session.remote.sendStringByFuture(message)
     fun send(message: ByteBuffer) = session.remote.sendBytesByFuture(message)
 
+    @JvmOverloads fun sendPing(message: ByteBuffer? = null) = session.remote.sendPing(message ?: ByteBuffer.allocate(0))
+
     fun queryString(): String? = upgradeCtx.queryString()
     fun queryParamMap(): Map<String, List<String>> = upgradeCtx.queryParamMap()
     fun queryParams(key: String): List<String> = upgradeCtx.queryParams(key)


### PR DESCRIPTION
This PR adds a sendPing method to WsContext. This is the first PR to fix the problems mentioned in #1567.

Maybe we should add some tests, but pings are hard to test, as they only prevent timeouts which are sometimes OS or infrastructure dependent. As this is a simple method, maybe tests aren't actually necessary I think.